### PR TITLE
fix: update Dockerfile and GitHub Actions workflow

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -61,8 +61,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: v__VERSION__-${{ matrix.platform }}${{ matrix.args != '' && format('-{0}', matrix.args) || '' }}
-          releaseName: "IPTVnator v__VERSION__ (${{ matrix.platform }}${{ matrix.args != '' && format(' {0}', matrix.args) || '' }})"
+          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: 'App v__VERSION__'
           releaseBody: 'See the assets to download this version and install.'
           releaseDraft: true
           prerelease: false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,4 +29,4 @@ FROM nginx:stable-alpine
 COPY --from=build /usr/src/app/dist/ /usr/share/nginx/html
 COPY --from=build /usr/src/app/docker/nginx.conf /etc/nginx/conf.d/default.conf
 
-CMD sed -i "s#http://localhost:3333#$BACKEND_URL#g" /usr/share/nginx/html/main-*.js && nginx -g 'daemon off;'
+CMD sed -i "s#http://localhost:3333#$BACKEND_URL#g" /usr/share/nginx/html/main.js && nginx -g 'daemon off;'


### PR DESCRIPTION
Update the CMD instruction in the Dockerfile to target 
main.js instead of main-*.js for better specificity. 
Modify the tag and release names in the GitHub Actions 
workflow to follow a consistent naming convention, 
ensuring clarity in versioning.