### PR TITLE
add support for loading the epg data based on tvg.id (if provided)

### DIFF
--- a/epg-worker.ts
+++ b/epg-worker.ts
@@ -72,11 +72,17 @@ ipcRenderer.on(EPG_FETCH, (event, arg) => {
 
 // returns the epg data for the provided channel name and date
 ipcRenderer.on(EPG_GET_PROGRAM, (event, args) => {
+    const channelName = args.channel.name;
+    const tvgId = args.channel.tvg?.id;
     if (!EPG_DATA || !EPG_DATA.channels) return;
     const foundChannel = EPG_DATA?.channels?.find((epgChannel) => {
-        if (
+        if (tvgId) {
+            if (tvgId === epgChannel.id) {
+                return epgChannel;
+            }
+        } else if (
             epgChannel.name.find((nameObj) => {
-                if (nameObj.value.trim() === args.channelName.trim())
+                if (nameObj.value && nameObj.value.trim() === channelName.trim())
                     return nameObj;
             })
         ) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -56,9 +56,9 @@ export class AppComponent {
     commandsList = [
         new IpcCommand(VIEW_ADD_PLAYLIST, () => this.navigateToRoute('/')),
         new IpcCommand(VIEW_SETTINGS, () => this.navigateToRoute('/settings')),
-        new IpcCommand(EPG_FETCH_DONE, () => this.onEpgFetchDone),
-        new IpcCommand(EPG_ERROR, () => this.onEpgError),
-        new IpcCommand(SHOW_WHATS_NEW, () => this.showWhatsNewDialog),
+        new IpcCommand(EPG_FETCH_DONE, () => this.onEpgFetchDone()),
+        new IpcCommand(EPG_ERROR, () => this.onEpgError()),
+        new IpcCommand(SHOW_WHATS_NEW, () => this.showWhatsNewDialog()),
     ];
 
     /** Default language as fallback */

--- a/src/app/state/channel.store.ts
+++ b/src/app/state/channel.store.ts
@@ -64,7 +64,7 @@ export class ChannelStore extends EntityStore<ChannelState> {
         this.update((store) => {
             if (store.epgAvailable) {
                 this.electronService.ipcRenderer.send(EPG_GET_PROGRAM, {
-                    channelName: channel.name,
+                    channel,
                 });
                 if (channel.http['user-agent']) {
                     this.electronService.ipcRenderer.send(


### PR DESCRIPTION
This MR will attempt to match based on tvg id if provided in the playlist. If there's no tvg.id for a channel, the old behaviour will be used.

Notes: 
* I added a falsy check for the nameObj.value for my playlist has some names that are empty (I'm going to be looking at that next as the playlist works in other iptv apps)
* I also changed the callbacks for as they were, the callback functions weren't actually being called.

My System:
* macOS Monterey
* node v17.2.0