### PR TITLE
fix(xtream): display epg when live tv channel is selected

### DIFF
--- a/src/app/xtream/xtream-main-container.component.ts
+++ b/src/app/xtream/xtream-main-container.component.ts
@@ -349,6 +349,7 @@ export class XtreamMainContainerComponent implements OnInit {
     }
 
     openPlayer(streamUrl: string, title: string) {
+        this.streamUrl = streamUrl;
         this.player = this.settings()?.player ?? VideoPlayer.VideoJs;
         if (this.player === VideoPlayer.MPV) {
             if (!this.hideExternalInfoDialog())
@@ -363,7 +364,6 @@ export class XtreamMainContainerComponent implements OnInit {
                 url: streamUrl,
             });
         } else {
-            this.streamUrl = streamUrl;
             if (this.selectedContentType !== ContentType.ITV) {
                 this.dialog.open<PlayerDialogComponent, PlayerDialogData>(
                     PlayerDialogComponent,


### PR DESCRIPTION
Fixes https://github.com/4gray/iptvnator/issues/435

Set this.streamUrl so that child live-stream-layout displays the EPG.

Before:
![Screenshot 2024-09-27 at 10 01 01 pm](https://github.com/user-attachments/assets/a8ee4016-8964-4ecf-ab3b-8b136a4a4598)

After:
![Screenshot 2024-09-27 at 10 02 26 pm](https://github.com/user-attachments/assets/a1480bd4-87a7-4db3-b555-8096de5bb9a8)

Apologies, this is the first time i've contributed to this repository so i'm not 100% sure which branch this should be targeting. If this change is ok, please let me know if i need to select a different branch target.

Appreciate your work on this great app by the way. v0.16.0 is looking very nice!
