### PR TITLE
test(portal-shared-util): mock double-click setting

### DIFF
--- a/libs/portal/shared/util/src/lib/collection/unified-live-tab.component.spec.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-live-tab.component.spec.ts
@@ -200,6 +200,7 @@ describe('UnifiedLiveTabComponent', () => {
                 {
                     provide: SettingsStore,
                     useValue: {
+                        openStreamOnDoubleClick: signal(false),
                         player: signal('videojs'),
                     },
                 },


### PR DESCRIPTION
## Summary
- Add the missing `openStreamOnDoubleClick` signal to the `SettingsStore` mock used by `UnifiedLiveTabComponent` tests.
- Fix the unit CI failure introduced after PR #906 was merged.

## Testing
- [x] `NX_DAEMON=false pnpm nx test portal-shared-util --runInBand --testPathPatterns=libs/portal/shared/util/src/lib/collection/unified-live-tab.component.spec.ts`
- [x] `NX_DAEMON=false pnpm nx test portal-shared-util --runInBand`
- [x] `NX_DAEMON=false pnpm run test:unit:ci`