### PR TITLE
fix: epg ignored programs

### DIFF
--- a/apps/electron-backend/src/app/workers/epg-parser.worker.ts
+++ b/apps/electron-backend/src/app/workers/epg-parser.worker.ts
@@ -499,9 +499,7 @@ class StreamingEpgParser {
                         this.totalPrograms++;
 
                         if (this.programs.length >= PROGRAM_BATCH_SIZE) {
-                            if(this.channels.length) {
-                                this.flushChannels();
-                            }
+                            this.flushChannels();
                             this.flushPrograms();
                         }
                         this.currentProgram = null;


### PR DESCRIPTION
Hello. 

This change solves an issue I was having with the EPG. I opened this issue for it: https://github.com/4gray/iptvnator/issues/802

Seems like making the parser flush the channels always before flush the programs is enough to solve the issue as the channels were already parsed but not flushed due to having less than CHANNEL_BATCH_SIZE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved batch processing order in EPG parsing to enhance data handling reliability and efficiency during program updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->