### PR TITLE
fix: update signingIdentity to default value

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -96,7 +96,7 @@
             "exceptionDomain": "*",
             "frameworks": [],
             "providerShortName": null,
-            "signingIdentity": null
+            "signingIdentity": "-"
         }
     }
 }


### PR DESCRIPTION
Set the signingIdentity in tauri.conf.json to a default value of 
"-" to ensure compatibility with the build process and avoid 
potential errors during application signing.