### PR TITLE
fix: enable auto-refresh for URL-based playlists on startup

### DIFF
--- a/src/app/services/tauri.service.ts
+++ b/src/app/services/tauri.service.ts
@@ -140,16 +140,34 @@ export class TauriService extends DataService {
             const data = payload as Playlist[];
 
             for await (const item of data) {
-                if (item.filePath) {
-                    const playlist = await readTextFile(item.filePath);
-                    const parsedPlaylist = parse(playlist);
-                    const playlistObject = createPlaylistObject(
-                        item.title,
-                        parsedPlaylist,
-                        item.filePath,
-                        'FILE'
+                try {
+                    if (item.filePath) {
+                        const playlist = await readTextFile(item.filePath);
+                        const parsedPlaylist = parse(playlist);
+                        const playlistObject = createPlaylistObject(
+                            item.title,
+                            parsedPlaylist,
+                            item.filePath,
+                            'FILE'
+                        );
+                        playlists.push({ ...playlistObject, _id: item._id });
+                    } else if (item.url) {
+                        const response = await fetch(item.url);
+                        const playlistContent = await response.text();
+                        const parsedPlaylist = parse(playlistContent);
+                        const playlistObject = createPlaylistObject(
+                            item.title,
+                            parsedPlaylist,
+                            item.url,
+                            'URL'
+                        );
+                        playlists.push({ ...playlistObject, _id: item._id });
+                    }
+                } catch (error) {
+                    console.error(
+                        `Failed to update playlist "${item.title}":`,
+                        error
                     );
-                    playlists.push({ ...playlistObject, _id: item._id });
                 }
             }
             window.postMessage({


### PR DESCRIPTION
The auto-refresh mechanism was already being triggered on app startup,
but it only handled file-based playlists (with filePath property).
URL-based playlists were being silently ignored.

This fix adds support for auto-refreshing URL-based playlists by:
- Adding URL playlist handling in the AUTO_UPDATE_PLAYLISTS handler
- Fetching playlist content from URLs using the fetch API
- Parsing and updating URL playlists the same way as file playlists
- Adding error handling to prevent individual failures from stopping
  the entire update process

Now both file-based and URL-based playlists with autoRefresh enabled
will be automatically updated when the application starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing playlists via URL.

* **Bug Fixes**
  * Improved error handling during automatic playlist updates with better logging.
  * Enhanced reliability of playlist processing to ensure correct data handling in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->