### PR TITLE
fix(vlc): path in quotes to allow path with spaces

### DIFF
--- a/electron/api.ts
+++ b/electron/api.ts
@@ -271,7 +271,7 @@ export class Api {
             })
             .on(OPEN_VLC_PLAYER, (event, { url }) => {
                 const proc = child_process.spawn(
-                    this.getVlcPath(),
+                    `"${this.getVlcPath()}"`,
                     [`"${url as string}"`],
                     {
                         shell: true,


### PR DESCRIPTION
Currently, paths with spaces (C:\Program Files\VideoLAN\VLC) don't work. This is the most common install directory of vlc on windows. I put the path in quotes when passing it to the child process to fix this