### PR TITLE
feat: support for setting channel HTTP referrer headers for HTML 5 Player

### DIFF
--- a/electron/api.ts
+++ b/electron/api.ts
@@ -169,14 +169,12 @@ export class Api {
             .on(
                 CHANNEL_SET_USER_AGENT,
                 (_event, args: { userAgent: string; referer?: string }) => {
-                    if (args.userAgent && args.referer !== undefined) {
+                    if (args.userAgent || args.referer !== undefined) {
                         this.setUserAgent(
-                            args.userAgent,
+                            args.userAgent || 'localhost',
                             args.referer || 'localhost'
                         );
-                    } else {
-                        this.setUserAgent(this.defaultUserAgent, 'localhost');
-                    }
+                    } 
                 }
             )
             .on(IS_PLAYLISTS_MIGRATION_POSSIBLE, (event) => {

--- a/src/app/player/components/html-video-player/html-video-player.component.ts
+++ b/src/app/player/components/html-video-player/html-video-player.component.ts
@@ -10,6 +10,8 @@ import {
 import Hls from 'hls.js';
 import { Channel } from '../../../../../shared/channel.interface';
 import { getExtensionFromUrl } from '../../../../../shared/playlist.utils';
+import { DataService } from '../../../services/data.service';
+import { CHANNEL_SET_USER_AGENT } from '../../../../../shared/ipc-commands';
 
 /**
  * This component contains the implementation of HTML5 based video player
@@ -23,6 +25,11 @@ import { getExtensionFromUrl } from '../../../../../shared/playlist.utils';
 export class HtmlVideoPlayerComponent implements OnChanges, OnDestroy {
     /** Channel to play  */
     @Input() channel: Channel;
+    dataService: DataService; // Declare the dataService property
+   
+    constructor(dataService: DataService) {
+        this.dataService = dataService; // Inject the DataService
+    }
 
     /** Video player DOM element */
     @ViewChild('videoPlayer', { static: true })
@@ -63,6 +70,10 @@ export class HtmlVideoPlayerComponent implements OnChanges, OnDestroy {
                 this.hls = new Hls();
                 this.hls.attachMedia(this.videoPlayer.nativeElement);
                 this.hls.loadSource(url);
+                this.dataService.sendIpcEvent(CHANNEL_SET_USER_AGENT, {
+                    userAgent: channel.http['user-agent'],
+                    referer: channel.http.referrer,
+                });
                 this.handlePlayOperation();
             } else {
                 console.error('something wrong with hls.js init...');
@@ -71,6 +82,10 @@ export class HtmlVideoPlayerComponent implements OnChanges, OnDestroy {
                     url,
                     'video/mp4'
                 );
+                this.dataService.sendIpcEvent(CHANNEL_SET_USER_AGENT, {
+                    userAgent: channel.http['user-agent'],
+                    referer: channel.http.referrer,
+                });
                 this.videoPlayer.nativeElement.play();
             }
         }


### PR DESCRIPTION
This commit introduces support for setting the HTTP referrer headers per channel. The referrer is the http-referrer as defined for each channel in the m3u8 playlist using the VLC format (#EXTVLCOPT:http-referrer=http://example.com/) This feature works currently only for the HTML5 player. Would love any insight on how to do it for the js one.

Updates were made to the html-video-player component for the HTML5 player, and to the logic in the CHANNEL_SET_USER_AGENT function in the main electron api.ts.