### PR TITLE
fix(electron): resolve macOS external player app paths

### DIFF
--- a/apps/electron-backend/src/app/events/player.events.spec.ts
+++ b/apps/electron-backend/src/app/events/player.events.spec.ts
@@ -145,6 +145,60 @@ describe('player.events Flatpak launch helpers', () => {
         });
     });
 
+    it('resolves custom macOS MPV app bundles to their executable', () => {
+        const launchContext = resolveExternalPlayerLaunchContext(
+            'mpv',
+            '/Applications/mpv copy.app',
+            {
+                platform: 'darwin',
+                isFlatpak: false,
+            }
+        );
+
+        expect(launchContext).toEqual({
+            mode: 'direct',
+            playerPath: '/Applications/mpv copy.app/Contents/MacOS/mpv',
+            command: '/Applications/mpv copy.app/Contents/MacOS/mpv',
+            argsPrefix: [],
+        });
+    });
+
+    it('resolves custom macOS VLC app bundles to their executable', () => {
+        const launchContext = resolveExternalPlayerLaunchContext(
+            'vlc',
+            '/Applications/VLC.app/',
+            {
+                platform: 'darwin',
+                isFlatpak: false,
+            }
+        );
+
+        expect(launchContext).toEqual({
+            mode: 'direct',
+            playerPath: '/Applications/VLC.app/Contents/MacOS/VLC',
+            command: '/Applications/VLC.app/Contents/MacOS/VLC',
+            argsPrefix: [],
+        });
+    });
+
+    it('keeps custom macOS executable player paths unchanged', () => {
+        const launchContext = resolveExternalPlayerLaunchContext(
+            'mpv',
+            '/Applications/mpv.app/Contents/MacOS/mpv',
+            {
+                platform: 'darwin',
+                isFlatpak: false,
+            }
+        );
+
+        expect(launchContext).toEqual({
+            mode: 'direct',
+            playerPath: '/Applications/mpv.app/Contents/MacOS/mpv',
+            command: '/Applications/mpv.app/Contents/MacOS/mpv',
+            argsPrefix: [],
+        });
+    });
+
     it('disables MPV reuse and socket bridging only in Flatpak', () => {
         expect(shouldReuseMpvInstance(true, true)).toBe(false);
         expect(shouldUseMpvSocketBridge(true)).toBe(false);

--- a/apps/electron-backend/src/app/events/player.events.ts
+++ b/apps/electron-backend/src/app/events/player.events.ts
@@ -93,8 +93,13 @@ function normalizePlayerPathForStore(value: string | null | undefined): string {
     return normalizeCustomPlayerPath(value) ?? '';
 }
 
+const macOSAppBundleExecutableNames: Record<ExternalPlayerName, string> = {
+    mpv: 'mpv',
+    vlc: 'VLC',
+};
+
 function getMacOSAppBundleExecutableName(player: ExternalPlayerName): string {
-    return player === 'mpv' ? 'mpv' : 'VLC';
+    return macOSAppBundleExecutableNames[player];
 }
 
 function removeTrailingPathSeparators(value: string): string {

--- a/apps/electron-backend/src/app/events/player.events.ts
+++ b/apps/electron-backend/src/app/events/player.events.ts
@@ -93,6 +93,37 @@ function normalizePlayerPathForStore(value: string | null | undefined): string {
     return normalizeCustomPlayerPath(value) ?? '';
 }
 
+function getMacOSAppBundleExecutableName(player: ExternalPlayerName): string {
+    return player === 'mpv' ? 'mpv' : 'VLC';
+}
+
+function removeTrailingPathSeparators(value: string): string {
+    return value.replace(/[\\/]+$/, '') || value;
+}
+
+function resolveMacOSAppBundlePlayerPath(
+    player: ExternalPlayerName,
+    playerPath: string,
+    platform: NodeJS.Platform
+): string {
+    if (platform !== 'darwin') {
+        return playerPath;
+    }
+
+    const appBundlePath = removeTrailingPathSeparators(playerPath);
+
+    if (!/\.app$/i.test(appBundlePath)) {
+        return playerPath;
+    }
+
+    return path.join(
+        appBundlePath,
+        'Contents',
+        'MacOS',
+        getMacOSAppBundleExecutableName(player)
+    );
+}
+
 function getDefaultPlayerPath(
     player: ExternalPlayerName,
     options: PlayerPathOptions = {}
@@ -131,20 +162,25 @@ export function resolveExternalPlayerLaunchContext(
             isFlatpak,
             pathExists,
         });
+    const resolvedPlayerPath = resolveMacOSAppBundlePlayerPath(
+        player,
+        playerPath,
+        platform
+    );
 
     if (platform === 'linux' && isFlatpak) {
         return {
             mode: 'flatpak-host',
-            playerPath,
+            playerPath: resolvedPlayerPath,
             command: 'flatpak-spawn',
-            argsPrefix: ['--host', '--watch-bus', playerPath],
+            argsPrefix: ['--host', '--watch-bus', resolvedPlayerPath],
         };
     }
 
     return {
         mode: 'direct',
-        playerPath,
-        command: playerPath,
+        playerPath: resolvedPlayerPath,
+        command: resolvedPlayerPath,
         argsPrefix: [],
     };
 }


### PR DESCRIPTION
## Summary
- Resolve custom macOS MPV/VLC `.app` bundle paths to the executable inside `Contents/MacOS` before spawning the external player.
- Keep already-correct executable paths unchanged, including `/Applications/mpv.app/Contents/MacOS/mpv`.
- Add regression coverage for MPV, VLC, and backward-compatible executable paths.

Fixes #918

## Changes
- Add macOS-only `.app` bundle path normalization in the external player launch context.
- Preserve Linux, Windows, and Flatpak launch behavior.
- Extend `player.events.spec.ts` with bundle-path and existing executable-path cases.

## Testing
- [x] `pnpm nx test electron-backend --testFile=apps/electron-backend/src/app/events/player.events.spec.ts --runInBand`
- [x] `pnpm run typecheck:backend`
- [ ] `pnpm nx lint electron-backend` currently fails on an existing `@nx/enforce-module-boundaries` error at `apps/electron-backend/src/main.ts:2`, unrelated to this change.