### PR TITLE
feat(package): include built remote-control-web in packaged app

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,13 @@
             "output": "dist/executables"
         },
         "files": [
+            {
+                "from": "dist/apps/remote-control-web",
+                "to": "remote-control-web",
+                "filter": ["**/*"]
+            },
             "electron-backend/**/*",
             "web/**/*",
-            "remote-control-web/**/*",
             "!**/*.map"
         ],
         "asarUnpack": [


### PR DESCRIPTION
Add a packaging rule to copy the built remote-control-web output from
dist/apps/remote-control-web into the installer as remote-control-web.
Previously the repository included the raw source pattern
remote-control-web/**/* which did not reflect the compiled build output.
By pointing files to the dist build and filtering all files, the packaged
app now contains the production web assets instead of source files.

This fixes missing runtime assets in releases and ensures the packaged
installer includes the correct built web app for remote control.