### PR TITLE
fix(playlist): preserve auto-refresh on manual refresh

### DIFF
--- a/libs/m3u-state/src/lib/reducers/playlist.reducers.spec.ts
+++ b/libs/m3u-state/src/lib/reducers/playlist.reducers.spec.ts
@@ -130,4 +130,38 @@ describe('playlistReducers', () => {
             nextState.playlists.entities['playlist-1']?.hiddenGroupTitles
         ).toEqual(['Radio-de']);
     });
+
+    it('keeps autoRefresh enabled on playlist refresh when the parser payload defaults it to false', () => {
+        const existingPlaylist: PlaylistMeta = {
+            _id: 'playlist-1',
+            autoRefresh: true,
+            count: 1,
+            importDate: '2026-03-28T00:00:00.000Z',
+            title: 'Playlist One',
+        } as PlaylistMeta;
+        const state = {
+            ...initialState,
+            playlists: playlistsAdapter.addOne(existingPlaylist, {
+                ...initialState.playlists,
+                selectedId: 'playlist-1',
+            }),
+        };
+
+        const nextState = reducer(
+            state,
+            PlaylistActions.updatePlaylist({
+                playlist: {
+                    autoRefresh: false,
+                    playlist: {
+                        items: [],
+                    },
+                } as Playlist,
+                playlistId: 'playlist-1',
+            })
+        );
+
+        expect(
+            nextState.playlists.entities['playlist-1']?.autoRefresh
+        ).toBe(true);
+    });
 });

--- a/libs/m3u-state/src/lib/reducers/playlist.reducers.spec.ts
+++ b/libs/m3u-state/src/lib/reducers/playlist.reducers.spec.ts
@@ -164,4 +164,38 @@ describe('playlistReducers', () => {
             nextState.playlists.entities['playlist-1']?.autoRefresh
         ).toBe(true);
     });
+
+    it('keeps autoRefresh disabled on playlist refresh when the existing playlist has it disabled', () => {
+        const existingPlaylist: PlaylistMeta = {
+            _id: 'playlist-1',
+            autoRefresh: false,
+            count: 1,
+            importDate: '2026-03-28T00:00:00.000Z',
+            title: 'Playlist One',
+        } as PlaylistMeta;
+        const state = {
+            ...initialState,
+            playlists: playlistsAdapter.addOne(existingPlaylist, {
+                ...initialState.playlists,
+                selectedId: 'playlist-1',
+            }),
+        };
+
+        const nextState = reducer(
+            state,
+            PlaylistActions.updatePlaylist({
+                playlist: {
+                    autoRefresh: true,
+                    playlist: {
+                        items: [],
+                    },
+                } as Playlist,
+                playlistId: 'playlist-1',
+            })
+        );
+
+        expect(
+            nextState.playlists.entities['playlist-1']?.autoRefresh
+        ).toBe(false);
+    });
 });

--- a/libs/m3u-state/src/lib/reducers/playlist.reducers.ts
+++ b/libs/m3u-state/src/lib/reducers/playlist.reducers.ts
@@ -33,6 +33,7 @@ export const playlistReducers = [
     on(PlaylistActions.updatePlaylist, (state, action): PlaylistState => {
         const isActivePlaylist =
             state.playlists.selectedId === action.playlistId;
+        const currentPlaylist = state.playlists.entities[action.playlistId];
         return {
             ...state,
             channels: isActivePlaylist
@@ -49,8 +50,10 @@ export const playlistReducers = [
                         count: action.playlist.playlist.items.length,
                         userAgent: action.playlist.userAgent,
                         favorites:
-                            state.playlists.entities[action.playlistId]
-                                ?.favorites ?? [],
+                            currentPlaylist?.favorites ?? [],
+                        autoRefresh:
+                            currentPlaylist?.autoRefresh ??
+                            action.playlist.autoRefresh,
                     },
                 },
                 state.playlists

--- a/libs/services/src/lib/playlists.service.spec.ts
+++ b/libs/services/src/lib/playlists.service.spec.ts
@@ -411,4 +411,47 @@ describe('PlaylistsService', () => {
             })
         );
     });
+
+    it('keeps autoRefresh enabled when refreshing a playlist payload with the parser default disabled', async () => {
+        const existingPlaylist: Playlist = {
+            _id: 'playlist-3',
+            title: 'Playlist Three',
+            count: 1,
+            importDate: new Date('2026-04-12T00:00:00.000Z').toISOString(),
+            lastUsage: new Date('2026-04-12T00:00:00.000Z').toISOString(),
+            autoRefresh: true,
+            playlist: {
+                items: [{ id: 'channel-1' }],
+            },
+        } as Playlist;
+        const dbService = {
+            getAll: jest.fn(() => of([])),
+            getByID: jest.fn(() => of(existingPlaylist)),
+            update: jest.fn((_storeName: string, playlist: Playlist) =>
+                of(playlist)
+            ),
+        };
+        testWindow.electron = undefined;
+
+        const service = createService(dbService);
+
+        await firstValueFrom(
+            service.updatePlaylist('playlist-3', {
+                _id: 'playlist-3',
+                autoRefresh: false,
+                playlist: {
+                    items: [],
+                },
+            } as Playlist)
+        );
+
+        expect(dbService.update).toHaveBeenCalledWith(
+            DbStores.Playlists,
+            expect.objectContaining({
+                _id: 'playlist-3',
+                autoRefresh: true,
+                count: 0,
+            })
+        );
+    });
 });

--- a/libs/services/src/lib/playlists.service.ts
+++ b/libs/services/src/lib/playlists.service.ts
@@ -436,6 +436,9 @@ export class PlaylistsService {
                     updateDate: Date.now(),
                     updateState: PlaylistUpdateState.UPDATED,
                     favorites: currentPlaylist.favorites,
+                    autoRefresh:
+                        currentPlaylist.autoRefresh ??
+                        updatedPlaylist.autoRefresh,
                 };
 
                 if (this.isElectronStorageAvailable) {


### PR DESCRIPTION
## Summary
- Preserve the saved auto-refresh setting when a playlist is updated manually.
- Add regression coverage for both the NgRx playlist state and persisted playlist merge path.

## Changes
- Keep the existing playlist's `autoRefresh` value during `updatePlaylist` reducer updates.
- Keep the existing `autoRefresh` value when `PlaylistsService.updatePlaylist` persists refreshed playlist data.

## Testing
- [x] `pnpm nx test m3u-state --skip-nx-cache`
- [x] `pnpm nx test services --skip-nx-cache`
- [x] `pnpm nx lint m3u-state --skip-nx-cache` (0 errors; existing warnings remain)
- [x] `pnpm nx lint services --skip-nx-cache` (0 errors; existing warnings remain)