### PR TITLE
ci: run workflows on master branch instead of nx

### DIFF
--- a/.github/workflows/build-and-make.yaml
+++ b/.github/workflows/build-and-make.yaml
@@ -3,14 +3,12 @@ name: Build and Make Electron App
 on:
     push:
         branches:
-            - nx
-            # - master  # Uncomment this when ready to run on master branch
+            - master
         tags:
             - 'v*.*.*'
     pull_request:
         branches:
-            - nx
-            # - master  # Uncomment this when ready to run on master branch
+            - master
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -3,10 +3,10 @@ name: 'Cross-Platform E2E Tests'
 on:
   push:
     branches:
-      - nx
+      - master
   pull_request:
     branches:
-      - nx
+      - master
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
Update GitHub Actions workflow triggers to use the master branch
for push and pull_request events. Replace the previous nx branch
restriction so CI (build, make and e2e tests) runs on master and tag
events as intended.

This enables workflows to execute for changes merged to master and
aligns branch configuration across workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to run automated builds and end-to-end tests on the master branch instead of the nx branch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->