### PR TITLE
fix(linux): align packaged app identity

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -24,6 +24,8 @@
         "**/*.dylib"
     ],
     "extraMetadata": {
+        "name": "iptvnator",
+        "productName": "IPTVnator",
         "main": "electron-backend/main.js"
     },
     "extraResources": ["dist/apps/electron-backend/workers"],
@@ -43,6 +45,12 @@
     },
     "linux": {
         "category": "Video",
+        "executableName": "iptvnator",
+        "desktop": {
+            "entry": {
+                "StartupWMClass": "iptvnator"
+            }
+        },
         "target": [
             {
                 "target": "AppImage",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "test:frontend": "nx test web",
         "test:backend": "nx test electron-backend",
         "test:unit:all": "nx run-many --target=test --all --parallel=3",
-        "test:unit:ci": "nx run-many --target=test --projects=electron-backend,web,services,m3u-state,portal-stalker-data-access,portal-shared-util,playlist-shared-ui,portal-xtream-data-access,portal-xtream-feature,workspace-dashboard-data-access,components,@iptvnator/pipes --parallel=3 --output-style=static",
+        "test:unit:ci": "nx run-many --target=test --projects=electron-backend,web,services,m3u-state,portal-stalker-data-access,portal-shared-util,playlist-shared-ui,portal-xtream-data-access,portal-xtream-feature,workspace-dashboard-data-access,components,@iptvnator/pipes,packaging --parallel=3 --output-style=static",
         "typecheck:web": "tsc -p apps/web/tsconfig.app.json --noEmit",
         "typecheck:backend": "tsc -p apps/electron-backend/tsconfig.app.json --noEmit",
         "typecheck:ci": "pnpm run typecheck:web && pnpm run typecheck:backend",

--- a/tools/packaging/electron-package-identity.test.mjs
+++ b/tools/packaging/electron-package-identity.test.mjs
@@ -1,9 +1,15 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { dirname, join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
+const currentDir = dirname(fileURLToPath(import.meta.url));
 const electronBuilderConfig = JSON.parse(
-    fs.readFileSync('electron-builder.json', 'utf8')
+    fs.readFileSync(
+        join(currentDir, '..', '..', 'electron-builder.json'),
+        'utf8'
+    )
 );
 
 test('Linux package identity does not expose the internal Electron backend project name', () => {
@@ -14,13 +20,5 @@ test('Linux package identity does not expose the internal Electron backend proje
     assert.equal(
         electronBuilderConfig.linux?.desktop?.entry?.StartupWMClass,
         'iptvnator'
-    );
-    assert.notEqual(
-        electronBuilderConfig.extraMetadata?.name,
-        'electron-backend'
-    );
-    assert.notEqual(
-        electronBuilderConfig.linux?.executableName,
-        'electron-backend'
     );
 });

--- a/tools/packaging/electron-package-identity.test.mjs
+++ b/tools/packaging/electron-package-identity.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+const electronBuilderConfig = JSON.parse(
+    fs.readFileSync('electron-builder.json', 'utf8')
+);
+
+test('Linux package identity does not expose the internal Electron backend project name', () => {
+    assert.equal(electronBuilderConfig.productName, 'IPTVnator');
+    assert.equal(electronBuilderConfig.extraMetadata?.name, 'iptvnator');
+    assert.equal(electronBuilderConfig.extraMetadata?.productName, 'IPTVnator');
+    assert.equal(electronBuilderConfig.linux?.executableName, 'iptvnator');
+    assert.equal(
+        electronBuilderConfig.linux?.desktop?.entry?.StartupWMClass,
+        'iptvnator'
+    );
+    assert.notEqual(
+        electronBuilderConfig.extraMetadata?.name,
+        'electron-backend'
+    );
+    assert.notEqual(
+        electronBuilderConfig.linux?.executableName,
+        'electron-backend'
+    );
+});

--- a/tools/packaging/project.json
+++ b/tools/packaging/project.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "name": "packaging",
+    "projectType": "library",
+    "sourceRoot": "tools/packaging",
+    "targets": {
+        "test": {
+            "executor": "nx:run-commands",
+            "cache": true,
+            "inputs": ["default", "{workspaceRoot}/electron-builder.json"],
+            "options": {
+                "command": "node --test tools/packaging/electron-package-identity.test.mjs",
+                "cwd": "{workspaceRoot}"
+            }
+        }
+    },
+    "tags": ["scope:tools", "type:tool"]
+}


### PR DESCRIPTION
## Summary
- Align Linux package identity so desktop environments do not surface the internal `electron-backend` project name.
- Add a regression test for the Electron Builder identity fields that drive Linux executable/window matching.

## Changes
- Set packaged metadata `name`/`productName` to `iptvnator`/`IPTVnator`.
- Set Linux executable name and `StartupWMClass` to `iptvnator`.
- Add a Node test covering the expected Linux package identity values.

## Testing
- [x] `node --test tools/packaging/electron-package-identity.test.mjs`
- [x] `pnpm exec prettier --check electron-builder.json tools/packaging/electron-package-identity.test.mjs`
- [x] `pnpm nx run electron-backend:build --configuration=production`

Closes #905