### PR TITLE
feat: ship unified self-hosted Docker image

### DIFF
--- a/.plans/2026-05-15-self-hosted-sqlite.md
+++ b/.plans/2026-05-15-self-hosted-sqlite.md
@@ -1,0 +1,52 @@
+# Self-Hosted SQLite Storage Follow-Up
+
+## Status
+
+Deferred. This plan captures the intended direction only; do not start implementation as part of the current PWA self-hosted Docker work.
+
+## Context
+
+The current self-hosted PWA runtime ships one Docker image with nginx, the Angular PWA, and `web-backend`. Xtream in PWA mode remains API-first: catalog categories and content are cached in memory only, while playlist metadata, favorites, recent items, and playback positions use browser storage. Electron has a DB-first SQLite flow for Xtream content, user activity, search, and refresh behavior.
+
+Adding backend-owned SQLite for self-hosted can reduce the architectural gap between Electron and PWA, but it should be introduced deliberately rather than as ad-hoc endpoints.
+
+## Proposed Direction
+
+1. Add a persistent SQLite database owned by `web-backend`.
+2. Store the database under a Docker volume, for example `/data/iptvnator.db`.
+3. Expose backend HTTP APIs that mirror the Electron database contract closely enough for frontend data sources to share behavior.
+4. Add a self-hosted Xtream data source that uses the backend storage API instead of PWA-only localStorage/in-memory catalog behavior.
+5. Reuse shared SQLite schema and operation code where practical so Electron and self-hosted do not drift.
+6. Keep Stalker catalog API-first initially; move only Stalker metadata, favorites, recent items, and playback positions into backend storage unless a concrete catalog-cache need appears.
+
+## Expected Benefits
+
+- Xtream catalog survives browser reloads and browser storage clearing.
+- Self-hosted instances can provide the same DB-backed favorites, recent items, dashboard, search, and refresh semantics as Electron.
+- The frontend needs fewer PWA-specific fallbacks.
+- Docker self-hosted state becomes easier to back up and restore through one mounted data directory.
+- Web/PWA E2E can validate persisted backend state without depending on browser localStorage snapshots.
+
+## Risks And Decisions
+
+- The backend database must be mounted as a volume; storing it only inside the container would lose data on container replacement.
+- Self-hosted is currently effectively single-user. A backend SQLite database would be shared by everyone with access to the instance unless authentication/multi-profile storage is added.
+- Cache freshness needs an explicit policy: manual refresh, TTL, or Electron-style import status.
+- The API should be designed as a storage contract, not a set of route-specific helpers, otherwise the codebase gains a third persistence model.
+- Migrations, backup/restore docs, and Docker upgrade behavior need to be part of the implementation.
+
+## Suggested Implementation Phases
+
+1. Introduce backend SQLite volume, schema initialization, migrations, and health/debug visibility.
+2. Add HTTP storage endpoints for playlists, Xtream categories/content, favorites, recent items, playback positions, and import status.
+3. Extract or share Electron SQLite operations where boundaries allow it.
+4. Implement `SelfHostedXtreamDataSource` and select it when runtime config points at the monorepo backend.
+5. Add Docker/self-hosted E2E coverage for persisted Xtream catalog, favorites, recently viewed, dashboard, and reload behavior.
+6. Evaluate Stalker storage after Xtream parity is stable.
+
+## Validation Expectations
+
+- Unit tests for backend SQLite operations and frontend data-source selection.
+- Web/PWA E2E against self-hosted backend for Xtream add portal, catalog import/cache, favorite, recent item, reload persistence, dashboard, and global collection pages.
+- Docker compose smoke with a named volume and a recreate cycle proving data persistence.
+- Documentation updates in `docker/README.md`, `README.md`, `docs/architecture/pwa-self-hosted.md`, and `AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ This file provides guidance to coding agents working in this repository.
 - `web:serve-static` should serve `dist/apps/web` from `web:build:pwa`; do not point it back at the old `dist/apps/web/browser` layout.
 - The unified Docker image builds `web:pwa` and `web-backend`, serves static files through nginx, and proxies `/api/*` to the internal Express backend. Keep `BACKEND_URL=/api` for the bundled self-hosted setup.
 - Validate Xtream and Stalker self-hosted changes with the mock servers and `pnpm nx run web-e2e:e2e -- --project=chromium --grep @self-hosted`.
+- Browser/PWA Xtream favorites and recently viewed are surfaced to shared global collection routes through `XTREAM_COLLECTION_DATA_SOURCE` from `@iptvnator/portal/shared/util`. Do not import `@iptvnator/portal/xtream/data-access` into `portal-shared-util`; bind the shared token to `XTREAM_DATA_SOURCE` at the app/provider boundary.
 
 ## Documentation After Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,16 @@ This file provides guidance to coding agents working in this repository.
 - See `docs/architecture/nx-workspace-boundaries.md` for the current Nx tag and alias policy.
 - Repository-specific skills are committed under `.codex/skills/`. If an external agent does not support skills, treat those files as concise ownership docs.
 
+## PWA / Self-hosted Web
+
+- The browser self-hosted backend lives in `apps/web-backend`. Do not rely on the historical external `4gray/iptvnator-backend` container for the default Docker flow unless the task explicitly asks to re-sync missing behavior from that repository.
+- The Angular PWA resolves its backend through `window.__IPTVNATOR_CONFIG__.BACKEND_URL`, read by `apps/web/src/app/services/runtime-config.ts`. The placeholder file is `apps/web/src/assets/app-config.js`; Docker rewrites the built copy at container startup.
+- Keep `assets/app-config.js` out of Angular service worker hashing in `ngsw-config.json`. Runtime rewrites after `web:pwa` must not invalidate `ngsw.json`.
+- For PWA output checks, run `pnpm nx build web --configuration=pwa --skip-nx-cache` and verify `dist/apps/web/ngsw-worker.js` plus `dist/apps/web/ngsw.json` exist. If Nx serves stale build metadata after project config changes, run `pnpm nx reset`.
+- `web:serve-static` should serve `dist/apps/web` from `web:build:pwa`; do not point it back at the old `dist/apps/web/browser` layout.
+- The unified Docker image builds `web:pwa` and `web-backend`, serves static files through nginx, and proxies `/api/*` to the internal Express backend. Keep `BACKEND_URL=/api` for the bundled self-hosted setup.
+- Validate Xtream and Stalker self-hosted changes with the mock servers and `pnpm nx run web-e2e:e2e -- --project=chromium --grep @self-hosted`.
+
 ## Documentation After Changes
 
 - After implementing a meaningful change, agents must assess whether canonical repo docs need updates before considering the task complete.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The application is a cross-platform, open-source project built with Electron and
     - Polish
 - Custom "User Agent" header configuration for playlists
 - Light and Dark themes
-- Docker version available for self-hosting
+- Docker image available for self-hosting the PWA and web backend together
 
 ## Screenshots:
 
@@ -78,6 +78,21 @@ The application is a cross-platform, open-source project built with Electron and
 | ![Application settings](./apps/website/public/screenshots/settings.webp) | |
 
 _Note: First version of the application which was developed as a PWA is available in an extra git branch._
+
+## Self-hosted PWA
+
+The Docker setup builds the Angular PWA and the monorepo web backend into one
+image. The backend handles remote M3U/XMLTV parsing plus Xtream and Stalker
+proxy requests under `/api`, so a separate `4gray/iptvnator-backend` container
+is not required for the default self-hosted flow.
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+
+The application is available at <http://localhost:4333>. See
+[`docker/README.md`](./docker/README.md) for environment variables and build
+details.
 
 ## Download
 

--- a/apps/web/src/app/app.config.ts
+++ b/apps/web/src/app/app.config.ts
@@ -6,6 +6,7 @@ import {
 import {
     ApplicationConfig,
     importProvidersFrom,
+    inject,
     provideZoneChangeDetection,
 } from '@angular/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
@@ -24,9 +25,13 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import {
     PORTAL_EXTERNAL_PLAYBACK,
     PORTAL_PLAYER,
+    XTREAM_COLLECTION_DATA_SOURCE,
 } from '@iptvnator/portal/shared/util';
 import { PLAYLIST_PLAYER_ACTIONS } from '@iptvnator/playlist/shared/util';
-import { provideXtreamDataSource } from '@iptvnator/portal/xtream/data-access';
+import {
+    provideXtreamDataSource,
+    XTREAM_DATA_SOURCE,
+} from '@iptvnator/portal/xtream/data-access';
 import { DataService } from '@iptvnator/services';
 import { dbConfig } from '@iptvnator/shared/interfaces';
 import { AppConfig } from '../environments/environment';
@@ -153,6 +158,10 @@ export const appConfig: ApplicationConfig = {
         },
         ...provideWorkspaceShellActions(),
         ...provideXtreamDataSource(),
+        {
+            provide: XTREAM_COLLECTION_DATA_SOURCE,
+            useFactory: () => inject(XTREAM_DATA_SOURCE),
+        },
         {
             provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
             useValue: { appearance: 'outline', subscriptSizing: 'dynamic' },

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /usr/src/app
 
 COPY .npmrc ./
 COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
 
 RUN corepack enable && pnpm install --frozen-lockfile
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN pnpm nx build web-backend
 
 FROM node:22-alpine
 
-RUN apk add --no-cache nginx
+RUN apk add --no-cache gettext nginx
 
 WORKDIR /opt/iptvnator
 
@@ -27,11 +27,14 @@ ENV CLIENT_URL=http://localhost:4333
 
 COPY --from=build /usr/src/app/dist/apps/web /usr/share/nginx/html
 COPY --from=build /usr/src/app/dist/apps/web-backend ./web-backend
-COPY docker/nginx.conf /etc/nginx/http.d/default.conf
+COPY docker/nginx.conf /etc/nginx/http.d/default.conf.template
 COPY docker/docker-entrypoint.sh /usr/local/bin/iptvnator-entrypoint
 
 RUN chmod +x /usr/local/bin/iptvnator-entrypoint
 
 EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1/api/health >/dev/null || exit 1
 
 CMD ["iptvnator-entrypoint"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,32 +1,36 @@
-# Stage 1 - build environment
 FROM node:22-alpine AS build
 
 RUN apk add --no-cache python3 make g++ git
 
-# Create app directory
 WORKDIR /usr/src/app
-
-# Swtich to node user
-#RUN chown node:node ./
-#USER node
 
 COPY .npmrc ./
 COPY package.json pnpm-lock.yaml ./
 
-# Install app dependencies
 RUN corepack enable && pnpm install --frozen-lockfile
 
-# Copy all required files
 COPY . .
 
-# Build the application
-RUN pnpm run build:web
+RUN pnpm nx build web --configuration=pwa
+RUN pnpm nx build web-backend
 
-# Stage 2 - the production environment
-FROM nginx:stable-alpine
+FROM node:22-alpine
 
-# Copy artifacts and nignx.conf
-COPY --from=build /usr/src/app/dist/browser /usr/share/nginx/html
-COPY --from=build /usr/src/app/docker/nginx.conf /etc/nginx/conf.d/default.conf
+RUN apk add --no-cache nginx
 
-CMD sed -i "s#http://localhost:3333#$BACKEND_URL#g" /usr/share/nginx/html/main.js && nginx -g 'daemon off;'
+WORKDIR /opt/iptvnator
+
+ENV PORT=3000
+ENV BACKEND_URL=/api
+ENV CLIENT_URL=http://localhost:4333
+
+COPY --from=build /usr/src/app/dist/apps/web /usr/share/nginx/html
+COPY --from=build /usr/src/app/dist/apps/web-backend ./web-backend
+COPY docker/nginx.conf /etc/nginx/http.d/default.conf
+COPY docker/docker-entrypoint.sh /usr/local/bin/iptvnator-entrypoint
+
+RUN chmod +x /usr/local/bin/iptvnator-entrypoint
+
+EXPOSE 80
+
+CMD ["iptvnator-entrypoint"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,7 +39,7 @@ before it creates `PwaService`.
 | ---------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `BACKEND_URL`                            | `/api`                  | Browser-facing backend URL used by the PWA. Keep `/api` for the bundled nginx proxy.                               |
 | `CLIENT_URL`                             | `http://localhost:4333` | Allowed browser origin for backend CORS. Use the public URL when hosting behind a reverse proxy.                   |
-| `PORT`                                   | `3000`                  | Internal Express backend port. nginx proxy config is patched to match it at container startup.                     |
+| `PORT`                                   | `3000`                  | Internal Express backend port. nginx proxy config is rendered from the template to match it at startup.            |
 | `IPTVNATOR_PROXY_ALLOW_PRIVATE_NETWORKS` | unset                   | Set to `1` only for trusted local/LAN deployments that intentionally proxy private network IPTV or mock endpoints. |
 
 The web backend proxy accepts only `http` and `https` provider URLs. The PWA
@@ -53,8 +53,11 @@ instance restricted to trusted users.
 For providers that use private certificate authorities, keep TLS validation
 enabled and pass the CA bundle to Node with `NODE_EXTRA_CA_CERTS=/path/to/ca.pem`.
 
-The nginx config serves the PWA with SPA fallback, avoids caching
-`assets/app-config.js`, and proxies `/api/*` to the internal backend.
+The entrypoint renders the nginx config from `docker/nginx.conf`, starts the
+backend, waits for `/health`, and only then starts nginx. The nginx config
+serves the PWA with SPA fallback, avoids caching `assets/app-config.js`, and
+proxies `/api/*` to the internal backend. The Dockerfile and compose file both
+define a health check against `/api/health`.
 
 ## Local Validation
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,16 +1,55 @@
-# Self-hosted version of IPTVnator
+# Self-hosted IPTVnator
 
-You can deploy and run the PWA version of IPTVnator on your own machine with `docker-compose` using the following command:
+The self-hosted image contains both pieces required for the browser PWA:
 
-    $ cd docker
-    $ docker-compose up -d
+- Angular PWA static files served by nginx
+- The monorepo `web-backend` Express app proxied under `/api`
 
-This command will launch the frontend and backend applications. By default, the application will be available at: http://localhost:4333/. The ports can be configured in the `docker-compose.yml` file.
+The historical standalone `4gray/iptvnator-backend` image is no longer needed
+for the default Docker deployment.
 
-## Build frontend 
+## Run With Docker Compose
 
-    $ docker build -t 4gray/iptvnator -f docker/Dockerfile .
+```bash
+docker compose -f docker/docker-compose.yml up --build -d
+```
 
-## Build backend
+By default the app is available at <http://localhost:4333>.
 
-You can find the backend app with all instructions in a separate GitHub repository - https://github.com/4gray/iptvnator-backend
+## Build The Image
+
+```bash
+docker build -t 4gray/iptvnator -f docker/Dockerfile .
+```
+
+The image build runs:
+
+```bash
+pnpm nx build web --configuration=pwa
+pnpm nx build web-backend
+```
+
+## Runtime Configuration
+
+The container writes `/usr/share/nginx/html/assets/app-config.js` on startup.
+That file sets `window.__IPTVNATOR_CONFIG__.BACKEND_URL`, which the PWA reads
+before it creates `PwaService`.
+
+| Variable      | Default                 | Purpose                                                                                          |
+| ------------- | ----------------------- | ------------------------------------------------------------------------------------------------ |
+| `BACKEND_URL` | `/api`                  | Browser-facing backend URL used by the PWA. Keep `/api` for the bundled nginx proxy.             |
+| `CLIENT_URL`  | `http://localhost:4333` | Allowed browser origin for backend CORS. Use the public URL when hosting behind a reverse proxy. |
+| `PORT`        | `3000`                  | Internal Express backend port. nginx proxy config is patched to match it at container startup.   |
+
+The nginx config serves the PWA with SPA fallback, avoids caching
+`assets/app-config.js`, and proxies `/api/*` to the internal backend.
+
+## Local Validation
+
+```bash
+pnpm nx test web-backend
+pnpm nx build web --configuration=pwa --skip-nx-cache
+pnpm nx build web-backend
+pnpm nx run web-e2e:e2e -- --project=chromium --grep @self-hosted
+docker compose -f docker/docker-compose.yml config
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,3 +10,9 @@ services:
     environment:
       BACKEND_URL: /api
       CLIENT_URL: http://localhost:4333
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/api/health >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,18 +1,12 @@
 ---
 services:
-  backend:
-    image: 4gray/iptvnator-backend:latest
-    ports:
-      - "7333:3000"
-    environment:
-      - CLIENT_URL=http://localhost:4333 
-      # this one should match with the address and port in frontend CLIENT_URL env
-      
-  frontend: 
+  iptvnator:
     image: 4gray/iptvnator:latest
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     ports:
       - "4333:80"
     environment:
-      - BACKEND_URL=http://localhost:7333 
-      # this one should match with the address of the backend service
-      
+      BACKEND_URL: /api
+      CLIENT_URL: http://localhost:4333

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -32,9 +32,17 @@ NODE
 
 node /opt/iptvnator/web-backend/main.cjs &
 backend_pid="$!"
+nginx_pid=""
 
 shutdown() {
+  if [ -n "${nginx_pid:-}" ]; then
+    kill -TERM "$nginx_pid" 2>/dev/null || true
+    wait "$nginx_pid" 2>/dev/null || true
+  else
+    kill -TERM "$(cat /var/run/nginx.pid 2>/dev/null)" 2>/dev/null || true
+  fi
   kill "$backend_pid" 2>/dev/null || true
+  wait "$backend_pid" 2>/dev/null || true
 }
 
 trap shutdown INT TERM EXIT
@@ -87,4 +95,6 @@ function check() {
 check();
 NODE
 
-nginx -g 'daemon off;'
+nginx -g 'daemon off;' &
+nginx_pid="$!"
+wait "$nginx_pid"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+: "${PORT:=3000}"
+: "${BACKEND_URL:=/api}"
+: "${CLIENT_URL:=http://localhost:4333}"
+
+export PORT BACKEND_URL CLIENT_URL
+
+sed -i "s#127.0.0.1:3000#127.0.0.1:${PORT}#g" /etc/nginx/http.d/default.conf
+
+node <<'NODE'
+const fs = require('node:fs');
+
+const configPath = '/usr/share/nginx/html/assets/app-config.js';
+const config = { BACKEND_URL: process.env.BACKEND_URL || '/api' };
+
+fs.mkdirSync('/usr/share/nginx/html/assets', { recursive: true });
+fs.writeFileSync(
+  configPath,
+  `window.__IPTVNATOR_CONFIG__ = Object.assign({}, window.__IPTVNATOR_CONFIG__, ${JSON.stringify(config)});\n`
+);
+NODE
+
+node /opt/iptvnator/web-backend/main.cjs &
+backend_pid="$!"
+
+shutdown() {
+  kill "$backend_pid" 2>/dev/null || true
+}
+
+trap shutdown INT TERM EXIT
+
+nginx -g 'daemon off;'

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,7 +7,15 @@ set -eu
 
 export PORT BACKEND_URL CLIENT_URL
 
-sed -i "s#127.0.0.1:3000#127.0.0.1:${PORT}#g" /etc/nginx/http.d/default.conf
+nginx_template="/etc/nginx/http.d/default.conf.template"
+nginx_config="/etc/nginx/http.d/default.conf"
+
+if ! grep -q '\${PORT}' "$nginx_template"; then
+  echo "nginx template is missing the \${PORT} backend placeholder" >&2
+  exit 1
+fi
+
+envsubst '${PORT}' < "$nginx_template" > "$nginx_config"
 
 node <<'NODE'
 const fs = require('node:fs');
@@ -30,5 +38,53 @@ shutdown() {
 }
 
 trap shutdown INT TERM EXIT
+
+node <<'NODE'
+const http = require('node:http');
+
+const port = Number.parseInt(process.env.PORT || '3000', 10);
+const deadline = Date.now() + 30_000;
+const retryDelayMs = 250;
+
+function retry(error) {
+  if (Date.now() >= deadline) {
+    const reason = error?.message ? `: ${error.message}` : '';
+    console.error(`web-backend did not become ready on 127.0.0.1:${port}${reason}`);
+    process.exit(1);
+  }
+
+  setTimeout(check, retryDelayMs);
+}
+
+function check() {
+  const request = http.get(
+    {
+      host: '127.0.0.1',
+      path: '/health',
+      port,
+      timeout: 1000,
+    },
+    (response) => {
+      response.resume();
+      if (
+        response.statusCode &&
+        response.statusCode >= 200 &&
+        response.statusCode < 500
+      ) {
+        process.exit(0);
+      }
+
+      retry(new Error(`HTTP ${response.statusCode}`));
+    }
+  );
+
+  request.on('timeout', () => {
+    request.destroy(new Error('timeout'));
+  });
+  request.on('error', retry);
+}
+
+check();
+NODE
 
 nginx -g 'daemon off;'

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -24,7 +24,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_pass http://127.0.0.1:3000/;
+    proxy_pass http://127.0.0.1:${PORT}/;
   }
 
   location / {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,11 +1,33 @@
 server {
   listen 80;
-  
-  location / {
-    root /usr/share/nginx/html;
-    index index.html index.htm;
-    try_files $uri $uri/ /index.html =404;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location = /assets/app-config.js {
+    add_header Cache-Control "no-store";
+    try_files $uri =404;
   }
-  
-  include /etc/nginx/extra-conf.d/*.conf;
+
+  location = /ngsw-worker.js {
+    add_header Cache-Control "no-cache";
+    try_files $uri =404;
+  }
+
+  location = /ngsw.json {
+    add_header Cache-Control "no-cache";
+    try_files $uri =404;
+  }
+
+  location /api/ {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://127.0.0.1:3000/;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
 }

--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -106,6 +106,8 @@ The Docker image has two stages:
 1. Build stage installs dependencies and runs `web:pwa` plus `web-backend`.
 2. Runtime stage uses `node:22-alpine` with nginx installed. nginx serves
    `dist/apps/web` and proxies `/api/*` to the local Express backend.
+   The entrypoint renders the nginx config from a `${PORT}` template, starts the
+   backend, waits for `/health`, and then starts nginx.
 
 Default runtime values:
 

--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -64,6 +64,26 @@ The PWA continues to use `PwaService`; only the backend base URL is resolved at
 runtime. Electron routes remain owned by the Electron backend and preload
 bridge.
 
+## PWA Portal User Data
+
+Xtream favorites and recently viewed items use the browser-side
+`PwaXtreamDataSource` when Electron DB preload APIs are unavailable. The PWA
+stores this user activity in localStorage:
+
+- `xtream-favorites`
+- `xtream-recent-items`
+
+Entries should include a content snapshot when the item is added. Global
+collection routes and the dashboard can then restore titles, posters, content
+type, and category IDs after navigation or a page reload without relying on the
+Electron SQLite content table.
+
+Shared collection services must not import `@iptvnator/portal/xtream/data-access`
+directly. Use `XTREAM_COLLECTION_DATA_SOURCE` from
+`@iptvnator/portal/shared/util` and bind it to `XTREAM_DATA_SOURCE` at the app
+provider boundary (`apps/web/src/app/app.config.ts`). This keeps
+`portal-shared-util` provider-neutral and avoids adding new Nx boundary cycles.
+
 ## Docker Runtime
 
 The Docker image has two stages:
@@ -96,3 +116,8 @@ docker compose -f docker/docker-compose.yml config
 
 Run `docker build -t iptvnator:self-hosted-test -f docker/Dockerfile .` when a
 Docker daemon is available.
+
+For manual Docker smoke testing, run the Xtream and Stalker mock servers plus a
+small M3U fixture, then verify in the browser that M3U, Xtream, and Stalker
+can add sources, play an item, toggle favorites, populate global favorites,
+populate recently viewed, and appear on the dashboard rails.

--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -1,0 +1,98 @@
+# PWA Self-hosted Architecture
+
+This document describes the browser PWA and self-hosted Docker path.
+
+## Ownership
+
+- `apps/web` owns the Angular browser UI and PWA service worker configuration.
+- `apps/web-backend` owns the browser-only backend proxy for remote playlist,
+  XMLTV, Xtream, and Stalker requests.
+- `docker/` owns the production self-hosted image that bundles the PWA and
+  `web-backend` into one container.
+
+The old external `4gray/iptvnator-backend` repository is not required for the
+default self-hosted deployment. Sync behavior from that repository only when a
+change intentionally restores or imports missing backend capabilities.
+
+## Runtime Backend Configuration
+
+The PWA reads `window.__IPTVNATOR_CONFIG__.BACKEND_URL` through
+`apps/web/src/app/services/runtime-config.ts`. The static placeholder lives at
+`apps/web/src/assets/app-config.js` and keeps hosted builds working without
+Docker-specific values.
+
+The Docker entrypoint rewrites `assets/app-config.js` at container startup.
+`ngsw-config.json` explicitly excludes this file from Angular service worker
+asset hashing so a runtime rewrite does not break cache validation.
+
+## Service Worker Build
+
+Use the PWA build configuration for browser deployments:
+
+```bash
+pnpm nx build web --configuration=pwa
+```
+
+The build must emit these files in `dist/apps/web`:
+
+- `ngsw-worker.js`
+- `ngsw.json`
+- `safety-worker.js`
+- `worker-basic.min.js`
+
+`web:serve-static` serves `dist/apps/web` and builds with
+`web:build:pwa`, so it exercises the same output layout as Docker. If Nx daemon
+state returns stale service worker outputs while changing build options, run:
+
+```bash
+pnpm nx reset
+pnpm nx build web --configuration=pwa --skip-nx-cache
+```
+
+## Web Backend
+
+`apps/web-backend` exposes these routes:
+
+- `GET /health`
+- `GET /config.js`
+- `GET /parse?url=<m3u-url>`
+- `GET /parse-xml?url=<xmltv-url>`
+- `GET /xtream?url=<server>&username=<u>&password=<p>&action=<action>`
+- `GET /stalker?url=<portal.php>&macAddress=<mac>&action=<action>`
+
+The PWA continues to use `PwaService`; only the backend base URL is resolved at
+runtime. Electron routes remain owned by the Electron backend and preload
+bridge.
+
+## Docker Runtime
+
+The Docker image has two stages:
+
+1. Build stage installs dependencies and runs `web:pwa` plus `web-backend`.
+2. Runtime stage uses `node:22-alpine` with nginx installed. nginx serves
+   `dist/apps/web` and proxies `/api/*` to the local Express backend.
+
+Default runtime values:
+
+- `BACKEND_URL=/api`
+- `CLIENT_URL=http://localhost:4333`
+- `PORT=3000`
+
+When hosting behind another domain, set `CLIENT_URL` to the browser origin and
+keep `BACKEND_URL=/api` unless the reverse proxy exposes the backend elsewhere.
+
+## Validation
+
+Use the narrow validation ladder for self-hosted changes:
+
+```bash
+pnpm nx test web-backend
+pnpm nx test web --runTestsByPath apps/web/src/app/services/runtime-config.spec.ts
+pnpm nx build web --configuration=pwa --skip-nx-cache
+pnpm nx build web-backend
+pnpm nx run web-e2e:e2e -- --project=chromium --grep @self-hosted
+docker compose -f docker/docker-compose.yml config
+```
+
+Run `docker build -t iptvnator:self-hosted-test -f docker/Dockerfile .` when a
+Docker daemon is available.

--- a/libs/portal/shared/util/src/lib/collection/collection-helpers.ts
+++ b/libs/portal/shared/util/src/lib/collection/collection-helpers.ts
@@ -34,3 +34,35 @@ export function xtreamContentType(type: string): CollectionContentType {
     if (type === 'series') return 'series';
     return 'live';
 }
+
+export function getPwaXtreamContentType(
+    item: Record<string, unknown>
+): CollectionContentType {
+    if (item['series_id'] != null) {
+        return 'series';
+    }
+
+    return xtreamContentType(
+        String(item['type'] ?? item['stream_type'] ?? 'movie')
+    );
+}
+
+export function getXtreamString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0
+        ? value
+        : undefined;
+}
+
+export function getXtreamNumericValue(
+    item: Record<string, unknown>,
+    keys: readonly string[]
+): number | null {
+    for (const key of keys) {
+        const value = Number(item[key]);
+        if (Number.isFinite(value) && value > 0) {
+            return value;
+        }
+    }
+
+    return null;
+}

--- a/libs/portal/shared/util/src/lib/collection/index.ts
+++ b/libs/portal/shared/util/src/lib/collection/index.ts
@@ -4,3 +4,4 @@ export * from './scope-toggle.service';
 export * from './unified-favorites-data.service';
 export * from './unified-recent-data.service';
 export * from './stream-resolver.service';
+export * from './xtream-collection-data-source.token';

--- a/libs/portal/shared/util/src/lib/collection/index.ts
+++ b/libs/portal/shared/util/src/lib/collection/index.ts
@@ -5,3 +5,8 @@ export * from './unified-favorites-data.service';
 export * from './unified-recent-data.service';
 export * from './stream-resolver.service';
 export * from './xtream-collection-data-source.token';
+export {
+    getPwaXtreamContentType,
+    getXtreamNumericValue,
+    getXtreamString,
+} from './collection-helpers';

--- a/libs/portal/shared/util/src/lib/collection/unified-favorites-data.service.spec.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-favorites-data.service.spec.ts
@@ -11,12 +11,17 @@ import {
 } from '@iptvnator/shared/interfaces';
 import { UnifiedCollectionItem } from './unified-collection-item.interface';
 import { UnifiedFavoritesDataService } from './unified-favorites-data.service';
+import {
+    XTREAM_COLLECTION_DATA_SOURCE,
+    XtreamCollectionDataSourceItem,
+} from './xtream-collection-data-source.token';
 
 describe('UnifiedFavoritesDataService', () => {
     let service: UnifiedFavoritesDataService;
     let electronApi: {
         dbAddFavorite: jest.Mock;
         dbGetAllGlobalFavorites: jest.Mock;
+        dbGetFavorites: jest.Mock;
         dbRemoveFavorite: jest.Mock;
     };
     let databaseService: {
@@ -33,6 +38,11 @@ describe('UnifiedFavoritesDataService', () => {
         getPlaylistById: jest.Mock;
         setFavorites: jest.Mock;
         setPortalFavorites: jest.Mock;
+    };
+    let xtreamDataSource: {
+        addFavorite: jest.Mock;
+        getFavorites: jest.Mock;
+        removeFavorite: jest.Mock;
     };
 
     const m3uChannels: Channel[] = [
@@ -93,6 +103,7 @@ describe('UnifiedFavoritesDataService', () => {
         electronApi = {
             dbAddFavorite: jest.fn().mockResolvedValue({ success: true }),
             dbGetAllGlobalFavorites: jest.fn(),
+            dbGetFavorites: jest.fn(),
             dbRemoveFavorite: jest.fn().mockResolvedValue(undefined),
         };
         Object.defineProperty(window, 'electron', {
@@ -126,8 +137,20 @@ describe('UnifiedFavoritesDataService', () => {
                         macAddress: '00:11:22:33:44:55',
                         favorites: stalkerFavorites,
                     },
+                    {
+                        _id: 'xtream-1',
+                        title: 'Xtream One',
+                        serverUrl: 'https://xtream.example.com',
+                        username: 'user',
+                        password: 'pass',
+                    },
                 ] satisfies PlaylistMeta[])
             ),
+        };
+        xtreamDataSource = {
+            addFavorite: jest.fn().mockResolvedValue(undefined),
+            getFavorites: jest.fn().mockResolvedValue([]),
+            removeFavorite: jest.fn().mockResolvedValue(undefined),
         };
 
         TestBed.configureTestingModule({
@@ -144,6 +167,10 @@ describe('UnifiedFavoritesDataService', () => {
                 {
                     provide: PlaylistsService,
                     useValue: playlistsService,
+                },
+                {
+                    provide: XTREAM_COLLECTION_DATA_SOURCE,
+                    useValue: xtreamDataSource,
                 },
                 {
                     provide: TranslateService,
@@ -398,6 +425,80 @@ describe('UnifiedFavoritesDataService', () => {
             'xtream-1',
             'live.png'
         );
+    });
+
+    it('adds Xtream favorites through the PWA data source when Electron favorites APIs are absent', async () => {
+        Object.defineProperty(window, 'electron', {
+            value: {} as Window['electron'],
+            configurable: true,
+        });
+
+        await service.addFavorite({
+            uid: 'xtream::xtream-1::movie:20203',
+            name: 'PWA Movie',
+            contentType: 'movie',
+            sourceType: 'xtream',
+            playlistId: 'xtream-1',
+            playlistName: 'Xtream One',
+            posterUrl: 'movie.png',
+            xtreamId: 20203,
+        } satisfies UnifiedCollectionItem);
+
+        expect(databaseService.getContentByXtreamId).not.toHaveBeenCalled();
+        expect(xtreamDataSource.addFavorite).toHaveBeenCalledWith(
+            20203,
+            'xtream-1',
+            'movie.png'
+        );
+    });
+
+    it('maps PWA Xtream favorites from the shared data source without Electron DB APIs', async () => {
+        Object.defineProperty(window, 'electron', {
+            value: {} as Window['electron'],
+            configurable: true,
+        });
+        store.select.mockReturnValue(
+            of([
+                {
+                    _id: 'xtream-1',
+                    title: 'Xtream One',
+                    serverUrl: 'https://xtream.example.com',
+                } satisfies Partial<PlaylistMeta>,
+            ])
+        );
+        xtreamDataSource.getFavorites.mockResolvedValue([
+            {
+                id: 20203,
+                stream_id: 20203,
+                name: 'PWA Movie',
+                stream_type: 'movie',
+                stream_icon: 'movie.png',
+                category_id: '2',
+                rating: '8.1',
+                added_at: '2026-03-26T08:00:00.000Z',
+            } satisfies XtreamCollectionDataSourceItem,
+        ]);
+
+        const items = await service.getFavorites('all');
+
+        expect(databaseService.getAllGlobalFavorites).not.toHaveBeenCalled();
+        expect(xtreamDataSource.getFavorites).toHaveBeenCalledWith(
+            'xtream-1'
+        );
+        expect(items).toEqual([
+            expect.objectContaining({
+                uid: 'xtream::xtream-1::movie:20203',
+                name: 'PWA Movie',
+                contentType: 'movie',
+                sourceType: 'xtream',
+                playlistId: 'xtream-1',
+                playlistName: 'Xtream One',
+                posterUrl: 'movie.png',
+                xtreamId: 20203,
+                contentId: 20203,
+                rating: '8.1',
+            }),
+        ]);
     });
 
     it('adds Stalker favorites through portal favorites', async () => {

--- a/libs/portal/shared/util/src/lib/collection/unified-favorites-data.service.spec.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-favorites-data.service.spec.ts
@@ -477,14 +477,19 @@ describe('UnifiedFavoritesDataService', () => {
                 rating: '8.1',
                 added_at: '2026-03-26T08:00:00.000Z',
             } satisfies XtreamCollectionDataSourceItem,
+            {
+                name: 'Broken PWA Movie',
+                stream_type: 'movie',
+                stream_icon: 'broken.png',
+                added_at: '2026-03-26T09:00:00.000Z',
+            } satisfies XtreamCollectionDataSourceItem,
         ]);
 
         const items = await service.getFavorites('all');
 
         expect(databaseService.getAllGlobalFavorites).not.toHaveBeenCalled();
-        expect(xtreamDataSource.getFavorites).toHaveBeenCalledWith(
-            'xtream-1'
-        );
+        expect(xtreamDataSource.getFavorites).toHaveBeenCalledWith('xtream-1');
+        expect(items).toHaveLength(1);
         expect(items).toEqual([
             expect.objectContaining({
                 uid: 'xtream::xtream-1::movie:20203',

--- a/libs/portal/shared/util/src/lib/collection/unified-favorites-data.service.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-favorites-data.service.ts
@@ -27,6 +27,10 @@ import {
     xtreamContentType,
     XtreamFavoriteRow,
 } from './collection-helpers';
+import {
+    XTREAM_COLLECTION_DATA_SOURCE,
+    XtreamCollectionDataSourceItem,
+} from './xtream-collection-data-source.token';
 
 const GLOBAL_FAVORITES_ORDER_KEY = 'global-favorites-channel-order-v1';
 
@@ -44,6 +48,7 @@ export class UnifiedFavoritesDataService {
     private readonly store = inject(Store);
     private readonly dbService = inject(DatabaseService);
     private readonly playlistsService = inject(PlaylistsService);
+    private readonly xtreamDataSource = inject(XTREAM_COLLECTION_DATA_SOURCE);
     private readonly translate = inject(TranslateService);
 
     async getFavorites(
@@ -88,11 +93,19 @@ export class UnifiedFavoritesDataService {
                 break;
             }
             case 'xtream':
-                if (window.electron && item.contentId != null) {
+                if (this.hasElectronFavoritesApi() && item.contentId != null) {
                     await window.electron.dbRemoveFavorite(
                         item.contentId,
                         item.playlistId
                     );
+                } else {
+                    const contentId = this.getXtreamItemId(item);
+                    if (contentId != null) {
+                        await this.xtreamDataSource.removeFavorite(
+                            contentId,
+                            item.playlistId
+                        );
+                    }
                 }
                 break;
             case 'stalker': {
@@ -136,31 +149,36 @@ export class UnifiedFavoritesDataService {
     private async addXtreamFavorite(
         item: UnifiedCollectionItem
     ): Promise<void> {
-        if (!window.electron) {
-            return;
-        }
-
-        const contentId =
-            item.contentId ??
-            (item.xtreamId != null
-                ? (
-                      await this.dbService.getContentByXtreamId(
-                          item.xtreamId,
-                          item.playlistId,
-                          item.contentType
-                      )
-                  )?.id
-                : null);
+        const contentId = this.hasElectronFavoritesApi()
+            ? (item.contentId ??
+              (item.xtreamId != null
+                  ? (
+                        await this.dbService.getContentByXtreamId(
+                            item.xtreamId,
+                            item.playlistId,
+                            item.contentType
+                        )
+                    )?.id
+                  : null))
+            : this.getXtreamItemId(item);
 
         if (contentId == null) {
             return;
         }
 
-        await window.electron.dbAddFavorite(
-            contentId,
-            item.playlistId,
-            item.posterUrl ?? item.logo ?? undefined
-        );
+        if (this.hasElectronFavoritesApi()) {
+            await window.electron.dbAddFavorite(
+                contentId,
+                item.playlistId,
+                item.posterUrl ?? item.logo ?? undefined
+            );
+        } else {
+            await this.xtreamDataSource.addFavorite(
+                contentId,
+                item.playlistId,
+                item.posterUrl ?? item.logo ?? undefined
+            );
+        }
     }
 
     private async addStalkerFavorite(
@@ -283,14 +301,14 @@ export class UnifiedFavoritesDataService {
             options.playlistId &&
             options.portalType === 'xtream'
         ) {
-            if (xtreamUpdates.length > 0 && window.electron) {
+            if (xtreamUpdates.length > 0 && this.hasElectronReorderApi()) {
                 await window.electron.dbReorderGlobalFavorites(xtreamUpdates);
             }
             return;
         }
 
         await Promise.all([
-            xtreamUpdates.length > 0 && window.electron
+            xtreamUpdates.length > 0 && this.hasElectronReorderApi()
                 ? window.electron.dbReorderGlobalFavorites(xtreamUpdates)
                 : Promise.resolve(),
             this.saveOrder(items.map((item) => item.uid)),
@@ -346,16 +364,35 @@ export class UnifiedFavoritesDataService {
     private async clearXtreamFavorites(
         items: UnifiedCollectionItem[]
     ): Promise<void> {
-        if (!window.electron) {
+        if (this.hasElectronFavoritesApi()) {
+            await Promise.all(
+                items
+                    .filter((item) => item.contentId != null)
+                    .map((item) =>
+                        window.electron!.dbRemoveFavorite(
+                            item.contentId!,
+                            item.playlistId
+                        )
+                    )
+            );
             return;
         }
 
         await Promise.all(
             items
-                .filter((item) => item.contentId != null)
+                .map((item) => ({
+                    playlistId: item.playlistId,
+                    contentId: this.getXtreamItemId(item),
+                }))
+                .filter(
+                    (
+                        item
+                    ): item is { playlistId: string; contentId: number } =>
+                        item.contentId != null
+                )
                 .map((item) =>
-                    window.electron!.dbRemoveFavorite(
-                        item.contentId!,
+                    this.xtreamDataSource.removeFavorite(
+                        item.contentId,
                         item.playlistId
                     )
                 )
@@ -484,7 +521,19 @@ export class UnifiedFavoritesDataService {
     }
 
     private async getXtreamAllFavorites(): Promise<UnifiedCollectionItem[]> {
-        if (!window.electron?.dbGetAllGlobalFavorites) return [];
+        if (!this.hasElectronFavoritesApi()) {
+            const allMeta = await this.getAllMeta();
+            const results: UnifiedCollectionItem[] = [];
+
+            for (const meta of allMeta.filter((playlist) =>
+                Boolean(playlist.serverUrl)
+            )) {
+                results.push(...(await this.getPwaXtreamFavorites(meta)));
+            }
+
+            return results;
+        }
+
         try {
             const rows =
                 (await this.dbService.getAllGlobalFavorites()) as XtreamFavoriteRow[];
@@ -497,7 +546,11 @@ export class UnifiedFavoritesDataService {
     private async getXtreamPlaylistFavorites(
         playlistId: string
     ): Promise<UnifiedCollectionItem[]> {
-        if (!window.electron) return [];
+        if (!this.hasElectronPlaylistFavoritesApi()) {
+            const meta = await this.getPlaylistMeta(playlistId);
+            return meta ? this.getPwaXtreamFavorites(meta) : [];
+        }
+
         try {
             const rows = await this.dbService.getFavorites(playlistId);
             const meta = await this.getPlaylistMeta(playlistId);
@@ -509,6 +562,122 @@ export class UnifiedFavoritesDataService {
         } catch {
             return [];
         }
+    }
+
+    private async getPwaXtreamFavorites(
+        meta: PlaylistMeta
+    ): Promise<UnifiedCollectionItem[]> {
+        try {
+            const rows = await this.xtreamDataSource.getFavorites(meta._id);
+            return rows.map((row, index) =>
+                this.mapPwaXtreamFavoriteItem(row, meta, index)
+            );
+        } catch {
+            return [];
+        }
+    }
+
+    private mapPwaXtreamFavoriteItem(
+        row: XtreamCollectionDataSourceItem,
+        meta: PlaylistMeta,
+        index: number
+    ): UnifiedCollectionItem {
+        const record = row as unknown as Record<string, unknown>;
+        const contentType = this.getPwaXtreamContentType(record);
+        const xtreamId = this.getXtreamNumericValue(record, [
+            'xtream_id',
+            'stream_id',
+            'series_id',
+            'id',
+        ]);
+        const contentId = this.getXtreamNumericValue(record, [
+            'id',
+            'stream_id',
+            'series_id',
+            'xtream_id',
+        ]);
+        const title =
+            this.getXtreamString(record['title']) ??
+            this.getXtreamString(record['name']) ??
+            this.getXtreamString(record['stream_display_name']) ??
+            'Unknown';
+        const image =
+            this.getXtreamString(record['poster_url']) ??
+            this.getXtreamString(record['stream_icon']) ??
+            this.getXtreamString(record['cover']) ??
+            null;
+
+        return {
+            uid: buildXtreamCollectionUid(meta._id, contentType, xtreamId),
+            name: title,
+            contentType,
+            sourceType: 'xtream',
+            playlistId: meta._id,
+            playlistName: meta.title || meta.filename || 'Xtream',
+            logo: contentType === 'live' ? image : null,
+            posterUrl: contentType !== 'live' ? image : null,
+            xtreamId,
+            categoryId: record['category_id'] as string | number,
+            tvgId: contentType === 'live' ? String(xtreamId) : undefined,
+            rating: this.getXtreamString(record['rating']),
+            addedAt:
+                normalizeStalkerDate(
+                    this.getXtreamString(record['added_at']) ??
+                        this.getXtreamString(record['added']) ??
+                        ''
+                ) || new Date(0).toISOString(),
+            position: index,
+            contentId,
+        };
+    }
+
+    private hasElectronFavoritesApi(): boolean {
+        return typeof window.electron?.dbGetAllGlobalFavorites === 'function';
+    }
+
+    private hasElectronPlaylistFavoritesApi(): boolean {
+        return typeof window.electron?.dbGetFavorites === 'function';
+    }
+
+    private hasElectronReorderApi(): boolean {
+        return typeof window.electron?.dbReorderGlobalFavorites === 'function';
+    }
+
+    private getXtreamItemId(item: UnifiedCollectionItem): number | null {
+        const value = Number(item.contentId ?? item.xtreamId);
+        return Number.isFinite(value) && value > 0 ? value : null;
+    }
+
+    private getPwaXtreamContentType(
+        item: Record<string, unknown>
+    ): UnifiedCollectionItem['contentType'] {
+        if (item['series_id'] != null) {
+            return 'series';
+        }
+
+        return xtreamContentType(
+            String(item['type'] ?? item['stream_type'] ?? 'movie')
+        );
+    }
+
+    private getXtreamString(value: unknown): string | undefined {
+        return typeof value === 'string' && value.trim().length > 0
+            ? value
+            : undefined;
+    }
+
+    private getXtreamNumericValue(
+        item: Record<string, unknown>,
+        keys: string[]
+    ): number {
+        for (const key of keys) {
+            const value = Number(item[key]);
+            if (Number.isFinite(value) && value > 0) {
+                return value;
+            }
+        }
+
+        return 0;
     }
 
     private mapXtreamRow(row: XtreamFavoriteRow): UnifiedCollectionItem {

--- a/libs/portal/shared/util/src/lib/collection/unified-favorites-data.service.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-favorites-data.service.ts
@@ -23,6 +23,9 @@ import {
 } from './unified-collection-item.interface';
 import { CollectionScope } from './scope-toggle.service';
 import {
+    getPwaXtreamContentType,
+    getXtreamNumericValue,
+    getXtreamString,
     isStalkerItem,
     xtreamContentType,
     XtreamFavoriteRow,
@@ -385,9 +388,7 @@ export class UnifiedFavoritesDataService {
                     contentId: this.getXtreamItemId(item),
                 }))
                 .filter(
-                    (
-                        item
-                    ): item is { playlistId: string; contentId: number } =>
+                    (item): item is { playlistId: string; contentId: number } =>
                         item.contentId != null
                 )
                 .map((item) =>
@@ -569,9 +570,11 @@ export class UnifiedFavoritesDataService {
     ): Promise<UnifiedCollectionItem[]> {
         try {
             const rows = await this.xtreamDataSource.getFavorites(meta._id);
-            return rows.map((row, index) =>
-                this.mapPwaXtreamFavoriteItem(row, meta, index)
-            );
+            return rows
+                .map((row, index) =>
+                    this.mapPwaXtreamFavoriteItem(row, meta, index)
+                )
+                .filter((item): item is UnifiedCollectionItem => item !== null);
         } catch {
             return [];
         }
@@ -581,30 +584,34 @@ export class UnifiedFavoritesDataService {
         row: XtreamCollectionDataSourceItem,
         meta: PlaylistMeta,
         index: number
-    ): UnifiedCollectionItem {
+    ): UnifiedCollectionItem | null {
         const record = row as unknown as Record<string, unknown>;
-        const contentType = this.getPwaXtreamContentType(record);
-        const xtreamId = this.getXtreamNumericValue(record, [
+        const contentType = getPwaXtreamContentType(record);
+        const xtreamId = getXtreamNumericValue(record, [
             'xtream_id',
             'stream_id',
             'series_id',
             'id',
         ]);
-        const contentId = this.getXtreamNumericValue(record, [
+        if (xtreamId == null) {
+            return null;
+        }
+
+        const contentId = getXtreamNumericValue(record, [
             'id',
             'stream_id',
             'series_id',
             'xtream_id',
         ]);
         const title =
-            this.getXtreamString(record['title']) ??
-            this.getXtreamString(record['name']) ??
-            this.getXtreamString(record['stream_display_name']) ??
+            getXtreamString(record['title']) ??
+            getXtreamString(record['name']) ??
+            getXtreamString(record['stream_display_name']) ??
             'Unknown';
         const image =
-            this.getXtreamString(record['poster_url']) ??
-            this.getXtreamString(record['stream_icon']) ??
-            this.getXtreamString(record['cover']) ??
+            getXtreamString(record['poster_url']) ??
+            getXtreamString(record['stream_icon']) ??
+            getXtreamString(record['cover']) ??
             null;
 
         return {
@@ -619,15 +626,15 @@ export class UnifiedFavoritesDataService {
             xtreamId,
             categoryId: record['category_id'] as string | number,
             tvgId: contentType === 'live' ? String(xtreamId) : undefined,
-            rating: this.getXtreamString(record['rating']),
+            rating: getXtreamString(record['rating']),
             addedAt:
                 normalizeStalkerDate(
-                    this.getXtreamString(record['added_at']) ??
-                        this.getXtreamString(record['added']) ??
+                    getXtreamString(record['added_at']) ??
+                        getXtreamString(record['added']) ??
                         ''
                 ) || new Date(0).toISOString(),
             position: index,
-            contentId,
+            contentId: contentId ?? xtreamId,
         };
     }
 
@@ -646,38 +653,6 @@ export class UnifiedFavoritesDataService {
     private getXtreamItemId(item: UnifiedCollectionItem): number | null {
         const value = Number(item.contentId ?? item.xtreamId);
         return Number.isFinite(value) && value > 0 ? value : null;
-    }
-
-    private getPwaXtreamContentType(
-        item: Record<string, unknown>
-    ): UnifiedCollectionItem['contentType'] {
-        if (item['series_id'] != null) {
-            return 'series';
-        }
-
-        return xtreamContentType(
-            String(item['type'] ?? item['stream_type'] ?? 'movie')
-        );
-    }
-
-    private getXtreamString(value: unknown): string | undefined {
-        return typeof value === 'string' && value.trim().length > 0
-            ? value
-            : undefined;
-    }
-
-    private getXtreamNumericValue(
-        item: Record<string, unknown>,
-        keys: string[]
-    ): number {
-        for (const key of keys) {
-            const value = Number(item[key]);
-            if (Number.isFinite(value) && value > 0) {
-                return value;
-            }
-        }
-
-        return 0;
     }
 
     private mapXtreamRow(row: XtreamFavoriteRow): UnifiedCollectionItem {

--- a/libs/portal/shared/util/src/lib/collection/unified-recent-data.service.spec.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-recent-data.service.spec.ts
@@ -10,7 +10,10 @@ import {
 } from '@iptvnator/shared/interfaces';
 import { UnifiedCollectionItem } from './unified-collection-item.interface';
 import { UnifiedRecentDataService } from './unified-recent-data.service';
-import { XTREAM_COLLECTION_DATA_SOURCE } from './xtream-collection-data-source.token';
+import {
+    XTREAM_COLLECTION_DATA_SOURCE,
+    XtreamCollectionDataSourceItem,
+} from './xtream-collection-data-source.token';
 
 describe('UnifiedRecentDataService', () => {
     let service: UnifiedRecentDataService;
@@ -309,6 +312,52 @@ describe('UnifiedRecentDataService', () => {
                 }),
             ])
         );
+    });
+
+    it('filters PWA Xtream recent rows that have no positive Xtream identity', async () => {
+        Object.defineProperty(window, 'electron', {
+            value: {} as Window['electron'],
+            configurable: true,
+        });
+        store.select.mockReturnValue(
+            of([
+                {
+                    _id: 'xtream-1',
+                    title: 'Xtream One',
+                    serverUrl: 'https://example.com',
+                } satisfies Partial<PlaylistMeta>,
+            ])
+        );
+        xtreamDataSource.getRecentItems.mockResolvedValue([
+            {
+                id: 20203,
+                stream_id: 20203,
+                title: 'PWA Recent Movie',
+                type: 'movie',
+                poster_url: 'https://example.com/movie.png',
+                viewed_at: '2026-04-21T20:42:27.000Z',
+            } satisfies XtreamCollectionDataSourceItem,
+            {
+                title: 'Broken PWA Recent',
+                type: 'movie',
+                poster_url: 'https://example.com/broken.png',
+                viewed_at: '2026-04-21T20:43:27.000Z',
+            } satisfies XtreamCollectionDataSourceItem,
+        ]);
+
+        const items = await service.getRecentItems(
+            'playlist',
+            'xtream-1',
+            'xtream'
+        );
+
+        expect(items).toEqual([
+            expect.objectContaining({
+                uid: 'xtream::xtream-1::movie:20203',
+                contentId: 20203,
+                xtreamId: 20203,
+            }),
+        ]);
     });
 
     it('keeps Stalker radio recent items in the live collection with radio metadata', async () => {

--- a/libs/portal/shared/util/src/lib/collection/unified-recent-data.service.spec.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-recent-data.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@iptvnator/shared/interfaces';
 import { UnifiedCollectionItem } from './unified-collection-item.interface';
 import { UnifiedRecentDataService } from './unified-recent-data.service';
+import { XTREAM_COLLECTION_DATA_SOURCE } from './xtream-collection-data-source.token';
 
 describe('UnifiedRecentDataService', () => {
     let service: UnifiedRecentDataService;
@@ -32,6 +33,12 @@ describe('UnifiedRecentDataService', () => {
         clearGlobalRecentlyViewed: jest.Mock;
         addRecentItem: jest.Mock;
         getContentByXtreamId: jest.Mock;
+    };
+    let xtreamDataSource: {
+        addRecentItem: jest.Mock;
+        clearRecentItems: jest.Mock;
+        getRecentItems: jest.Mock;
+        removeRecentItem: jest.Mock;
     };
 
     const playlistMeta = {
@@ -87,6 +94,12 @@ describe('UnifiedRecentDataService', () => {
     ];
 
     beforeEach(() => {
+        Object.defineProperty(window, 'electron', {
+            value: {
+                dbGetRecentlyViewed: jest.fn(),
+            } as unknown as Window['electron'],
+            configurable: true,
+        });
         store = {
             select: jest.fn(() => of([playlistMeta])),
             dispatch: jest.fn(),
@@ -136,6 +149,12 @@ describe('UnifiedRecentDataService', () => {
             addRecentItem: jest.fn().mockResolvedValue(true),
             getContentByXtreamId: jest.fn().mockResolvedValue(null),
         };
+        xtreamDataSource = {
+            addRecentItem: jest.fn().mockResolvedValue(undefined),
+            clearRecentItems: jest.fn().mockResolvedValue(undefined),
+            getRecentItems: jest.fn().mockResolvedValue([]),
+            removeRecentItem: jest.fn().mockResolvedValue(undefined),
+        };
 
         TestBed.configureTestingModule({
             providers: [
@@ -143,6 +162,10 @@ describe('UnifiedRecentDataService', () => {
                 { provide: Store, useValue: store },
                 { provide: PlaylistsService, useValue: playlistsService },
                 { provide: DatabaseService, useValue: dbService },
+                {
+                    provide: XTREAM_COLLECTION_DATA_SOURCE,
+                    useValue: xtreamDataSource,
+                },
             ],
         });
 

--- a/libs/portal/shared/util/src/lib/collection/unified-recent-data.service.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-recent-data.service.ts
@@ -26,6 +26,10 @@ import {
 } from './unified-collection-item.interface';
 import { CollectionScope } from './scope-toggle.service';
 import { xtreamContentType } from './collection-helpers';
+import {
+    XTREAM_COLLECTION_DATA_SOURCE,
+    XtreamCollectionDataSourceItem,
+} from './xtream-collection-data-source.token';
 
 type PlaylistWithChannels = Playlist & {
     readonly playlist?: { readonly items?: Channel[] };
@@ -35,6 +39,7 @@ type PlaylistWithChannels = Playlist & {
 export class UnifiedRecentDataService {
     private readonly store = inject(Store);
     private readonly dbService = inject(DatabaseService);
+    private readonly xtreamDataSource = inject(XTREAM_COLLECTION_DATA_SOURCE);
     private readonly playlistsService = inject(PlaylistsService);
 
     async getRecentItems(
@@ -55,10 +60,17 @@ export class UnifiedRecentDataService {
                 return;
             }
 
-            await this.dbService.removeRecentItem(
-                item.contentId,
-                item.playlistId
-            );
+            if (this.hasElectronRecentApi()) {
+                await this.dbService.removeRecentItem(
+                    item.contentId,
+                    item.playlistId
+                );
+            } else {
+                await this.xtreamDataSource.removeRecentItem(
+                    item.contentId,
+                    item.playlistId
+                );
+            }
             return;
         }
 
@@ -126,7 +138,20 @@ export class UnifiedRecentDataService {
         const tasks: Promise<unknown>[] = [];
 
         if (xtreamBatch.length > 0) {
-            tasks.push(this.dbService.removeRecentItemsBatch(xtreamBatch));
+            if (this.hasElectronRecentApi()) {
+                tasks.push(this.dbService.removeRecentItemsBatch(xtreamBatch));
+            } else {
+                tasks.push(
+                    Promise.all(
+                        xtreamBatch.map((item) =>
+                            this.xtreamDataSource.removeRecentItem(
+                                item.contentId,
+                                item.playlistId
+                            )
+                        )
+                    )
+                );
+            }
         }
 
         for (const [playlistId, identities] of groupedByPlaylist) {
@@ -153,7 +178,11 @@ export class UnifiedRecentDataService {
         playlistId?: string
     ): Promise<void> {
         if (scope === 'playlist' && playlistId) {
-            await this.dbService.clearPlaylistRecentItems(playlistId);
+            if (this.hasElectronRecentApi()) {
+                await this.dbService.clearPlaylistRecentItems(playlistId);
+            } else {
+                await this.xtreamDataSource.clearRecentItems(playlistId);
+            }
             const updatedPlaylist = await firstValueFrom(
                 this.playlistsService.clearPlaylistRecentlyViewed(playlistId)
             );
@@ -161,7 +190,18 @@ export class UnifiedRecentDataService {
             return;
         }
 
-        await this.dbService.clearGlobalRecentlyViewed();
+        if (this.hasElectronRecentApi()) {
+            await this.dbService.clearGlobalRecentlyViewed();
+        } else {
+            const allMeta = await this.getAllMeta();
+            await Promise.all(
+                allMeta
+                    .filter((playlist) => Boolean(playlist.serverUrl))
+                    .map((playlist) =>
+                        this.xtreamDataSource.clearRecentItems(playlist._id)
+                    )
+            );
+        }
         const playlists = (await firstValueFrom(
             this.playlistsService.getAllPlaylists()
         )) as Playlist[];
@@ -223,17 +263,29 @@ export class UnifiedRecentDataService {
             const contentId =
                 item.contentId ??
                 (item.xtreamId != null
-                    ? (
-                          await this.dbService.getContentByXtreamId(
-                              item.xtreamId,
-                              item.playlistId,
-                              item.contentType
-                          )
-                      )?.id
+                    ? this.hasElectronRecentApi()
+                        ? (
+                              await this.dbService.getContentByXtreamId(
+                                  item.xtreamId,
+                                  item.playlistId,
+                                  item.contentType
+                              )
+                          )?.id
+                        : item.xtreamId
                     : null);
 
             if (contentId != null) {
-                await this.dbService.addRecentItem(contentId, item.playlistId);
+                if (this.hasElectronRecentApi()) {
+                    await this.dbService.addRecentItem(
+                        contentId,
+                        item.playlistId
+                    );
+                } else {
+                    await this.xtreamDataSource.addRecentItem(
+                        contentId,
+                        item.playlistId
+                    );
+                }
             }
 
             return {
@@ -309,6 +361,19 @@ export class UnifiedRecentDataService {
     }
 
     private async getXtreamGlobalRecent(): Promise<UnifiedCollectionItem[]> {
+        if (!this.hasElectronRecentApi()) {
+            const allMeta = await this.getAllMeta();
+            const results: UnifiedCollectionItem[] = [];
+
+            for (const meta of allMeta.filter((playlist) =>
+                Boolean(playlist.serverUrl)
+            )) {
+                results.push(...(await this.getPwaXtreamRecent(meta)));
+            }
+
+            return results;
+        }
+
         try {
             const rows = await this.dbService.getGlobalRecentlyViewed();
             return (rows || []).map((row) => ({
@@ -339,6 +404,11 @@ export class UnifiedRecentDataService {
     private async getXtreamPlaylistRecent(
         playlistId: string
     ): Promise<UnifiedCollectionItem[]> {
+        if (!this.hasElectronRecentApi()) {
+            const meta = await this.getPlaylistMeta(playlistId);
+            return meta ? this.getPwaXtreamRecent(meta) : [];
+        }
+
         try {
             const rows = await this.dbService.getRecentItems(playlistId);
             const meta = await this.getPlaylistMeta(playlistId);
@@ -366,6 +436,101 @@ export class UnifiedRecentDataService {
         } catch {
             return [];
         }
+    }
+
+    private async getPwaXtreamRecent(
+        meta: PlaylistMeta
+    ): Promise<UnifiedCollectionItem[]> {
+        try {
+            const rows = await this.xtreamDataSource.getRecentItems(meta._id);
+            return rows.map((row) => this.mapPwaXtreamRecentItem(row, meta));
+        } catch {
+            return [];
+        }
+    }
+
+    private mapPwaXtreamRecentItem(
+        row: XtreamCollectionDataSourceItem,
+        meta: PlaylistMeta
+    ): UnifiedCollectionItem {
+        const record = row as unknown as Record<string, unknown>;
+        const contentType = this.getPwaXtreamContentType(record);
+        const xtreamId = this.getXtreamNumericValue(record, [
+            'xtream_id',
+            'stream_id',
+            'series_id',
+            'id',
+        ]);
+        const contentId = this.getXtreamNumericValue(record, [
+            'id',
+            'stream_id',
+            'series_id',
+            'xtream_id',
+        ]);
+        const title =
+            this.getXtreamString(record['title']) ??
+            this.getXtreamString(record['name']) ??
+            this.getXtreamString(record['stream_display_name']) ??
+            'Unknown';
+        const image =
+            this.getXtreamString(record['poster_url']) ??
+            this.getXtreamString(record['stream_icon']) ??
+            this.getXtreamString(record['cover']) ??
+            null;
+
+        return {
+            uid: buildXtreamCollectionUid(meta._id, contentType, xtreamId),
+            name: title,
+            contentType,
+            sourceType: 'xtream',
+            playlistId: meta._id,
+            playlistName: meta.title || meta.filename || 'Xtream',
+            logo: contentType === 'live' ? image : null,
+            posterUrl: contentType !== 'live' ? image : null,
+            xtreamId,
+            categoryId: record['category_id'] as string | number,
+            tvgId: contentType === 'live' ? String(xtreamId) : undefined,
+            contentId,
+            viewedAt: normalizeStalkerDate(
+                this.getXtreamString(record['viewed_at']) ?? ''
+            ),
+        };
+    }
+
+    private hasElectronRecentApi(): boolean {
+        return typeof window.electron?.dbGetRecentlyViewed === 'function';
+    }
+
+    private getPwaXtreamContentType(
+        item: Record<string, unknown>
+    ): UnifiedCollectionItem['contentType'] {
+        if (item['series_id'] != null) {
+            return 'series';
+        }
+
+        return xtreamContentType(
+            String(item['type'] ?? item['stream_type'] ?? 'movie')
+        );
+    }
+
+    private getXtreamString(value: unknown): string | undefined {
+        return typeof value === 'string' && value.trim().length > 0
+            ? value
+            : undefined;
+    }
+
+    private getXtreamNumericValue(
+        item: Record<string, unknown>,
+        keys: string[]
+    ): number {
+        for (const key of keys) {
+            const value = Number(item[key]);
+            if (Number.isFinite(value) && value > 0) {
+                return value;
+            }
+        }
+
+        return 0;
     }
 
     private async getM3uGlobalRecent(): Promise<UnifiedCollectionItem[]> {

--- a/libs/portal/shared/util/src/lib/collection/unified-recent-data.service.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-recent-data.service.ts
@@ -25,7 +25,12 @@ import {
     UnifiedCollectionItem,
 } from './unified-collection-item.interface';
 import { CollectionScope } from './scope-toggle.service';
-import { xtreamContentType } from './collection-helpers';
+import {
+    getPwaXtreamContentType,
+    getXtreamNumericValue,
+    getXtreamString,
+    xtreamContentType,
+} from './collection-helpers';
 import {
     XTREAM_COLLECTION_DATA_SOURCE,
     XtreamCollectionDataSourceItem,
@@ -443,7 +448,9 @@ export class UnifiedRecentDataService {
     ): Promise<UnifiedCollectionItem[]> {
         try {
             const rows = await this.xtreamDataSource.getRecentItems(meta._id);
-            return rows.map((row) => this.mapPwaXtreamRecentItem(row, meta));
+            return rows
+                .map((row) => this.mapPwaXtreamRecentItem(row, meta))
+                .filter((item): item is UnifiedCollectionItem => item !== null);
         } catch {
             return [];
         }
@@ -452,30 +459,34 @@ export class UnifiedRecentDataService {
     private mapPwaXtreamRecentItem(
         row: XtreamCollectionDataSourceItem,
         meta: PlaylistMeta
-    ): UnifiedCollectionItem {
+    ): UnifiedCollectionItem | null {
         const record = row as unknown as Record<string, unknown>;
-        const contentType = this.getPwaXtreamContentType(record);
-        const xtreamId = this.getXtreamNumericValue(record, [
+        const contentType = getPwaXtreamContentType(record);
+        const xtreamId = getXtreamNumericValue(record, [
             'xtream_id',
             'stream_id',
             'series_id',
             'id',
         ]);
-        const contentId = this.getXtreamNumericValue(record, [
+        if (xtreamId == null) {
+            return null;
+        }
+
+        const contentId = getXtreamNumericValue(record, [
             'id',
             'stream_id',
             'series_id',
             'xtream_id',
         ]);
         const title =
-            this.getXtreamString(record['title']) ??
-            this.getXtreamString(record['name']) ??
-            this.getXtreamString(record['stream_display_name']) ??
+            getXtreamString(record['title']) ??
+            getXtreamString(record['name']) ??
+            getXtreamString(record['stream_display_name']) ??
             'Unknown';
         const image =
-            this.getXtreamString(record['poster_url']) ??
-            this.getXtreamString(record['stream_icon']) ??
-            this.getXtreamString(record['cover']) ??
+            getXtreamString(record['poster_url']) ??
+            getXtreamString(record['stream_icon']) ??
+            getXtreamString(record['cover']) ??
             null;
 
         return {
@@ -490,47 +501,15 @@ export class UnifiedRecentDataService {
             xtreamId,
             categoryId: record['category_id'] as string | number,
             tvgId: contentType === 'live' ? String(xtreamId) : undefined,
-            contentId,
+            contentId: contentId ?? xtreamId,
             viewedAt: normalizeStalkerDate(
-                this.getXtreamString(record['viewed_at']) ?? ''
+                getXtreamString(record['viewed_at']) ?? ''
             ),
         };
     }
 
     private hasElectronRecentApi(): boolean {
         return typeof window.electron?.dbGetRecentlyViewed === 'function';
-    }
-
-    private getPwaXtreamContentType(
-        item: Record<string, unknown>
-    ): UnifiedCollectionItem['contentType'] {
-        if (item['series_id'] != null) {
-            return 'series';
-        }
-
-        return xtreamContentType(
-            String(item['type'] ?? item['stream_type'] ?? 'movie')
-        );
-    }
-
-    private getXtreamString(value: unknown): string | undefined {
-        return typeof value === 'string' && value.trim().length > 0
-            ? value
-            : undefined;
-    }
-
-    private getXtreamNumericValue(
-        item: Record<string, unknown>,
-        keys: string[]
-    ): number {
-        for (const key of keys) {
-            const value = Number(item[key]);
-            if (Number.isFinite(value) && value > 0) {
-                return value;
-            }
-        }
-
-        return 0;
     }
 
     private async getM3uGlobalRecent(): Promise<UnifiedCollectionItem[]> {

--- a/libs/portal/shared/util/src/lib/collection/xtream-collection-data-source.token.ts
+++ b/libs/portal/shared/util/src/lib/collection/xtream-collection-data-source.token.ts
@@ -1,0 +1,61 @@
+import { InjectionToken } from '@angular/core';
+
+export interface XtreamCollectionDataSourceItem {
+    readonly id?: number;
+    readonly category_id?: number | string;
+    readonly title?: string;
+    readonly name?: string;
+    readonly rating?: string;
+    readonly added?: string;
+    readonly added_at?: string;
+    readonly viewed_at?: string;
+    readonly poster_url?: string;
+    readonly backdrop_url?: string | null;
+    readonly xtream_id?: number;
+    readonly type?: string;
+    readonly stream_type?: 'live' | 'movie';
+    readonly stream_id?: number;
+    readonly stream_icon?: string;
+    readonly stream_display_name?: string;
+    readonly cover?: string;
+    readonly series_id?: number;
+}
+
+export interface XtreamCollectionDataSource {
+    getFavorites(playlistId: string): Promise<XtreamCollectionDataSourceItem[]>;
+    addFavorite(
+        contentId: number,
+        playlistId: string,
+        backdropUrl?: string
+    ): Promise<void>;
+    removeFavorite(contentId: number, playlistId: string): Promise<void>;
+    getRecentItems(
+        playlistId: string
+    ): Promise<XtreamCollectionDataSourceItem[]>;
+    addRecentItem(
+        contentId: number,
+        playlistId: string,
+        backdropUrl?: string
+    ): Promise<void>;
+    removeRecentItem(contentId: number, playlistId: string): Promise<void>;
+    clearRecentItems(playlistId: string): Promise<void>;
+}
+
+const noopXtreamCollectionDataSource: XtreamCollectionDataSource = {
+    getFavorites: async () => [],
+    addFavorite: async () => undefined,
+    removeFavorite: async () => undefined,
+    getRecentItems: async () => [],
+    addRecentItem: async () => undefined,
+    removeRecentItem: async () => undefined,
+    clearRecentItems: async () => undefined,
+};
+
+export const XTREAM_COLLECTION_DATA_SOURCE =
+    new InjectionToken<XtreamCollectionDataSource>(
+        'XtreamCollectionDataSource',
+        {
+            providedIn: 'root',
+            factory: () => noopXtreamCollectionDataSource,
+        }
+    );

--- a/libs/portal/xtream/data-access/src/lib/data-sources/index.spec.ts
+++ b/libs/portal/xtream/data-access/src/lib/data-sources/index.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+import { XtreamApiService } from '../services/xtream-api.service';
+import {
+    provideXtreamDataSource,
+    PwaXtreamDataSource,
+    XTREAM_DATA_SOURCE,
+} from './index';
+
+describe('provideXtreamDataSource', () => {
+    let originalElectron: typeof window.electron;
+
+    beforeEach(() => {
+        originalElectron = window.electron;
+    });
+
+    afterEach(() => {
+        (window as unknown as { electron?: typeof window.electron }).electron =
+            originalElectron;
+        TestBed.resetTestingModule();
+    });
+
+    it('uses the PWA data source when the web shim exposes an empty electron object', () => {
+        (window as unknown as { electron?: typeof window.electron }).electron =
+            {} as typeof window.electron;
+
+        TestBed.configureTestingModule({
+            providers: [
+                ...provideXtreamDataSource(),
+                {
+                    provide: XtreamApiService,
+                    useValue: {},
+                },
+            ],
+        });
+
+        expect(TestBed.inject(XTREAM_DATA_SOURCE)).toBeInstanceOf(
+            PwaXtreamDataSource
+        );
+    });
+});

--- a/libs/portal/xtream/data-access/src/lib/data-sources/index.ts
+++ b/libs/portal/xtream/data-access/src/lib/data-sources/index.ts
@@ -1,12 +1,23 @@
 import { inject, Provider } from '@angular/core';
 import { ElectronXtreamDataSource } from './electron-xtream-data-source';
 import { PwaXtreamDataSource } from './pwa-xtream-data-source';
-import { IXtreamDataSource, XTREAM_DATA_SOURCE } from './xtream-data-source.interface';
+import {
+    IXtreamDataSource,
+    XTREAM_DATA_SOURCE,
+} from './xtream-data-source.interface';
 
 // Re-export all types and interfaces
 export * from './xtream-data-source.interface';
 export { ElectronXtreamDataSource } from './electron-xtream-data-source';
 export { PwaXtreamDataSource } from './pwa-xtream-data-source';
+
+function hasElectronDatabasePreload(): boolean {
+    return (
+        typeof window !== 'undefined' &&
+        typeof window.electron?.dbGetPlaylist === 'function' &&
+        typeof window.electron?.dbGetContent === 'function'
+    );
+}
 
 /**
  * Factory function that returns the appropriate data source based on environment.
@@ -15,7 +26,7 @@ export { PwaXtreamDataSource } from './pwa-xtream-data-source';
  */
 export function xtreamDataSourceFactory(): IXtreamDataSource {
     // Check if we're in Electron environment
-    if (typeof window !== 'undefined' && window.electron) {
+    if (hasElectronDatabasePreload()) {
         return inject(ElectronXtreamDataSource);
     }
 

--- a/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.spec.ts
+++ b/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.spec.ts
@@ -1,0 +1,106 @@
+import { TestBed } from '@angular/core/testing';
+import { XtreamApiService } from '../services/xtream-api.service';
+import { PwaXtreamDataSource } from './pwa-xtream-data-source';
+
+describe('PwaXtreamDataSource', () => {
+    let dataSource: PwaXtreamDataSource;
+    let apiService: {
+        getStreams: jest.Mock;
+    };
+
+    const credentials = {
+        serverUrl: 'http://localhost:3211',
+        username: 'user1',
+        password: 'pass1',
+    };
+
+    beforeEach(() => {
+        localStorage.clear();
+        apiService = {
+            getStreams: jest.fn().mockResolvedValue([
+                {
+                    stream_id: 20203,
+                    category_id: '206',
+                    name: 'Movie',
+                    title: 'Movie',
+                    stream_type: 'movie',
+                    type: 'movie',
+                },
+            ]),
+        };
+
+        TestBed.configureTestingModule({
+            providers: [
+                PwaXtreamDataSource,
+                {
+                    provide: XtreamApiService,
+                    useValue: apiService,
+                },
+            ],
+        });
+
+        dataSource = TestBed.inject(PwaXtreamDataSource);
+    });
+
+    it('finds VOD cached under vod when callers request movie content', async () => {
+        await dataSource.getContent('playlist-1', credentials, 'vod');
+
+        await expect(
+            dataSource.getContentByXtreamId(20203, 'playlist-1', 'movie')
+        ).resolves.toMatchObject({
+            stream_id: 20203,
+            title: 'Movie',
+        });
+    });
+
+    it('matches PWA favorites and recent items against VOD cache entries', async () => {
+        await dataSource.getContent('playlist-1', credentials, 'vod');
+
+        await dataSource.addFavorite(20203, 'playlist-1');
+        await dataSource.addRecentItem(20203, 'playlist-1');
+
+        await expect(dataSource.getFavorites('playlist-1')).resolves.toEqual([
+            expect.objectContaining({ stream_id: 20203 }),
+        ]);
+        await expect(dataSource.getRecentItems('playlist-1')).resolves.toEqual([
+            expect.objectContaining({ stream_id: 20203 }),
+        ]);
+    });
+
+    it('restores PWA favorites and recent items from persisted content snapshots after reload', async () => {
+        await dataSource.getContent('playlist-1', credentials, 'vod');
+
+        await dataSource.addFavorite(20203, 'playlist-1');
+        await dataSource.addRecentItem(20203, 'playlist-1');
+
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            providers: [
+                PwaXtreamDataSource,
+                {
+                    provide: XtreamApiService,
+                    useValue: apiService,
+                },
+            ],
+        });
+        const freshDataSource = TestBed.inject(PwaXtreamDataSource);
+
+        await expect(
+            freshDataSource.getFavorites('playlist-1')
+        ).resolves.toEqual([
+            expect.objectContaining({
+                stream_id: 20203,
+                title: 'Movie',
+            }),
+        ]);
+        await expect(
+            freshDataSource.getRecentItems('playlist-1')
+        ).resolves.toEqual([
+            expect.objectContaining({
+                stream_id: 20203,
+                title: 'Movie',
+                viewed_at: expect.any(String),
+            }),
+        ]);
+    });
+});

--- a/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.spec.ts
+++ b/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.spec.ts
@@ -42,6 +42,20 @@ describe('PwaXtreamDataSource', () => {
         dataSource = TestBed.inject(PwaXtreamDataSource);
     });
 
+    function createFreshDataSource(): PwaXtreamDataSource {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            providers: [
+                PwaXtreamDataSource,
+                {
+                    provide: XtreamApiService,
+                    useValue: apiService,
+                },
+            ],
+        });
+        return TestBed.inject(PwaXtreamDataSource);
+    }
+
     it('finds VOD cached under vod when callers request movie content', async () => {
         await dataSource.getContent('playlist-1', credentials, 'vod');
 
@@ -73,17 +87,63 @@ describe('PwaXtreamDataSource', () => {
         await dataSource.addFavorite(20203, 'playlist-1');
         await dataSource.addRecentItem(20203, 'playlist-1');
 
-        TestBed.resetTestingModule();
-        TestBed.configureTestingModule({
-            providers: [
-                PwaXtreamDataSource,
-                {
-                    provide: XtreamApiService,
-                    useValue: apiService,
-                },
-            ],
-        });
-        const freshDataSource = TestBed.inject(PwaXtreamDataSource);
+        const freshDataSource = createFreshDataSource();
+
+        await expect(
+            freshDataSource.getFavorites('playlist-1')
+        ).resolves.toEqual([
+            expect.objectContaining({
+                stream_id: 20203,
+                title: 'Movie',
+            }),
+        ]);
+        await expect(
+            freshDataSource.getRecentItems('playlist-1')
+        ).resolves.toEqual([
+            expect.objectContaining({
+                stream_id: 20203,
+                title: 'Movie',
+                viewed_at: expect.any(String),
+            }),
+        ]);
+    });
+
+    it('keeps PWA favorites in restore state when only stored snapshots are available', async () => {
+        await dataSource.getContent('playlist-1', credentials, 'vod');
+
+        await dataSource.addFavorite(20203, 'playlist-1');
+        await dataSource.addRecentItem(20203, 'playlist-1');
+
+        const freshDataSource = createFreshDataSource();
+        const restoreState =
+            await freshDataSource.clearPlaylistContent('playlist-1');
+
+        expect(restoreState.favorites).toEqual([
+            expect.objectContaining({
+                contentType: 'movie',
+                xtreamId: 20203,
+            }),
+        ]);
+        expect(restoreState.recentlyViewed).toEqual([
+            expect.objectContaining({
+                contentType: 'movie',
+                xtreamId: 20203,
+                viewedAt: expect.any(String),
+            }),
+        ]);
+    });
+
+    it('restores PWA favorites and recent items with snapshots after content refresh', async () => {
+        await dataSource.getContent('playlist-1', credentials, 'vod');
+
+        await dataSource.addFavorite(20203, 'playlist-1');
+        await dataSource.addRecentItem(20203, 'playlist-1');
+
+        const restoreState =
+            await dataSource.clearPlaylistContent('playlist-1');
+        await dataSource.restoreUserData('playlist-1', restoreState);
+
+        const freshDataSource = createFreshDataSource();
 
         await expect(
             freshDataSource.getFavorites('playlist-1')

--- a/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.ts
+++ b/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.ts
@@ -35,8 +35,11 @@ const STORAGE_KEYS = {
 };
 
 interface XtreamCachedContentItem {
-    readonly added?: string;
+    readonly added?: string | number;
+    readonly added_at?: string | number;
+    readonly backdrop_url?: string | null;
     readonly category_id?: string | number;
+    readonly cover?: string;
     readonly id?: number;
     readonly name?: string;
     readonly poster_url?: string;
@@ -49,10 +52,23 @@ interface XtreamCachedContentItem {
     readonly viewed_at?: string;
 }
 
+interface StoredFavoriteItem {
+    readonly id: number;
+    readonly addedAt: string;
+    readonly backdropUrl?: string;
+    readonly content?: XtreamCachedContentItem;
+}
+
+type StoredFavoriteEntry = number | StoredFavoriteItem;
+
 interface StoredRecentItem {
     readonly id: number;
     readonly viewedAt: string;
+    readonly backdropUrl?: string;
+    readonly content?: XtreamCachedContentItem;
 }
+
+type PwaContentCacheType = 'live' | 'movie' | 'vod' | 'series';
 
 /**
  * PWA implementation of the Xtream data source.
@@ -67,6 +83,20 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
     // In-memory cache for the current session
     private categoryCache = new Map<string, XtreamCategory[]>();
     private contentCache = new Map<string, XtreamCachedContentItem[]>();
+
+    private getContentCacheLookupTypes(
+        contentType?: 'live' | 'movie' | 'series'
+    ): PwaContentCacheType[] {
+        if (contentType === 'movie') {
+            return ['movie', 'vod'];
+        }
+
+        if (contentType) {
+            return [contentType];
+        }
+
+        return ['live', 'movie', 'vod', 'series'];
+    }
 
     // =========================================================================
     // Playlist Operations (localStorage)
@@ -319,17 +349,27 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         const allFavorites = this.getFavoritesFromStorage();
         const playlistFavorites = allFavorites[playlistId] || [];
 
-        // Match favorites with cached content
         const results: XtreamCachedContentItem[] = [];
-        for (const type of ['live', 'movie', 'series']) {
-            const cacheKey = `${playlistId}-${type}-content`;
-            const content = this.contentCache.get(cacheKey) || [];
+        const seenIds = new Set<number>();
 
-            for (const item of content) {
-                const itemId = item.stream_id || item.series_id || item.id;
-                if (playlistFavorites.includes(itemId)) {
-                    results.push(item);
-                }
+        for (const favorite of playlistFavorites) {
+            const favoriteId = this.getStoredFavoriteId(favorite);
+            if (seenIds.has(favoriteId)) {
+                continue;
+            }
+
+            const content =
+                this.getStoredFavoriteContent(favorite) ??
+                this.findCachedContentById(playlistId, favoriteId);
+            if (content) {
+                results.push({
+                    ...content,
+                    added_at: this.getStoredFavoriteAddedAt(favorite),
+                    backdrop_url:
+                        this.getStoredFavoriteBackdropUrl(favorite) ??
+                        content.backdrop_url,
+                });
+                seenIds.add(favoriteId);
             }
         }
 
@@ -347,8 +387,35 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         if (!allFavorites[playlistId]) {
             allFavorites[playlistId] = [];
         }
-        if (!allFavorites[playlistId].includes(contentId)) {
-            allFavorites[playlistId].push(contentId);
+
+        const existingIndex = allFavorites[playlistId].findIndex(
+            (entry) => this.getStoredFavoriteId(entry) === contentId
+        );
+        const existing =
+            existingIndex >= 0 ? allFavorites[playlistId][existingIndex] : null;
+        const cachedContent = this.findCachedContentById(playlistId, contentId);
+        const nextFavorite: StoredFavoriteItem = {
+            id: contentId,
+            addedAt:
+                existing && typeof existing !== 'number'
+                    ? existing.addedAt
+                    : new Date().toISOString(),
+            backdropUrl:
+                _backdropUrl ??
+                (existing && typeof existing !== 'number'
+                    ? existing.backdropUrl
+                    : undefined),
+            content:
+                cachedContent ??
+                (existing && typeof existing !== 'number'
+                    ? existing.content
+                    : undefined),
+        };
+
+        if (existingIndex >= 0) {
+            allFavorites[playlistId][existingIndex] = nextFavorite;
+        } else {
+            allFavorites[playlistId].push(nextFavorite);
         }
         this.saveFavoritesToStorage(allFavorites);
     }
@@ -357,7 +424,7 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         const allFavorites = this.getFavoritesFromStorage();
         if (allFavorites[playlistId]) {
             allFavorites[playlistId] = allFavorites[playlistId].filter(
-                (id: number) => id !== contentId
+                (entry) => this.getStoredFavoriteId(entry) !== contentId
             );
         }
         this.saveFavoritesToStorage(allFavorites);
@@ -365,10 +432,12 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
 
     async isFavorite(contentId: number, playlistId: string): Promise<boolean> {
         const allFavorites = this.getFavoritesFromStorage();
-        return (allFavorites[playlistId] || []).includes(contentId);
+        return (allFavorites[playlistId] || []).some(
+            (entry) => this.getStoredFavoriteId(entry) === contentId
+        );
     }
 
-    private getFavoritesFromStorage(): Record<string, number[]> {
+    private getFavoritesFromStorage(): Record<string, StoredFavoriteEntry[]> {
         try {
             const data = localStorage.getItem(STORAGE_KEYS.FAVORITES);
             return data ? JSON.parse(data) : {};
@@ -377,8 +446,32 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         }
     }
 
-    private saveFavoritesToStorage(favorites: Record<string, number[]>): void {
+    private saveFavoritesToStorage(
+        favorites: Record<string, StoredFavoriteEntry[]>
+    ): void {
         localStorage.setItem(STORAGE_KEYS.FAVORITES, JSON.stringify(favorites));
+    }
+
+    private getStoredFavoriteId(favorite: StoredFavoriteEntry): number {
+        return typeof favorite === 'number' ? favorite : favorite.id;
+    }
+
+    private getStoredFavoriteContent(
+        favorite: StoredFavoriteEntry
+    ): XtreamCachedContentItem | undefined {
+        return typeof favorite === 'number' ? undefined : favorite.content;
+    }
+
+    private getStoredFavoriteAddedAt(favorite: StoredFavoriteEntry): string {
+        return typeof favorite === 'number'
+            ? new Date(0).toISOString()
+            : favorite.addedAt;
+    }
+
+    private getStoredFavoriteBackdropUrl(
+        favorite: StoredFavoriteEntry
+    ): string | undefined {
+        return typeof favorite === 'number' ? undefined : favorite.backdropUrl;
     }
 
     private clearFavoritesForPlaylist(playlistId: string): void {
@@ -526,21 +619,25 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         const allRecent = this.getRecentItemsFromStorage();
         const playlistRecent = allRecent[playlistId] || [];
 
-        // Match recent items with cached content
         const results: (XtreamCachedContentItem & { viewed_at: string })[] = [];
-        for (const type of ['live', 'movie', 'series']) {
-            const cacheKey = `${playlistId}-${type}-content`;
-            const content = this.contentCache.get(cacheKey) || [];
+        const seenIds = new Set<number>();
 
-            for (const item of content) {
-                const itemId = item.stream_id || item.series_id || item.id;
-                const recentEntry = playlistRecent.find((r) => r.id === itemId);
-                if (recentEntry) {
-                    results.push({
-                        ...item,
-                        viewed_at: recentEntry.viewedAt,
-                    });
-                }
+        for (const recentEntry of playlistRecent) {
+            if (seenIds.has(recentEntry.id)) {
+                continue;
+            }
+
+            const content =
+                recentEntry.content ??
+                this.findCachedContentById(playlistId, recentEntry.id);
+            if (content) {
+                results.push({
+                    ...content,
+                    viewed_at: recentEntry.viewedAt,
+                    backdrop_url:
+                        recentEntry.backdropUrl ?? content.backdrop_url,
+                });
+                seenIds.add(recentEntry.id);
             }
         }
 
@@ -573,6 +670,8 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         allRecent[playlistId].unshift({
             id: contentId,
             viewedAt: new Date().toISOString(),
+            backdropUrl: _backdropUrl,
+            content: this.findCachedContentById(playlistId, contentId),
         });
 
         // Keep only last 50 items
@@ -631,19 +730,13 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         playlistId: string,
         contentType?: 'live' | 'movie' | 'series'
     ): Promise<XtreamContentItem | null> {
-        const types = contentType
-            ? [contentType]
-            : (['live', 'movie', 'series'] as const);
-
-        for (const type of types) {
+        for (const type of this.getContentCacheLookupTypes(contentType)) {
             const cacheKey = `${playlistId}-${type}-content`;
             const content = this.contentCache.get(cacheKey) || [];
 
-            const found = content.find((item) => {
-                const itemXtreamId =
-                    item.stream_id || item.series_id || item.id;
-                return itemXtreamId === xtreamId;
-            });
+            const found = content.find(
+                (item) => this.resolveContentId(item) === xtreamId
+            );
 
             if (found) {
                 return found as XtreamContentItem;
@@ -658,29 +751,47 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         xtreamId: number,
         contentType?: 'live' | 'movie' | 'series'
     ): { contentType: 'live' | 'movie' | 'series'; xtreamId: number } | null {
-        const types = contentType
-            ? [contentType]
-            : (['live', 'movie', 'series'] as const);
-
-        for (const type of types) {
+        for (const type of this.getContentCacheLookupTypes(contentType)) {
             const cacheKey = `${playlistId}-${type}-content`;
             const content = this.contentCache.get(cacheKey) || [];
 
-            const found = content.find((item) => {
-                const itemXtreamId =
-                    item.stream_id || item.series_id || item.id;
-                return itemXtreamId === xtreamId;
-            });
+            const found = content.find(
+                (item) => this.resolveContentId(item) === xtreamId
+            );
 
             if (found) {
                 return {
-                    contentType: type,
+                    contentType: type === 'vod' ? 'movie' : type,
                     xtreamId,
                 };
             }
         }
 
         return null;
+    }
+
+    private findCachedContentById(
+        playlistId: string,
+        contentId: number
+    ): XtreamCachedContentItem | undefined {
+        for (const type of this.getContentCacheLookupTypes()) {
+            const cacheKey = `${playlistId}-${type}-content`;
+            const content = this.contentCache.get(cacheKey) || [];
+            const found = content.find(
+                (item) => this.resolveContentId(item) === contentId
+            );
+
+            if (found) {
+                return found;
+            }
+        }
+
+        return undefined;
+    }
+
+    private resolveContentId(item: XtreamCachedContentItem): number | null {
+        const id = Number(item.stream_id ?? item.series_id ?? item.id);
+        return Number.isFinite(id) && id > 0 ? id : null;
     }
 
     // =========================================================================
@@ -697,7 +808,12 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
             await this.getAllPlaybackPositions(playlistId);
 
         const typedFavorites = (favorites[playlistId] || [])
-            .map((xtreamId) => this.findContentIdentity(playlistId, xtreamId))
+            .map((favorite) =>
+                this.findContentIdentity(
+                    playlistId,
+                    this.getStoredFavoriteId(favorite)
+                )
+            )
             .filter(
                 (
                     value

--- a/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.ts
+++ b/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.ts
@@ -894,7 +894,8 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
                 return {
                     ...identity,
                     viewedAt: item.viewedAt,
-                    backdropUrl: item.backdropUrl ?? content?.backdrop_url,
+                    backdropUrl:
+                        item.backdropUrl ?? content?.backdrop_url ?? undefined,
                     content,
                 };
             })

--- a/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.ts
+++ b/libs/portal/xtream/data-access/src/lib/data-sources/pwa-xtream-data-source.ts
@@ -7,7 +7,6 @@ import {
     XtreamSerieItem,
     XtreamVodStream,
 } from '@iptvnator/shared/interfaces';
-import { createLogger } from '@iptvnator/portal/shared/util';
 import {
     CategoryType,
     StreamType,
@@ -47,6 +46,7 @@ interface XtreamCachedContentItem {
     readonly stream_display_name?: string;
     readonly stream_id?: number;
     readonly stream_icon?: string;
+    readonly stream_type?: string;
     readonly title?: string;
     readonly type?: string;
     readonly viewed_at?: string;
@@ -69,6 +69,15 @@ interface StoredRecentItem {
 }
 
 type PwaContentCacheType = 'live' | 'movie' | 'vod' | 'series';
+type PwaRestoreFavoriteItem = XtreamPendingRestoreState['favorites'][number] & {
+    readonly backdropUrl?: string;
+    readonly content?: XtreamCachedContentItem;
+};
+type PwaRestoreRecentItem =
+    XtreamPendingRestoreState['recentlyViewed'][number] & {
+        readonly backdropUrl?: string;
+        readonly content?: XtreamCachedContentItem;
+    };
 
 /**
  * PWA implementation of the Xtream data source.
@@ -78,7 +87,6 @@ type PwaContentCacheType = 'live' | 'movie' | 'vod' | 'series';
 @Injectable({ providedIn: 'root' })
 export class PwaXtreamDataSource implements IXtreamDataSource {
     private readonly apiService = inject(XtreamApiService);
-    private readonly logger = createLogger('PwaXtreamDataSource');
 
     // In-memory cache for the current session
     private categoryCache = new Map<string, XtreamCategory[]>();
@@ -227,7 +235,10 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         void categoryIds;
         void hidden;
         // Category visibility is not supported in PWA mode
-        this.logger.warn('Category visibility not supported in PWA mode');
+        console.warn(
+            '[PwaXtreamDataSource]',
+            'Category visibility not supported in PWA mode'
+        );
     }
 
     // =========================================================================
@@ -770,11 +781,26 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         return null;
     }
 
+    private findStoredContentIdentity(
+        content: XtreamCachedContentItem | undefined,
+        fallbackId: number
+    ): { contentType: 'live' | 'movie' | 'series'; xtreamId: number } | null {
+        if (!content) {
+            return null;
+        }
+
+        const xtreamId = this.resolveContentId(content) ?? fallbackId;
+        const contentType = this.resolveContentType(content);
+
+        return contentType ? { contentType, xtreamId } : null;
+    }
+
     private findCachedContentById(
         playlistId: string,
-        contentId: number
+        contentId: number,
+        contentType?: 'live' | 'movie' | 'series'
     ): XtreamCachedContentItem | undefined {
-        for (const type of this.getContentCacheLookupTypes()) {
+        for (const type of this.getContentCacheLookupTypes(contentType)) {
             const cacheKey = `${playlistId}-${type}-content`;
             const content = this.contentCache.get(cacheKey) || [];
             const found = content.find(
@@ -787,6 +813,25 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         }
 
         return undefined;
+    }
+
+    private resolveContentType(
+        item: XtreamCachedContentItem
+    ): 'live' | 'movie' | 'series' | null {
+        if (item.series_id != null) {
+            return 'series';
+        }
+
+        const type = String(item.type ?? item.stream_type ?? '').toLowerCase();
+        if (type === 'live' || type === 'series') {
+            return type;
+        }
+
+        if (type === 'movie' || type === 'vod') {
+            return 'movie';
+        }
+
+        return null;
     }
 
     private resolveContentId(item: XtreamCachedContentItem): number | null {
@@ -808,24 +853,39 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
             await this.getAllPlaybackPositions(playlistId);
 
         const typedFavorites = (favorites[playlistId] || [])
-            .map((favorite) =>
-                this.findContentIdentity(
-                    playlistId,
-                    this.getStoredFavoriteId(favorite)
-                )
-            )
-            .filter(
-                (
-                    value
-                ): value is {
-                    contentType: 'live' | 'movie' | 'series';
-                    xtreamId: number;
-                } => value !== null
-            );
+            .map<PwaRestoreFavoriteItem | null>((favorite) => {
+                const favoriteId = this.getStoredFavoriteId(favorite);
+                const content =
+                    this.getStoredFavoriteContent(favorite) ??
+                    this.findCachedContentById(playlistId, favoriteId);
+                const identity =
+                    this.findStoredContentIdentity(content, favoriteId) ??
+                    this.findContentIdentity(playlistId, favoriteId);
+
+                if (!identity) {
+                    return null;
+                }
+
+                return {
+                    ...identity,
+                    addedAt: this.getStoredFavoriteAddedAt(favorite),
+                    backdropUrl:
+                        this.getStoredFavoriteBackdropUrl(favorite) ??
+                        content?.backdrop_url ??
+                        undefined,
+                    content,
+                };
+            })
+            .filter((value): value is PwaRestoreFavoriteItem => value !== null);
 
         const typedRecentlyViewed = (recentItems[playlistId] || [])
-            .map((item) => {
-                const identity = this.findContentIdentity(playlistId, item.id);
+            .map<PwaRestoreRecentItem | null>((item) => {
+                const content =
+                    item.content ??
+                    this.findCachedContentById(playlistId, item.id);
+                const identity =
+                    this.findStoredContentIdentity(content, item.id) ??
+                    this.findContentIdentity(playlistId, item.id);
 
                 if (!identity) {
                     return null;
@@ -834,17 +894,11 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
                 return {
                     ...identity,
                     viewedAt: item.viewedAt,
+                    backdropUrl: item.backdropUrl ?? content?.backdrop_url,
+                    content,
                 };
             })
-            .filter(
-                (
-                    value
-                ): value is {
-                    contentType: 'live' | 'movie' | 'series';
-                    xtreamId: number;
-                    viewedAt: string;
-                } => value !== null
-            );
+            .filter((value): value is PwaRestoreRecentItem => value !== null);
 
         // Clear in-memory cache
         this.clearCacheForPlaylist(playlistId);
@@ -865,17 +919,46 @@ export class PwaXtreamDataSource implements IXtreamDataSource {
         void options;
         // Restore favorites
         const favorites = this.getFavoritesFromStorage();
-        favorites[playlistId] = restoreState.favorites.map(
-            (item) => item.xtreamId
-        );
+        favorites[playlistId] = restoreState.favorites.map((item) => {
+            const pwaItem = item as PwaRestoreFavoriteItem;
+            const content =
+                pwaItem.content ??
+                this.findCachedContentById(
+                    playlistId,
+                    item.xtreamId,
+                    item.contentType
+                );
+
+            return {
+                id: item.xtreamId,
+                addedAt: item.addedAt ?? new Date().toISOString(),
+                backdropUrl:
+                    pwaItem.backdropUrl ?? content?.backdrop_url ?? undefined,
+                content,
+            };
+        });
         this.saveFavoritesToStorage(favorites);
 
         // Restore recent items
         const recentItems = this.getRecentItemsFromStorage();
-        recentItems[playlistId] = restoreState.recentlyViewed.map((item) => ({
-            id: item.xtreamId,
-            viewedAt: item.viewedAt,
-        }));
+        recentItems[playlistId] = restoreState.recentlyViewed.map((item) => {
+            const pwaItem = item as PwaRestoreRecentItem;
+            const content =
+                pwaItem.content ??
+                this.findCachedContentById(
+                    playlistId,
+                    item.xtreamId,
+                    item.contentType
+                );
+
+            return {
+                id: item.xtreamId,
+                viewedAt: item.viewedAt,
+                backdropUrl:
+                    pwaItem.backdropUrl ?? content?.backdrop_url ?? undefined,
+                content,
+            };
+        });
         this.saveRecentItemsToStorage(recentItems);
 
         // Restore playback positions

--- a/libs/portal/xtream/data-access/src/lib/with-favorites.feature.spec.ts
+++ b/libs/portal/xtream/data-access/src/lib/with-favorites.feature.spec.ts
@@ -1,7 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { patchState, signalStore } from '@ngrx/signals';
-import { DatabaseService } from '@iptvnator/services';
-import { FavoritesService } from './services/favorites.service';
+import { patchState, signalStore, withState } from '@ngrx/signals';
+import { XTREAM_DATA_SOURCE } from './data-sources/xtream-data-source.interface';
 import { withFavorites } from './with-favorites.feature';
 
 jest.mock('@iptvnator/portal/shared/util', () => ({
@@ -14,38 +13,42 @@ jest.mock('@iptvnator/portal/shared/util', () => ({
 }));
 
 const TestFavoritesStore = signalStore(withFavorites());
+const TestLoadedContentFavoritesStore = signalStore(
+    withState({
+        vodStreams: [
+            {
+                stream_id: 20203,
+                title: 'Movie',
+                type: 'movie',
+            },
+        ],
+    }),
+    withFavorites()
+);
 
 describe('withFavorites', () => {
     let store: InstanceType<typeof TestFavoritesStore>;
-    let databaseService: {
+    let dataSource: {
+        addFavorite: jest.Mock;
         getContentByXtreamId: jest.Mock;
-    };
-    let favoritesService: {
-        addToFavorites: jest.Mock;
         isFavorite: jest.Mock;
-        removeFromFavorites: jest.Mock;
+        removeFavorite: jest.Mock;
     };
 
     beforeEach(() => {
-        databaseService = {
+        dataSource = {
+            addFavorite: jest.fn().mockResolvedValue(undefined),
             getContentByXtreamId: jest.fn(),
-        };
-        favoritesService = {
-            addToFavorites: jest.fn().mockResolvedValue(undefined),
             isFavorite: jest.fn().mockResolvedValue(false),
-            removeFromFavorites: jest.fn().mockResolvedValue(undefined),
+            removeFavorite: jest.fn().mockResolvedValue(undefined),
         };
 
         TestBed.configureTestingModule({
             providers: [
                 TestFavoritesStore,
                 {
-                    provide: DatabaseService,
-                    useValue: databaseService,
-                },
-                {
-                    provide: FavoritesService,
-                    useValue: favoritesService,
+                    provide: XTREAM_DATA_SOURCE,
+                    useValue: dataSource,
                 },
             ],
         });
@@ -54,7 +57,7 @@ describe('withFavorites', () => {
     });
 
     it('looks favorites up with the requested content type before adding one', async () => {
-        databaseService.getContentByXtreamId.mockResolvedValue({
+        dataSource.getContentByXtreamId.mockResolvedValue({
             id: 3941697,
             title: 'Krypton',
             type: 'series',
@@ -63,21 +66,122 @@ describe('withFavorites', () => {
 
         const result = await store.toggleFavorite(290, 'playlist-1', 'series');
 
-        expect(databaseService.getContentByXtreamId).toHaveBeenCalledWith(
+        expect(dataSource.getContentByXtreamId).toHaveBeenCalledWith(
             290,
             'playlist-1',
             'series'
         );
-        expect(favoritesService.addToFavorites).toHaveBeenCalledWith({
-            content_id: 3941697,
-            playlist_id: 'playlist-1',
-        });
+        expect(dataSource.addFavorite).toHaveBeenCalledWith(
+            3941697,
+            'playlist-1',
+            undefined
+        );
         expect(result).toBe(true);
         expect(store.isFavorite()).toBe(true);
     });
 
+    it('uses stream_id as the PWA favorite id when no database id exists', async () => {
+        dataSource.getContentByXtreamId.mockResolvedValue({
+            stream_id: 20203,
+            title: 'Movie',
+            type: 'movie',
+        });
+
+        const result = await store.toggleFavorite(20203, 'playlist-1', 'movie');
+
+        expect(dataSource.addFavorite).toHaveBeenCalledWith(
+            20203,
+            'playlist-1',
+            undefined
+        );
+        expect(result).toBe(true);
+    });
+
+    it('normalizes route string ids before looking up PWA content', async () => {
+        dataSource.getContentByXtreamId.mockImplementation(
+            async (xtreamId: number) =>
+                xtreamId === 20203
+                    ? {
+                          stream_id: 20203,
+                          title: 'Movie',
+                          type: 'movie',
+                      }
+                    : null
+        );
+
+        const result = await store.toggleFavorite(
+            '20203',
+            'playlist-1',
+            'movie'
+        );
+
+        expect(dataSource.getContentByXtreamId).toHaveBeenCalledWith(
+            20203,
+            'playlist-1',
+            'movie'
+        );
+        expect(dataSource.addFavorite).toHaveBeenCalledWith(
+            20203,
+            'playlist-1',
+            undefined
+        );
+        expect(result).toBe(true);
+    });
+
+    it('normalizes route string ids before checking PWA favorite status', async () => {
+        dataSource.getContentByXtreamId.mockImplementation(
+            async (xtreamId: number) =>
+                xtreamId === 20203
+                    ? {
+                          stream_id: 20203,
+                          title: 'Movie',
+                          type: 'movie',
+                      }
+                    : null
+        );
+        dataSource.isFavorite.mockResolvedValue(true);
+
+        await store.checkFavoriteStatus('20203', 'playlist-1', 'movie');
+
+        expect(dataSource.getContentByXtreamId).toHaveBeenCalledWith(
+            20203,
+            'playlist-1',
+            'movie'
+        );
+        expect(dataSource.isFavorite).toHaveBeenCalledWith(20203, 'playlist-1');
+        expect(store.isFavorite()).toBe(true);
+    });
+
+    it('falls back to loaded store content when the PWA source cache misses', async () => {
+        dataSource.getContentByXtreamId.mockResolvedValue(null);
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            providers: [
+                TestLoadedContentFavoritesStore,
+                {
+                    provide: XTREAM_DATA_SOURCE,
+                    useValue: dataSource,
+                },
+            ],
+        });
+        const loadedStore = TestBed.inject(TestLoadedContentFavoritesStore);
+
+        const result = await loadedStore.toggleFavorite(
+            20203,
+            'playlist-1',
+            'movie'
+        );
+
+        expect(dataSource.addFavorite).toHaveBeenCalledWith(
+            20203,
+            'playlist-1',
+            undefined
+        );
+        expect(result).toBe(true);
+    });
+
     it('looks favorites up with the requested content type before removing one', async () => {
-        databaseService.getContentByXtreamId.mockResolvedValue({
+        dataSource.getContentByXtreamId.mockResolvedValue({
             id: 3867578,
             title: 'SE: V Film Premiere FHD',
             type: 'live',
@@ -87,12 +191,12 @@ describe('withFavorites', () => {
 
         const result = await store.toggleFavorite(290, 'playlist-1', 'live');
 
-        expect(databaseService.getContentByXtreamId).toHaveBeenCalledWith(
+        expect(dataSource.getContentByXtreamId).toHaveBeenCalledWith(
             290,
             'playlist-1',
             'live'
         );
-        expect(favoritesService.removeFromFavorites).toHaveBeenCalledWith(
+        expect(dataSource.removeFavorite).toHaveBeenCalledWith(
             3867578,
             'playlist-1'
         );
@@ -101,22 +205,22 @@ describe('withFavorites', () => {
     });
 
     it('checks favorite state against the matching content type', async () => {
-        databaseService.getContentByXtreamId.mockResolvedValue({
+        dataSource.getContentByXtreamId.mockResolvedValue({
             id: 3829429,
             title: 'Dragon Ball Heroes',
             type: 'series',
             xtream_id: 31,
         });
-        favoritesService.isFavorite.mockResolvedValue(true);
+        dataSource.isFavorite.mockResolvedValue(true);
 
         await store.checkFavoriteStatus(31, 'playlist-1', 'series');
 
-        expect(databaseService.getContentByXtreamId).toHaveBeenCalledWith(
+        expect(dataSource.getContentByXtreamId).toHaveBeenCalledWith(
             31,
             'playlist-1',
             'series'
         );
-        expect(favoritesService.isFavorite).toHaveBeenCalledWith(
+        expect(dataSource.isFavorite).toHaveBeenCalledWith(
             3829429,
             'playlist-1'
         );

--- a/libs/portal/xtream/data-access/src/lib/with-favorites.feature.ts
+++ b/libs/portal/xtream/data-access/src/lib/with-favorites.feature.ts
@@ -5,9 +5,43 @@ import {
     withMethods,
     withState,
 } from '@ngrx/signals';
-import { DatabaseService } from '@iptvnator/services';
-import { FavoritesService } from './services/favorites.service';
 import { createLogger } from '@iptvnator/portal/shared/util';
+import { XTREAM_DATA_SOURCE } from './data-sources/xtream-data-source.interface';
+
+function resolveContentId(content: Record<string, unknown>): number | null {
+    const rawId =
+        content['id'] ??
+        content['stream_id'] ??
+        content['series_id'] ??
+        content['xtream_id'];
+    const id = Number(rawId);
+    return Number.isFinite(id) && id > 0 ? id : null;
+}
+
+function findLoadedContent(
+    store: unknown,
+    xtreamId: number,
+    contentType: 'live' | 'movie' | 'series'
+): Record<string, unknown> | null {
+    const storeWithContent = store as {
+        liveStreams?: () => Record<string, unknown>[];
+        vodStreams?: () => Record<string, unknown>[];
+        serialStreams?: () => Record<string, unknown>[];
+    };
+    const items =
+        contentType === 'live'
+            ? storeWithContent.liveStreams?.()
+            : contentType === 'movie'
+              ? storeWithContent.vodStreams?.()
+              : storeWithContent.serialStreams?.();
+
+    return (
+        items?.find((item) => {
+            const itemId = resolveContentId(item);
+            return itemId === xtreamId;
+        }) ?? null
+    );
+}
 
 export const withFavorites = function () {
     const logger = createLogger('withFavorites');
@@ -15,85 +49,104 @@ export const withFavorites = function () {
         withState({
             isFavorite: false,
         }),
-        withMethods(
-            (
-                store,
-                dbService = inject(DatabaseService),
-                favoritesService = inject(FavoritesService)
-            ) => ({
-                async toggleFavorite(
-                    xtreamId: number,
-                    playlistId: string,
-                    contentType: 'live' | 'movie' | 'series',
-                    backdropUrl?: string
+        withMethods((store, dataSource = inject(XTREAM_DATA_SOURCE)) => ({
+            async toggleFavorite(
+                xtreamId: number | string,
+                playlistId: string,
+                contentType: 'live' | 'movie' | 'series',
+                backdropUrl?: string
+            ) {
+                const numericXtreamId = Number(xtreamId);
+                if (
+                    !Number.isFinite(numericXtreamId) ||
+                    numericXtreamId <= 0 ||
+                    !playlistId
                 ) {
-                    if (!xtreamId || !playlistId) {
-                        return false;
-                    }
+                    return false;
+                }
 
-                    const content = await dbService.getContentByXtreamId(
-                        xtreamId,
+                const content =
+                    (await dataSource.getContentByXtreamId(
+                        numericXtreamId,
                         playlistId,
                         contentType
+                    )) ??
+                    findLoadedContent(store, numericXtreamId, contentType);
+                if (!content) {
+                    logger.error(
+                        'Content not found for xtream ID',
+                        numericXtreamId
                     );
-                    if (!content) {
-                        logger.error(
-                            'Content not found for xtream ID',
-                            xtreamId
-                        );
-                        return false;
-                    }
+                    return false;
+                }
+                const contentId = resolveContentId(
+                    content as unknown as Record<string, unknown>
+                );
+                if (!contentId) {
+                    logger.error('Content has no favorite id', content);
+                    return false;
+                }
 
-                    const currentStatus = store.isFavorite();
+                const currentStatus = store.isFavorite();
 
-                    if (currentStatus) {
-                        // Remove from favorites
-                        await favoritesService.removeFromFavorites(
-                            content.id,
-                            playlistId
-                        );
-                        patchState(store, { isFavorite: false });
-                        return false;
-                    } else {
-                        // Add to favorites
-                        await favoritesService.addToFavorites({
-                            content_id: content.id,
-                            playlist_id: playlistId,
-                            backdrop_url: backdropUrl,
-                        });
-                        patchState(store, { isFavorite: true });
-                        return true;
-                    }
-                },
+                if (currentStatus) {
+                    // Remove from favorites
+                    await dataSource.removeFavorite(contentId, playlistId);
+                    patchState(store, { isFavorite: false });
+                    return false;
+                } else {
+                    // Add to favorites
+                    await dataSource.addFavorite(
+                        contentId,
+                        playlistId,
+                        backdropUrl
+                    );
+                    patchState(store, { isFavorite: true });
+                    return true;
+                }
+            },
 
-                async checkFavoriteStatus(
-                    xtreamId: number,
-                    playlistId: string,
-                    contentType: 'live' | 'movie' | 'series'
+            async checkFavoriteStatus(
+                xtreamId: number | string,
+                playlistId: string,
+                contentType: 'live' | 'movie' | 'series'
+            ) {
+                const numericXtreamId = Number(xtreamId);
+                if (
+                    !Number.isFinite(numericXtreamId) ||
+                    numericXtreamId <= 0 ||
+                    !playlistId
                 ) {
-                    if (!xtreamId || !playlistId) {
-                        patchState(store, { isFavorite: false });
-                        return;
-                    }
+                    patchState(store, { isFavorite: false });
+                    return;
+                }
 
-                    const content = await dbService.getContentByXtreamId(
-                        xtreamId,
+                const content =
+                    (await dataSource.getContentByXtreamId(
+                        numericXtreamId,
                         playlistId,
                         contentType
-                    );
-                    if (!content) {
-                        patchState(store, { isFavorite: false });
-                        return;
-                    }
+                    )) ??
+                    findLoadedContent(store, numericXtreamId, contentType);
+                if (!content) {
+                    patchState(store, { isFavorite: false });
+                    return;
+                }
+                const contentId = resolveContentId(
+                    content as unknown as Record<string, unknown>
+                );
+                if (!contentId) {
+                    patchState(store, { isFavorite: false });
+                    return;
+                }
 
-                    const isFavorite = await favoritesService.isFavorite(
-                        content.id,
-                        playlistId
-                    );
+                const isFavorite = await dataSource.isFavorite(
+                    contentId,
+                    playlistId
+                );
 
-                    patchState(store, { isFavorite });
-                },
-            })
-        )
+                patchState(store, { isFavorite });
+            },
+        }))
     );
 };

--- a/libs/portal/xtream/data-access/src/lib/with-recent-items.feature.spec.ts
+++ b/libs/portal/xtream/data-access/src/lib/with-recent-items.feature.spec.ts
@@ -1,8 +1,9 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { signalStore } from '@ngrx/signals';
+import { signalStore, withState } from '@ngrx/signals';
 import { of } from 'rxjs';
 import { DatabaseService, PlaylistsService } from '@iptvnator/services';
+import { XTREAM_DATA_SOURCE } from './data-sources/xtream-data-source.interface';
 import { withRecentItems } from './with-recent-items';
 
 jest.mock('@iptvnator/portal/shared/util', () => ({
@@ -15,11 +16,30 @@ jest.mock('@iptvnator/portal/shared/util', () => ({
 }));
 
 const TestRecentItemsStore = signalStore(withRecentItems());
+const TestLoadedContentRecentItemsStore = signalStore(
+    withState({
+        vodStreams: [
+            {
+                stream_id: 20203,
+                title: 'Movie',
+                type: 'movie',
+                category_id: 206,
+            },
+        ],
+    }),
+    withRecentItems()
+);
 
 describe('withRecentItems', () => {
     let store: InstanceType<typeof TestRecentItemsStore>;
-    let databaseService: {
+    let dataSource: {
         addRecentItem: jest.Mock;
+        clearRecentItems: jest.Mock;
+        getContentByXtreamId: jest.Mock;
+        getRecentItems: jest.Mock;
+        removeRecentItem: jest.Mock;
+    };
+    let databaseService: {
         getContentByXtreamId: jest.Mock;
         getRecentItems: jest.Mock;
         setContentBackdropIfMissing: jest.Mock;
@@ -31,8 +51,9 @@ describe('withRecentItems', () => {
             configurable: true,
         });
 
-        databaseService = {
+        dataSource = {
             addRecentItem: jest.fn().mockResolvedValue(undefined),
+            clearRecentItems: jest.fn().mockResolvedValue(undefined),
             getContentByXtreamId: jest.fn(),
             getRecentItems: jest.fn().mockResolvedValue([
                 {
@@ -46,6 +67,12 @@ describe('withRecentItems', () => {
                     category_id: 17,
                 },
             ]),
+            removeRecentItem: jest.fn().mockResolvedValue(undefined),
+        };
+
+        databaseService = {
+            getContentByXtreamId: jest.fn(),
+            getRecentItems: jest.fn().mockResolvedValue([]),
             setContentBackdropIfMissing: jest.fn().mockResolvedValue(undefined),
         };
 
@@ -53,15 +80,19 @@ describe('withRecentItems', () => {
             providers: [
                 TestRecentItemsStore,
                 {
+                    provide: XTREAM_DATA_SOURCE,
+                    useValue: dataSource,
+                },
+                {
                     provide: DatabaseService,
                     useValue: databaseService,
                 },
                 {
                     provide: PlaylistsService,
                     useValue: {
-                        clearPlaylistRecentlyViewed: jest.fn().mockReturnValue(
-                            of(undefined)
-                        ),
+                        clearPlaylistRecentlyViewed: jest
+                            .fn()
+                            .mockReturnValue(of(undefined)),
                         getAllPlaylists: jest.fn().mockReturnValue(of([])),
                     },
                 },
@@ -72,7 +103,7 @@ describe('withRecentItems', () => {
     });
 
     it('looks recent items up with the requested content type before saving one', async () => {
-        databaseService.getContentByXtreamId.mockResolvedValue({
+        dataSource.getContentByXtreamId.mockResolvedValue({
             id: 3941697,
             title: 'Krypton',
             type: 'series',
@@ -86,12 +117,12 @@ describe('withRecentItems', () => {
         });
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        expect(databaseService.getContentByXtreamId).toHaveBeenCalledWith(
+        expect(dataSource.getContentByXtreamId).toHaveBeenCalledWith(
             290,
             'playlist-1',
             'series'
         );
-        expect(databaseService.addRecentItem).toHaveBeenCalledWith(
+        expect(dataSource.addRecentItem).toHaveBeenCalledWith(
             3941697,
             'playlist-1',
             undefined
@@ -107,8 +138,71 @@ describe('withRecentItems', () => {
         ]);
     });
 
+    it('uses stream_id as the PWA recent id when no database id exists', async () => {
+        dataSource.getContentByXtreamId.mockResolvedValue({
+            stream_id: 20203,
+            title: 'Movie',
+            type: 'movie',
+            category_id: 206,
+        });
+
+        store.addRecentItem({
+            xtreamId: 20203,
+            contentType: 'movie',
+            playlist: signal({ id: 'playlist-1' }),
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(dataSource.addRecentItem).toHaveBeenCalledWith(
+            20203,
+            'playlist-1',
+            undefined
+        );
+    });
+
+    it('falls back to loaded store content when the PWA source cache misses', async () => {
+        dataSource.getContentByXtreamId.mockResolvedValue(null);
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            providers: [
+                TestLoadedContentRecentItemsStore,
+                {
+                    provide: XTREAM_DATA_SOURCE,
+                    useValue: dataSource,
+                },
+                {
+                    provide: DatabaseService,
+                    useValue: databaseService,
+                },
+                {
+                    provide: PlaylistsService,
+                    useValue: {
+                        clearPlaylistRecentlyViewed: jest
+                            .fn()
+                            .mockReturnValue(of(undefined)),
+                        getAllPlaylists: jest.fn().mockReturnValue(of([])),
+                    },
+                },
+            ],
+        });
+        const loadedStore = TestBed.inject(TestLoadedContentRecentItemsStore);
+
+        loadedStore.addRecentItem({
+            xtreamId: 20203,
+            contentType: 'movie',
+            playlist: signal({ id: 'playlist-1' }),
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(dataSource.addRecentItem).toHaveBeenCalledWith(
+            20203,
+            'playlist-1',
+            undefined
+        );
+    });
+
     it('forwards backdrop urls on recent-item saves', async () => {
-        databaseService.getContentByXtreamId.mockResolvedValue({
+        dataSource.getContentByXtreamId.mockResolvedValue({
             id: 3941697,
             title: 'Krypton',
             type: 'series',
@@ -123,7 +217,7 @@ describe('withRecentItems', () => {
         });
         await new Promise((resolve) => setTimeout(resolve, 0));
 
-        expect(databaseService.addRecentItem).toHaveBeenCalledWith(
+        expect(dataSource.addRecentItem).toHaveBeenCalledWith(
             3941697,
             'playlist-1',
             'https://example.com/krypton-backdrop.png'
@@ -156,6 +250,6 @@ describe('withRecentItems', () => {
             3941697,
             'https://example.com/krypton-backdrop.png'
         );
-        expect(databaseService.addRecentItem).not.toHaveBeenCalled();
+        expect(dataSource.addRecentItem).not.toHaveBeenCalled();
     });
 });

--- a/libs/portal/xtream/data-access/src/lib/with-recent-items.ts
+++ b/libs/portal/xtream/data-access/src/lib/with-recent-items.ts
@@ -14,35 +14,80 @@ import {
     PortalRecentItem,
 } from '@iptvnator/shared/interfaces';
 import { createLogger } from '@iptvnator/portal/shared/util';
+import { XTREAM_DATA_SOURCE } from './data-sources/xtream-data-source.interface';
 
 export interface RecentlyViewedItem extends PortalRecentItem {
     /** @deprecated Redundant — always equals `id`. Retained for compat. */
     content_id: number | string;
 }
 
+function resolveContentId(item: Record<string, unknown>): number | null {
+    const rawId =
+        item['id'] ??
+        item['stream_id'] ??
+        item['series_id'] ??
+        item['xtream_id'];
+    const id = Number(rawId);
+    return Number.isFinite(id) && id > 0 ? id : null;
+}
+
+function findLoadedContent(
+    store: unknown,
+    xtreamId: number,
+    contentType: 'live' | 'movie' | 'series'
+): Record<string, unknown> | null {
+    const storeWithContent = store as {
+        liveStreams?: () => Record<string, unknown>[];
+        vodStreams?: () => Record<string, unknown>[];
+        serialStreams?: () => Record<string, unknown>[];
+    };
+    const items =
+        contentType === 'live'
+            ? storeWithContent.liveStreams?.()
+            : contentType === 'movie'
+              ? storeWithContent.vodStreams?.()
+              : storeWithContent.serialStreams?.();
+
+    return (
+        items?.find((item) => {
+            const itemId = resolveContentId(item);
+            return itemId === xtreamId;
+        }) ?? null
+    );
+}
+
 function mapDbRecentItem(
     item: {
-        id: number;
-        title: string;
+        id?: number | string;
+        title?: string;
+        name?: string;
         type: string;
-        poster_url: string;
+        poster_url?: string;
+        stream_icon?: string;
+        cover?: string;
         backdrop_url?: string | null;
         viewed_at?: string;
-        xtream_id: number;
-        category_id: number;
+        xtream_id?: number | string;
+        stream_id?: number | string;
+        series_id?: number | string;
+        category_id: number | string;
     },
     playlistId: string
 ): RecentlyViewedItem {
+    const id = resolveContentId(item) ?? 0;
+
     return {
-        id: item.id,
-        title: item.title,
+        id,
+        title: item.title ?? item.name ?? 'Unknown',
         type: item.type as 'live' | 'movie' | 'series',
-        poster_url: item.poster_url,
+        poster_url: item.poster_url ?? item.stream_icon ?? item.cover ?? '',
         backdrop_url: item.backdrop_url ?? undefined,
-        content_id: item.id,
+        content_id: id,
         playlist_id: playlistId,
         viewed_at: item.viewed_at || '',
-        xtream_id: item.xtream_id,
+        xtream_id: Number(
+            item.xtream_id ?? item.stream_id ?? item.series_id ?? id
+        ),
         category_id: item.category_id,
     };
 }
@@ -53,11 +98,11 @@ export const withRecentItems = function () {
         withState({
             recentItems: [],
         }),
-        withMethods((store, dbService = inject(DatabaseService)) => ({
+        withMethods((store, dataSource = inject(XTREAM_DATA_SOURCE)) => ({
             loadRecentItems: rxMethod<{ id: string }>(
                 pipe(
                     switchMap(async (playlist) => {
-                        const items = await dbService.getRecentItems(
+                        const items = await dataSource.getRecentItems(
                             playlist.id
                         );
                         return items.map((item) =>
@@ -73,6 +118,7 @@ export const withRecentItems = function () {
         withMethods(
             (
                 store,
+                dataSource = inject(XTREAM_DATA_SOURCE),
                 dbService = inject(DatabaseService),
                 playlistsService = inject(PlaylistsService)
             ) => ({
@@ -90,30 +136,47 @@ export const withRecentItems = function () {
                                 playlist,
                                 backdropUrl,
                             }) => {
-                            const playlistId = playlist().id;
-                            const content = await dbService.getContentByXtreamId(
-                                xtreamId,
-                                playlistId,
-                                contentType
-                            );
-                            if (content) {
-                                await dbService.addRecentItem(
-                                    content.id,
-                                    playlistId,
-                                    backdropUrl
-                                );
+                                const playlistId = playlist().id;
+                                const content =
+                                    (await dataSource.getContentByXtreamId(
+                                        xtreamId,
+                                        playlistId,
+                                        contentType
+                                    )) ??
+                                    findLoadedContent(
+                                        store,
+                                        xtreamId,
+                                        contentType
+                                    );
+                                const contentId = content
+                                    ? resolveContentId(
+                                          content as unknown as Record<
+                                              string,
+                                              unknown
+                                          >
+                                      )
+                                    : null;
+                                if (contentId) {
+                                    await dataSource.addRecentItem(
+                                        contentId,
+                                        playlistId,
+                                        backdropUrl
+                                    );
 
-                                // Reload after add/update so re-watched items
-                                // immediately move to the top in recently-viewed.
-                                const items =
-                                    await dbService.getRecentItems(playlistId);
-                                patchState(store, {
-                                    recentItems: items.map((item) =>
-                                        mapDbRecentItem(item, playlistId)
-                                    ),
-                                });
+                                    // Reload after add/update so re-watched items
+                                    // immediately move to the top in recently-viewed.
+                                    const items =
+                                        await dataSource.getRecentItems(
+                                            playlistId
+                                        );
+                                    patchState(store, {
+                                        recentItems: items.map((item) =>
+                                            mapDbRecentItem(item, playlistId)
+                                        ),
+                                    });
+                                }
                             }
-                        })
+                        )
                     )
                 ),
                 async backfillContentBackdrop({
@@ -154,9 +217,7 @@ export const withRecentItems = function () {
                 clearRecentItems: rxMethod<{ id: string }>(
                     pipe(
                         switchMap(async (playlist) => {
-                            await dbService.clearPlaylistRecentItems(
-                                playlist.id
-                            );
+                            await dataSource.clearRecentItems(playlist.id);
                             patchState(store, { recentItems: [] });
                         })
                     )
@@ -167,13 +228,13 @@ export const withRecentItems = function () {
                 }>(
                     pipe(
                         switchMap(async ({ itemId, playlistId }) => {
-                            await dbService.removeRecentItem(
+                            await dataSource.removeRecentItem(
                                 itemId,
                                 playlistId
                             );
                             // Reload recent items to update UI
                             const items =
-                                await dbService.getRecentItems(playlistId);
+                                await dataSource.getRecentItems(playlistId);
                             patchState(store, {
                                 recentItems: items.map((item) =>
                                     mapDbRecentItem(item, playlistId)
@@ -189,14 +250,16 @@ export const withRecentItems = function () {
                         const playlists = (await firstValueFrom(
                             playlistsService.getAllPlaylists()
                         )) as Playlist[];
-                        const playlistBackedItems =
-                            buildPlaylistRecentItems(playlists, {
+                        const playlistBackedItems = buildPlaylistRecentItems(
+                            playlists,
+                            {
                                 stalker: 'Stalker Portal',
                                 m3u: 'M3U',
-                            }).map((item) => ({
-                                ...item,
-                                content_id: item.id,
-                            })) as RecentlyViewedItem[];
+                            }
+                        ).map((item) => ({
+                            ...item,
+                            content_id: item.id,
+                        })) as RecentlyViewedItem[];
 
                         const normalizedXtream: RecentlyViewedItem[] = (
                             xtreamItems || []

--- a/libs/portal/xtream/feature/src/lib/xtream-catalog-facade.service.spec.ts
+++ b/libs/portal/xtream/feature/src/lib/xtream-catalog-facade.service.spec.ts
@@ -1,8 +1,6 @@
 import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import {
-    PortalCatalogSortMode,
-} from '@iptvnator/portal/shared/util';
+import { PortalCatalogSortMode } from '@iptvnator/portal/shared/util';
 import {
     XtreamPlaylistData,
     XtreamStore,
@@ -178,6 +176,43 @@ describe('XtreamCatalogFacadeService', () => {
         expect(xtreamStore.loadAllPositions).toHaveBeenLastCalledWith(
             'playlist-2'
         );
+    });
+
+    it('routes raw Xtream VOD stream items by stream_id inside a category', () => {
+        selectedCategoryId.set(201);
+
+        expect(
+            service.selectItem({
+                stream_id: 650020,
+                category_id: '201',
+                title: 'Movie',
+            })
+        ).toEqual(['650020']);
+    });
+
+    it('routes raw Xtream VOD stream items from the all-items view with their category', () => {
+        selectedCategoryId.set(null);
+
+        expect(
+            service.selectItem({
+                stream_id: 650020,
+                category_id: '201',
+                title: 'Movie',
+            })
+        ).toEqual(['201', '650020']);
+    });
+
+    it('routes raw Xtream series items by series_id', () => {
+        contentType.set('series');
+        selectedCategoryId.set(301);
+
+        expect(
+            service.selectItem({
+                series_id: 103,
+                category_id: '301',
+                title: 'Series',
+            })
+        ).toEqual(['103']);
     });
 
     it('persists sort mode changes and delegates them to the store', () => {

--- a/libs/portal/xtream/feature/src/lib/xtream-catalog-facade.service.ts
+++ b/libs/portal/xtream/feature/src/lib/xtream-catalog-facade.service.ts
@@ -98,14 +98,14 @@ export class XtreamCatalogFacadeService implements PortalCatalogFacade<
     }
 
     selectItem(item: Record<string, unknown>): string[] | null {
-        const xtreamId = item['xtream_id'];
-        if (xtreamId === undefined || xtreamId === null) {
+        const itemId = this.getCatalogItemId(item);
+        if (itemId === undefined || itemId === null) {
             return null;
         }
 
         const selectedCategoryId = this.xtreamStore.selectedCategoryId();
         if (selectedCategoryId !== null && selectedCategoryId !== undefined) {
-            return [String(xtreamId)];
+            return [String(itemId)];
         }
 
         const categoryId = item['category_id'];
@@ -113,14 +113,12 @@ export class XtreamCatalogFacadeService implements PortalCatalogFacade<
             return null;
         }
 
-        return [String(categoryId), String(xtreamId)];
+        return [String(categoryId), String(itemId)];
     }
 
     getItemProgress(item: Record<string, unknown>): PortalCatalogItemProgress {
         const isSeries = this.contentType() === 'series';
-        const itemId = Number(
-            item['xtream_id'] ?? item['series_id'] ?? item['stream_id']
-        );
+        const itemId = Number(this.getCatalogItemId(item));
         if (Number.isNaN(itemId)) {
             return {};
         }
@@ -135,6 +133,17 @@ export class XtreamCatalogFacadeService implements PortalCatalogFacade<
             progress: this.xtreamStore.getProgressPercent(itemId, 'vod'),
             isWatched: this.xtreamStore.isWatched(itemId, 'vod'),
         };
+    }
+
+    private getCatalogItemId(
+        item: Record<string, unknown>
+    ): string | number | null | undefined {
+        const itemId =
+            item['xtream_id'] ?? item['series_id'] ?? item['stream_id'];
+
+        return typeof itemId === 'string' || typeof itemId === 'number'
+            ? itemId
+            : null;
     }
 }
 

--- a/libs/services/src/lib/database-electron.service.spec.ts
+++ b/libs/services/src/lib/database-electron.service.spec.ts
@@ -1,0 +1,48 @@
+import { DatabaseService } from './database-electron.service';
+
+describe('DatabaseService', () => {
+    let service: DatabaseService;
+    let originalElectron: typeof window.electron;
+
+    const setElectron = (electron: typeof window.electron | undefined) => {
+        (window as unknown as { electron?: typeof window.electron }).electron =
+            electron;
+    };
+
+    beforeEach(() => {
+        service = new DatabaseService();
+        originalElectron = window.electron;
+    });
+
+    afterEach(() => {
+        setElectron(originalElectron);
+        jest.restoreAllMocks();
+    });
+
+    it('skips Electron app-state reads when the preload API is unavailable', async () => {
+        setElectron(undefined);
+
+        await expect(service.getAppState('key')).resolves.toBeNull();
+    });
+
+    it('skips Electron app-state writes when the preload API is unavailable', async () => {
+        setElectron(undefined);
+
+        await expect(service.setAppState('key', 'value')).resolves.toBe(false);
+    });
+
+    it('delegates Electron app-state calls when the preload API is available', async () => {
+        setElectron({
+            dbGetAppState: jest.fn().mockResolvedValue('stored'),
+            dbSetAppState: jest.fn().mockResolvedValue(undefined),
+        } as unknown as typeof window.electron);
+
+        await expect(service.getAppState('key')).resolves.toBe('stored');
+        await expect(service.setAppState('key', 'value')).resolves.toBe(true);
+        expect(window.electron.dbGetAppState).toHaveBeenCalledWith('key');
+        expect(window.electron.dbSetAppState).toHaveBeenCalledWith(
+            'key',
+            'value'
+        );
+    });
+});

--- a/libs/services/src/lib/database-electron.service.ts
+++ b/libs/services/src/lib/database-electron.service.ts
@@ -506,6 +506,10 @@ export class DatabaseService {
     }
 
     async getAppState(key: string): Promise<string | null> {
+        if (typeof window.electron?.dbGetAppState !== 'function') {
+            return null;
+        }
+
         try {
             return await window.electron.dbGetAppState(key);
         } catch (error) {
@@ -515,6 +519,10 @@ export class DatabaseService {
     }
 
     async setAppState(key: string, value: string): Promise<boolean> {
+        if (typeof window.electron?.dbSetAppState !== 'function') {
+            return false;
+        }
+
         try {
             await window.electron.dbSetAppState(key, value);
             return true;

--- a/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.spec.ts
+++ b/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.spec.ts
@@ -2,7 +2,11 @@ import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import { selectAllPlaylistsMeta, selectPlaylistsLoadingFlag } from '@iptvnator/m3u-state';
+import {
+    selectAllPlaylistsMeta,
+    selectPlaylistsLoadingFlag,
+} from '@iptvnator/m3u-state';
+import { XTREAM_DATA_SOURCE } from '@iptvnator/portal/xtream/data-access';
 import { of } from 'rxjs';
 import { DatabaseService, PlaylistsService } from '@iptvnator/services';
 import { Playlist, PlaylistMeta } from '@iptvnator/shared/interfaces';
@@ -68,6 +72,12 @@ describe('DashboardDataService', () => {
         removeFromFavorites: jest.fn().mockResolvedValue(undefined),
         removeRecentItem: jest.fn().mockResolvedValue(undefined),
     };
+    const xtreamDataSourceMock = {
+        getFavorites: jest.fn().mockResolvedValue([]),
+        getRecentItems: jest.fn().mockResolvedValue([]),
+        removeFavorite: jest.fn().mockResolvedValue(undefined),
+        removeRecentItem: jest.fn().mockResolvedValue(undefined),
+    };
     const playlistMock: Playlist = {
         _id: 'm3u-1',
         title: 'M3U Playlist',
@@ -114,7 +124,11 @@ describe('DashboardDataService', () => {
 
     beforeEach(() => {
         Object.defineProperty(window, 'electron', {
-            value: {} as Window['electron'],
+            value: {
+                dbGetAllGlobalFavorites: jest.fn(),
+                dbGetGlobalRecentlyAdded: jest.fn(),
+                dbGetRecentlyViewed: jest.fn(),
+            } as unknown as Window['electron'],
             configurable: true,
         });
         playlistsLoadedSignal.set(true);
@@ -138,6 +152,14 @@ describe('DashboardDataService', () => {
         dbServiceMock.getGlobalRecentlyViewed.mockResolvedValue([]);
         dbServiceMock.removeFromFavorites.mockClear();
         dbServiceMock.removeRecentItem.mockClear();
+        xtreamDataSourceMock.getFavorites.mockClear();
+        xtreamDataSourceMock.getFavorites.mockResolvedValue([]);
+        xtreamDataSourceMock.getRecentItems.mockClear();
+        xtreamDataSourceMock.getRecentItems.mockResolvedValue([]);
+        xtreamDataSourceMock.removeFavorite.mockClear();
+        xtreamDataSourceMock.removeFavorite.mockResolvedValue(undefined);
+        xtreamDataSourceMock.removeRecentItem.mockClear();
+        xtreamDataSourceMock.removeRecentItem.mockResolvedValue(undefined);
         storeMock.dispatch.mockClear();
 
         TestBed.configureTestingModule({
@@ -148,6 +170,10 @@ describe('DashboardDataService', () => {
                 {
                     provide: PlaylistsService,
                     useValue: playlistsServiceMock,
+                },
+                {
+                    provide: XTREAM_DATA_SOURCE,
+                    useValue: xtreamDataSourceMock,
                 },
                 {
                     provide: TranslateService,
@@ -324,6 +350,48 @@ describe('DashboardDataService', () => {
         ).toHaveLength(1);
     });
 
+    it('includes PWA Xtream favorites from the data source when Electron DB APIs are unavailable', async () => {
+        Object.defineProperty(window, 'electron', {
+            value: {} as Window['electron'],
+            configurable: true,
+        });
+        xtreamDataSourceMock.getFavorites.mockResolvedValue([
+            {
+                id: 20203,
+                stream_id: 20203,
+                category_id: 206,
+                title: 'PWA Movie',
+                type: 'movie',
+                poster_url: 'https://example.com/pwa-movie.png',
+                backdrop_url: 'https://example.com/pwa-movie-backdrop.png',
+                xtream_id: 20203,
+                added: '1774298340',
+            },
+        ]);
+
+        await service.reloadGlobalFavorites();
+
+        expect(dbServiceMock.getAllGlobalFavorites).not.toHaveBeenCalled();
+        expect(xtreamDataSourceMock.getFavorites).toHaveBeenCalledWith(
+            'xtream-1'
+        );
+        expect(service.globalFavoriteItems()).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 20203,
+                    title: 'PWA Movie',
+                    type: 'movie',
+                    playlist_id: 'xtream-1',
+                    playlist_name: 'Xtream Playlist',
+                    poster_url: 'https://example.com/pwa-movie.png',
+                    backdrop_url: 'https://example.com/pwa-movie-backdrop.png',
+                    source: 'xtream',
+                    xtream_id: 20203,
+                }),
+            ])
+        );
+    });
+
     it('builds the M3U favorites route', async () => {
         await service.reloadGlobalFavorites();
         const m3uItem = service
@@ -414,6 +482,47 @@ describe('DashboardDataService', () => {
                     playlist_id: 'm3u-1',
                     source: 'm3u',
                     xtream_id: 'https://example.com/stream-1.m3u8',
+                }),
+            ])
+        );
+    });
+
+    it('includes PWA Xtream recent items from the data source when Electron DB APIs are unavailable', async () => {
+        Object.defineProperty(window, 'electron', {
+            value: {} as Window['electron'],
+            configurable: true,
+        });
+        xtreamDataSourceMock.getRecentItems.mockResolvedValue([
+            {
+                id: 20203,
+                stream_id: 20203,
+                category_id: 206,
+                title: 'PWA Recent Movie',
+                type: 'movie',
+                poster_url: 'https://example.com/pwa-recent.png',
+                backdrop_url: 'https://example.com/pwa-recent-backdrop.png',
+                xtream_id: 20203,
+                viewed_at: '2026-05-15T15:04:54.176Z',
+            },
+        ]);
+
+        await service.reloadGlobalRecentItems();
+
+        expect(dbServiceMock.getGlobalRecentlyViewed).not.toHaveBeenCalled();
+        expect(xtreamDataSourceMock.getRecentItems).toHaveBeenCalledWith(
+            'xtream-1'
+        );
+        expect(service.globalRecentItems()).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 20203,
+                    title: 'PWA Recent Movie',
+                    type: 'movie',
+                    playlist_id: 'xtream-1',
+                    playlist_name: 'Xtream Playlist',
+                    viewed_at: '2026-05-15T15:04:54.176Z',
+                    source: 'xtream',
+                    xtream_id: 20203,
                 }),
             ])
         );

--- a/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.spec.ts
+++ b/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.spec.ts
@@ -392,6 +392,49 @@ describe('DashboardDataService', () => {
         );
     });
 
+    it('removes PWA Xtream favorites through the data source when Electron DB APIs are unavailable', async () => {
+        Object.defineProperty(window, 'electron', {
+            value: {} as Window['electron'],
+            configurable: true,
+        });
+        xtreamDataSourceMock.getFavorites
+            .mockResolvedValueOnce([
+                {
+                    id: 20203,
+                    stream_id: 20203,
+                    category_id: 206,
+                    title: 'PWA Movie',
+                    type: 'movie',
+                    poster_url: 'https://example.com/pwa-movie.png',
+                    xtream_id: 20203,
+                    added: '1774298340',
+                },
+            ])
+            .mockResolvedValueOnce([]);
+
+        await service.reloadGlobalFavorites();
+        const xtreamFavorite = service
+            .globalFavoriteItems()
+            .find((item) => item.source === 'xtream');
+
+        if (!xtreamFavorite) {
+            throw new Error('Expected PWA Xtream favorite');
+        }
+
+        await service.removeGlobalFavorite(xtreamFavorite);
+
+        expect(dbServiceMock.removeFromFavorites).not.toHaveBeenCalled();
+        expect(xtreamDataSourceMock.removeFavorite).toHaveBeenCalledWith(
+            20203,
+            'xtream-1'
+        );
+        expect(
+            service
+                .globalFavoriteItems()
+                .some((item) => item.source === 'xtream')
+        ).toBe(false);
+    });
+
     it('builds the M3U favorites route', async () => {
         await service.reloadGlobalFavorites();
         const m3uItem = service
@@ -526,6 +569,47 @@ describe('DashboardDataService', () => {
                 }),
             ])
         );
+    });
+
+    it('removes PWA Xtream recent items through the data source when Electron DB APIs are unavailable', async () => {
+        Object.defineProperty(window, 'electron', {
+            value: {} as Window['electron'],
+            configurable: true,
+        });
+        xtreamDataSourceMock.getRecentItems
+            .mockResolvedValueOnce([
+                {
+                    id: 20203,
+                    stream_id: 20203,
+                    category_id: 206,
+                    title: 'PWA Recent Movie',
+                    type: 'movie',
+                    poster_url: 'https://example.com/pwa-recent.png',
+                    xtream_id: 20203,
+                    viewed_at: '2026-05-15T15:04:54.176Z',
+                },
+            ])
+            .mockResolvedValueOnce([]);
+
+        await service.reloadGlobalRecentItems();
+        const xtreamRecent = service
+            .globalRecentItems()
+            .find((item) => item.source === 'xtream');
+
+        if (!xtreamRecent) {
+            throw new Error('Expected PWA Xtream recent item');
+        }
+
+        await service.removeGlobalRecentItem(xtreamRecent);
+
+        expect(dbServiceMock.removeRecentItem).not.toHaveBeenCalled();
+        expect(xtreamDataSourceMock.removeRecentItem).toHaveBeenCalledWith(
+            20203,
+            'xtream-1'
+        );
+        expect(
+            service.globalRecentItems().some((item) => item.source === 'xtream')
+        ).toBe(false);
     });
 
     it('prioritizes recently used Xtream sources over newer imported M3U sources', async () => {

--- a/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
+++ b/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
@@ -42,7 +42,6 @@ import {
     mapDbFavoriteToItem,
     mapDbRecentlyAddedToItem,
     mapDbRecentToItem,
-    normalizeActivityType,
     toDateTimestamp,
     toTimestamp,
 } from './dashboard-mappers';
@@ -50,8 +49,11 @@ import {
     buildStalkerDetailNavigationTarget,
     buildStalkerStateItem,
     buildXtreamNavigationTarget,
+    getPwaXtreamContentType,
     getGlobalFavoriteNavigation,
     getRecentItemNavigation,
+    getXtreamNumericValue,
+    getXtreamString,
     WorkspaceNavigationTarget,
 } from '@iptvnator/portal/shared/util';
 
@@ -512,14 +514,14 @@ export class DashboardDataService {
         playlist: PlaylistMeta
     ): Omit<DashboardFavoriteItem, 'added_at'> {
         const record = item as unknown as Record<string, unknown>;
-        const id = this.getXtreamNumericValue(record, [
+        const id = getXtreamNumericValue(record, [
             'id',
             'stream_id',
             'series_id',
             'xtream_id',
         ]);
         const xtreamId =
-            this.getXtreamNumericValue(record, [
+            getXtreamNumericValue(record, [
                 'xtream_id',
                 'stream_id',
                 'series_id',
@@ -529,7 +531,7 @@ export class DashboardDataService {
         return {
             id: id ?? String(record['stream_id'] ?? record['series_id'] ?? ''),
             title: this.getXtreamTitle(record),
-            type: normalizeActivityType(this.getPwaXtreamActivityType(record)),
+            type: getPwaXtreamContentType(record),
             playlist_id: playlist._id,
             playlist_name:
                 playlist.title ||
@@ -540,33 +542,25 @@ export class DashboardDataService {
                 xtreamId ??
                 String(record['stream_id'] ?? record['series_id'] ?? ''),
             poster_url: this.getXtreamImage(record),
-            backdrop_url: this.getXtreamString(record['backdrop_url']),
+            backdrop_url: getXtreamString(record['backdrop_url']),
             source: 'xtream',
         };
     }
 
-    private getPwaXtreamActivityType(item: Record<string, unknown>): string {
-        if (item['series_id'] != null) {
-            return 'series';
-        }
-
-        return String(item['type'] ?? item['stream_type'] ?? 'movie');
-    }
-
     private getXtreamTitle(item: Record<string, unknown>): string {
         return (
-            this.getXtreamString(item['title']) ??
-            this.getXtreamString(item['name']) ??
-            this.getXtreamString(item['stream_display_name']) ??
+            getXtreamString(item['title']) ??
+            getXtreamString(item['name']) ??
+            getXtreamString(item['stream_display_name']) ??
             this.translateText('WORKSPACE.DASHBOARD.UNKNOWN_TITLE')
         );
     }
 
     private getXtreamImage(item: Record<string, unknown>): string {
         return (
-            this.getXtreamString(item['poster_url']) ??
-            this.getXtreamString(item['stream_icon']) ??
-            this.getXtreamString(item['cover']) ??
+            getXtreamString(item['poster_url']) ??
+            getXtreamString(item['stream_icon']) ??
+            getXtreamString(item['cover']) ??
             ''
         );
     }
@@ -582,26 +576,6 @@ export class DashboardDataService {
             new Date(0).toISOString();
         const timestamp = toTimestamp(value as string | number);
         return timestamp ? new Date(timestamp).toISOString() : String(value);
-    }
-
-    private getXtreamString(value: unknown): string | undefined {
-        return typeof value === 'string' && value.trim().length > 0
-            ? value
-            : undefined;
-    }
-
-    private getXtreamNumericValue(
-        item: Record<string, unknown>,
-        keys: string[]
-    ): number | null {
-        for (const key of keys) {
-            const value = Number(item[key]);
-            if (Number.isFinite(value) && value > 0) {
-                return value;
-            }
-        }
-
-        return null;
     }
 
     private hasElectronGlobalRecentApi(): boolean {

--- a/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
+++ b/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
@@ -612,6 +612,19 @@ export class DashboardDataService {
         return typeof window.electron?.dbGetAllGlobalFavorites === 'function';
     }
 
+    private getXtreamContentId(
+        item: Pick<PortalActivityItem, 'id' | 'xtream_id'>
+    ): number | null {
+        for (const candidate of [item.xtream_id, item.id]) {
+            const value = Number(candidate);
+            if (Number.isFinite(value) && value > 0) {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
     private async reloadM3uGlobalFavorites(): Promise<void> {
         const m3uPlaylists = this.playlists().filter(
             (playlist) =>
@@ -770,10 +783,20 @@ export class DashboardDataService {
 
     async removeGlobalRecentItem(item: GlobalRecentItem): Promise<void> {
         if (item.source === 'xtream') {
-            await this.dbService.removeRecentItem(
-                item.id as number,
-                item.playlist_id
-            );
+            if (this.hasElectronGlobalRecentApi()) {
+                await this.dbService.removeRecentItem(
+                    item.id as number,
+                    item.playlist_id
+                );
+            } else {
+                const contentId = this.getXtreamContentId(item);
+                if (contentId != null) {
+                    await this.xtreamDataSource.removeRecentItem(
+                        contentId,
+                        item.playlist_id
+                    );
+                }
+            }
             await this.reloadGlobalRecentItems();
             return;
         }
@@ -924,10 +947,20 @@ export class DashboardDataService {
 
     async removeGlobalFavorite(item: DashboardFavoriteItem): Promise<void> {
         if (item.source === 'xtream') {
-            await this.dbService.removeFromFavorites(
-                item.id as number,
-                item.playlist_id
-            );
+            if (this.hasElectronGlobalFavoritesApi()) {
+                await this.dbService.removeFromFavorites(
+                    item.id as number,
+                    item.playlist_id
+                );
+            } else {
+                const contentId = this.getXtreamContentId(item);
+                if (contentId != null) {
+                    await this.xtreamDataSource.removeFavorite(
+                        contentId,
+                        item.playlist_id
+                    );
+                }
+            }
             await this.reloadGlobalFavorites();
             return;
         }

--- a/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
+++ b/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
@@ -21,6 +21,10 @@ import {
     PlaylistsService,
 } from '@iptvnator/services';
 import {
+    XTREAM_DATA_SOURCE,
+    XtreamContentItem,
+} from '@iptvnator/portal/xtream/data-access';
+import {
     buildPlaylistRecentItems,
     Channel,
     Playlist,
@@ -38,6 +42,7 @@ import {
     mapDbFavoriteToItem,
     mapDbRecentlyAddedToItem,
     mapDbRecentToItem,
+    normalizeActivityType,
     toDateTimestamp,
     toTimestamp,
 } from './dashboard-mappers';
@@ -64,6 +69,7 @@ export type DashboardRecentlyAddedFilterKind = GlobalRecentlyAddedKind;
 export class DashboardDataService {
     private readonly store = inject(Store);
     private readonly dbService = inject(DatabaseService);
+    private readonly xtreamDataSource = inject(XTREAM_DATA_SOURCE);
     private readonly playlistsService = inject(PlaylistsService);
     private readonly ngZone = inject(NgZone);
     private readonly translate = inject(TranslateService);
@@ -297,8 +303,8 @@ export class DashboardDataService {
             this.globalRecentLoadingState.set(true);
         }
 
-        if (!window.electron) {
-            this.xtreamGlobalRecentItems.set([]);
+        if (!this.hasElectronGlobalRecentApi()) {
+            await this.reloadPwaXtreamGlobalRecentItems();
             this.globalRecentDbLoadedState.set(true);
             this.finishInitialGlobalRecentLoadIfReady();
             return;
@@ -399,8 +405,9 @@ export class DashboardDataService {
     }
 
     private async reloadXtreamGlobalFavorites(): Promise<void> {
-        if (!window.electron) {
-            this.xtreamGlobalFavorites.set([]);
+        if (!this.hasElectronGlobalFavoritesApi()) {
+            const favorites = await this.getPwaXtreamGlobalFavorites();
+            this.ngZone.run(() => this.xtreamGlobalFavorites.set(favorites));
             this.finishInitialGlobalFavoritesLoadIfReady();
             return;
         }
@@ -425,6 +432,184 @@ export class DashboardDataService {
     private async refreshPlaylistBackedGlobalFavorites(): Promise<void> {
         await this.reloadM3uGlobalFavorites();
         this.finishInitialGlobalFavoritesLoadIfReady();
+    }
+
+    private async reloadPwaXtreamGlobalRecentItems(): Promise<void> {
+        const items = await this.getPwaXtreamGlobalRecentItems();
+        this.ngZone.run(() => this.xtreamGlobalRecentItems.set(items));
+    }
+
+    private async getPwaXtreamGlobalFavorites(): Promise<
+        DashboardFavoriteItem[]
+    > {
+        const results: DashboardFavoriteItem[] = [];
+
+        for (const playlist of this.getXtreamPlaylists()) {
+            try {
+                const favorites = await this.xtreamDataSource.getFavorites(
+                    playlist._id
+                );
+                results.push(
+                    ...favorites.map((item) =>
+                        this.mapXtreamDataSourceFavorite(item, playlist)
+                    )
+                );
+            } catch {
+                // Keep the dashboard usable if one PWA playlist cache is stale.
+            }
+        }
+
+        return results;
+    }
+
+    private async getPwaXtreamGlobalRecentItems(): Promise<GlobalRecentItem[]> {
+        const results: GlobalRecentItem[] = [];
+
+        for (const playlist of this.getXtreamPlaylists()) {
+            try {
+                const recentItems = await this.xtreamDataSource.getRecentItems(
+                    playlist._id
+                );
+                results.push(
+                    ...recentItems.map((item) =>
+                        this.mapXtreamDataSourceRecent(item, playlist)
+                    )
+                );
+            } catch {
+                // Keep the dashboard usable if one PWA playlist cache is stale.
+            }
+        }
+
+        return results;
+    }
+
+    private getXtreamPlaylists(): PlaylistMeta[] {
+        return this.playlists().filter((playlist) => !!playlist.serverUrl);
+    }
+
+    private mapXtreamDataSourceFavorite(
+        item: XtreamContentItem,
+        playlist: PlaylistMeta
+    ): DashboardFavoriteItem {
+        return {
+            ...this.mapXtreamDataSourceActivity(item, playlist),
+            added_at: this.getXtreamDate(item, 'added_at'),
+        };
+    }
+
+    private mapXtreamDataSourceRecent(
+        item: XtreamContentItem,
+        playlist: PlaylistMeta
+    ): GlobalRecentItem {
+        return {
+            ...this.mapXtreamDataSourceActivity(item, playlist),
+            viewed_at: this.getXtreamDate(item, 'viewed_at'),
+        };
+    }
+
+    private mapXtreamDataSourceActivity(
+        item: XtreamContentItem,
+        playlist: PlaylistMeta
+    ): Omit<DashboardFavoriteItem, 'added_at'> {
+        const record = item as unknown as Record<string, unknown>;
+        const id = this.getXtreamNumericValue(record, [
+            'id',
+            'stream_id',
+            'series_id',
+            'xtream_id',
+        ]);
+        const xtreamId =
+            this.getXtreamNumericValue(record, [
+                'xtream_id',
+                'stream_id',
+                'series_id',
+                'id',
+            ]) ?? id;
+
+        return {
+            id: id ?? String(record['stream_id'] ?? record['series_id'] ?? ''),
+            title: this.getXtreamTitle(record),
+            type: normalizeActivityType(this.getPwaXtreamActivityType(record)),
+            playlist_id: playlist._id,
+            playlist_name:
+                playlist.title ||
+                playlist.filename ||
+                this.translateText('WORKSPACE.DASHBOARD.XTREAM'),
+            category_id: (record['category_id'] as string | number) ?? '',
+            xtream_id:
+                xtreamId ??
+                String(record['stream_id'] ?? record['series_id'] ?? ''),
+            poster_url: this.getXtreamImage(record),
+            backdrop_url: this.getXtreamString(record['backdrop_url']),
+            source: 'xtream',
+        };
+    }
+
+    private getPwaXtreamActivityType(item: Record<string, unknown>): string {
+        if (item['series_id'] != null) {
+            return 'series';
+        }
+
+        return String(item['type'] ?? item['stream_type'] ?? 'movie');
+    }
+
+    private getXtreamTitle(item: Record<string, unknown>): string {
+        return (
+            this.getXtreamString(item['title']) ??
+            this.getXtreamString(item['name']) ??
+            this.getXtreamString(item['stream_display_name']) ??
+            this.translateText('WORKSPACE.DASHBOARD.UNKNOWN_TITLE')
+        );
+    }
+
+    private getXtreamImage(item: Record<string, unknown>): string {
+        return (
+            this.getXtreamString(item['poster_url']) ??
+            this.getXtreamString(item['stream_icon']) ??
+            this.getXtreamString(item['cover']) ??
+            ''
+        );
+    }
+
+    private getXtreamDate(
+        item: XtreamContentItem,
+        key: 'added_at' | 'viewed_at'
+    ): string {
+        const record = item as unknown as Record<string, unknown>;
+        const value =
+            record[key] ??
+            (key === 'added_at' ? record['added'] : undefined) ??
+            new Date(0).toISOString();
+        const timestamp = toTimestamp(value as string | number);
+        return timestamp ? new Date(timestamp).toISOString() : String(value);
+    }
+
+    private getXtreamString(value: unknown): string | undefined {
+        return typeof value === 'string' && value.trim().length > 0
+            ? value
+            : undefined;
+    }
+
+    private getXtreamNumericValue(
+        item: Record<string, unknown>,
+        keys: string[]
+    ): number | null {
+        for (const key of keys) {
+            const value = Number(item[key]);
+            if (Number.isFinite(value) && value > 0) {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private hasElectronGlobalRecentApi(): boolean {
+        return typeof window.electron?.dbGetRecentlyViewed === 'function';
+    }
+
+    private hasElectronGlobalFavoritesApi(): boolean {
+        return typeof window.electron?.dbGetAllGlobalFavorites === 'function';
     }
 
     private async reloadM3uGlobalFavorites(): Promise<void> {
@@ -875,8 +1060,7 @@ export class DashboardDataService {
                 const matchedFavoriteId =
                     channelIdFavoritePosition !== undefined &&
                     (channelUrlFavoritePosition === undefined ||
-                        channelIdFavoritePosition <=
-                            channelUrlFavoritePosition)
+                        channelIdFavoritePosition <= channelUrlFavoritePosition)
                         ? channelId
                         : channelUrlFavoritePosition !== undefined
                           ? channelUrl


### PR DESCRIPTION
## Summary

- Replace the old two-container self-hosted setup with one image containing nginx, the Angular PWA, and `web-backend`.
- Generate runtime `assets/app-config.js` at container startup and proxy `/api/*` to the internal backend.
- Fix PWA-only Xtream favorites/recent persistence so VOD/series/live activity survives reloads and appears in global collections and dashboard without Electron SQLite APIs.
- Update `docker/README.md`, root `README.md`, `docs/architecture/pwa-self-hosted.md`, and `AGENTS.md` with the self-hosted/PWA contract.

## Validation

- `sh -n docker/docker-entrypoint.sh`
- `docker compose -f docker/docker-compose.yml config`
- `pnpm nx run-many -t test -p portal-shared-util,portal-xtream-data-access,workspace-dashboard-data-access,portal-xtream-feature,services --runInBand`
- `pnpm nx build web --configuration=pwa --skip-nx-cache`
- `pnpm nx build web-backend --skip-nx-cache`
- `pnpm nx run web-e2e:e2e -- --project=chromium --grep @self-hosted`
- `docker compose -f docker/docker-compose.yml up -d --build`
- Manual agent-browser smoke against the Docker container with mock M3U, Xtream, and Stalker servers: add source, open VOD/live content, toggle favorites, verify recently viewed, global collection pages, dashboard widgets, and inline playback.

## Notes

- Lint still exposes the existing `portal-shared-util` cycle through `stream-resolver.service.ts` imports into Xtream/Stalker data-access. This PR avoids adding another shared-util -> Xtream data-access dependency by using a provider-neutral collection token, but it does not unwind that older cycle.
- The web/PWA E2E suite now has self-hosted proxy smoke coverage; deeper favorites/recent/dashboard workflows are still mostly covered by Electron E2E and need dedicated web/PWA specs.
