### PR TITLE
feat: added support for setting the "origin" http header.

### DIFF
--- a/electron/api.ts
+++ b/electron/api.ts
@@ -113,6 +113,12 @@ export class Api {
                             event.sender.send(PLAYLIST_PARSE_RESPONSE, {
                                 payload: playlistObject,
                             });
+                        })
+                        .catch((err) => {
+                            event.sender.send(ERROR, {
+                                message: err.response.statusText,
+                                status: err.response.status,
+                            });
                         });
                 } catch (err) {
                     event.sender.send(ERROR, {
@@ -400,20 +406,12 @@ export class Api {
             userAgent = this.defaultUserAgent;
         }
 
-        // Remove trailing slash from referer if it exists
-        let originURL: string;
-        if (referer?.endsWith('/')) {
-        originURL= referer.slice(0, -1);
-        }
-
         session.defaultSession.webRequest.onBeforeSendHeaders(
             (details, callback) => {
                 details.requestHeaders['User-Agent'] = userAgent;
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                 details.requestHeaders['Referer'] = referer as string;
-                details.requestHeaders['Origin'] = originURL as string;
                 callback({ requestHeaders: details.requestHeaders });
-            
             }
         );
         console.log(`Success: Set "${userAgent}" as user agent header`);

--- a/electron/api.ts
+++ b/electron/api.ts
@@ -113,12 +113,6 @@ export class Api {
                             event.sender.send(PLAYLIST_PARSE_RESPONSE, {
                                 payload: playlistObject,
                             });
-                        })
-                        .catch((err) => {
-                            event.sender.send(ERROR, {
-                                message: err.response.statusText,
-                                status: err.response.status,
-                            });
                         });
                 } catch (err) {
                     event.sender.send(ERROR, {
@@ -406,12 +400,20 @@ export class Api {
             userAgent = this.defaultUserAgent;
         }
 
+        // Remove trailing slash from referer if it exists
+        let originURL: string;
+        if (referer?.endsWith('/')) {
+        originURL= referer.slice(0, -1);
+        }
+
         session.defaultSession.webRequest.onBeforeSendHeaders(
             (details, callback) => {
                 details.requestHeaders['User-Agent'] = userAgent;
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                 details.requestHeaders['Referer'] = referer as string;
+                details.requestHeaders['Origin'] = originURL as string;
                 callback({ requestHeaders: details.requestHeaders });
+            
             }
         );
         console.log(`Success: Set "${userAgent}" as user agent header`);

--- a/electron/api.ts
+++ b/electron/api.ts
@@ -406,11 +406,18 @@ export class Api {
             userAgent = this.defaultUserAgent;
         }
 
+        // Remove trailing slash from referer if it exists
+        let originURL: string;
+        if (referer?.endsWith('/')) {
+        originURL= referer.slice(0, -1);
+        }
+
         session.defaultSession.webRequest.onBeforeSendHeaders(
             (details, callback) => {
                 details.requestHeaders['User-Agent'] = userAgent;
                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                 details.requestHeaders['Referer'] = referer as string;
+                details.requestHeaders['Origin'] = originURL as string;
                 callback({ requestHeaders: details.requestHeaders });
             }
         );


### PR DESCRIPTION
This commit adds an http origin header which is by default set to be the same as the referer without the trailing '/'. 
This is to support certain popular Eastern European IPTV providers.

A more elegant approach would be to define a origin header format for each channel specified in the m3u8 file. Perhaps in a future commit if i have the time.
