### PR TITLE
fix(xtream): ignore future recently added dates

### DIFF
--- a/apps/electron-backend/src/app/database/operations/content.operations.spec.ts
+++ b/apps/electron-backend/src/app/database/operations/content.operations.spec.ts
@@ -93,7 +93,9 @@ describe('content.operations', () => {
     });
 
     it('uses a synchronous better-sqlite transaction callback when saving content', async () => {
-        const existingContentWhere = jest.fn().mockResolvedValue([{ count: 0 }]);
+        const existingContentWhere = jest
+            .fn()
+            .mockResolvedValue([{ count: 0 }]);
         const existingContentInnerJoin = jest
             .fn()
             .mockReturnValue({ where: existingContentWhere });
@@ -165,5 +167,92 @@ describe('content.operations', () => {
             }),
         ]);
         expect(run).toHaveBeenCalled();
+    });
+
+    it('does not persist far-future provider timestamps as valid recently-added dates', async () => {
+        const dateNowSpy = jest
+            .spyOn(Date, 'now')
+            .mockReturnValue(Date.parse('2026-05-19T00:00:00.000Z'));
+        const existingContentWhere = jest
+            .fn()
+            .mockResolvedValue([{ count: 0 }]);
+        const existingContentInnerJoin = jest
+            .fn()
+            .mockReturnValue({ where: existingContentWhere });
+        const existingContentFrom = jest
+            .fn()
+            .mockReturnValue({ innerJoin: existingContentInnerJoin });
+
+        const categoriesWhere = jest.fn().mockResolvedValue([
+            {
+                id: 42,
+                xtreamId: 201,
+            },
+        ]);
+        const categoriesFrom = jest
+            .fn()
+            .mockReturnValue({ where: categoriesWhere });
+
+        const select = jest
+            .fn()
+            .mockReturnValueOnce({ from: existingContentFrom })
+            .mockReturnValueOnce({ from: categoriesFrom });
+
+        const run = jest.fn();
+        const onConflictDoNothing = jest.fn().mockReturnValue({ run });
+        const values = jest.fn().mockReturnValue({ onConflictDoNothing });
+        const insert = jest.fn().mockReturnValue({ values });
+        const transaction = jest.fn((callback: (tx: unknown) => unknown) =>
+            callback({ insert })
+        );
+        const db = {
+            select,
+            transaction,
+        } as unknown as AppDatabase;
+
+        try {
+            await saveContent(
+                db,
+                'playlist-1',
+                [
+                    {
+                        added: '1893456000',
+                        category_id: '201',
+                        name: 'Future Movie',
+                        stream_id: '100',
+                    },
+                    {
+                        added: '1779062400',
+                        category_id: '201',
+                        name: 'Fresh Movie',
+                        stream_id: '101',
+                    },
+                    {
+                        category_id: '201',
+                        last_modified: '1778976000',
+                        name: 'Modified Movie',
+                        stream_id: '102',
+                    },
+                ],
+                'movie'
+            );
+
+            expect(values).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    title: 'Future Movie',
+                    added: '',
+                }),
+                expect.objectContaining({
+                    title: 'Fresh Movie',
+                    added: '1779062400',
+                }),
+                expect.objectContaining({
+                    title: 'Modified Movie',
+                    added: '1778976000',
+                }),
+            ]);
+        } finally {
+            dateNowSpy.mockRestore();
+        }
     });
 });

--- a/apps/electron-backend/src/app/database/operations/content.operations.ts
+++ b/apps/electron-backend/src/app/database/operations/content.operations.ts
@@ -1,5 +1,9 @@
 import { and, asc, desc, eq, inArray, or, sql } from 'drizzle-orm';
 import * as schema from '@iptvnator/shared/database/schema';
+import {
+    getXtreamRecentlyAddedMaxEpochSeconds,
+    toXtreamRecentlyAddedEpochSeconds,
+} from '@iptvnator/shared/interfaces';
 import type { AppDatabase } from '../database.types';
 import {
     checkpointOperation,
@@ -129,18 +133,19 @@ export async function getGlobalRecentlyAdded(
         inArray(schema.content.type, contentTypes),
         eq(schema.categories.hidden, false),
         sql`${schema.content.added} <> ''`,
+        sql`${schema.content.added} <= ${getXtreamRecentlyAddedMaxEpochSeconds()}`,
     ];
 
     if (playlistType) {
         whereConditions.push(eq(schema.playlists.type, playlistType));
     }
 
-    // Sort by `added` directly. Xtream stores Unix-epoch timestamps as
-    // 10-digit numeric strings (since 2001-09-09), so lexicographic sort
-    // is equivalent to numeric sort. Wrapping the column in CAST(... AS
-    // INTEGER) — as we used to — blocks SQLite from using
-    // idx_content_type_added and forces a full table scan + sort on the
-    // entire content table (often 100k+ rows) on every dashboard load.
+    // Sort by `added` directly. Xtream import and DB startup migrations
+    // normalize recently-added epochs to 10-digit seconds strings, so
+    // lexicographic sort is equivalent to numeric sort. Wrapping the column in
+    // CAST(... AS INTEGER) blocks SQLite from using idx_content_type_added and
+    // forces a full table scan + sort on the entire content table (often 100k+
+    // rows) on every dashboard load.
     return db
         .select({
             ...selectContentFields(),
@@ -183,16 +188,16 @@ type XtreamContentSource = Record<string, unknown> & {
     last_modified?: string;
     added?: string;
     stream_icon?: string;
-        poster?: string;
-        cover?: string;
-        name?: string;
-        title?: string;
-        epg_channel_id?: string;
-        tv_archive?: string | number;
-        tv_archive_duration?: string | number;
-        direct_source?: string;
-        series_id?: string | number;
-        stream_id?: string | number;
+    poster?: string;
+    cover?: string;
+    name?: string;
+    title?: string;
+    epg_channel_id?: string;
+    tv_archive?: string | number;
+    tv_archive_duration?: string | number;
+    direct_source?: string;
+    series_id?: string | number;
+    stream_id?: string | number;
 };
 
 function toXtreamContentValue(
@@ -224,10 +229,11 @@ function toXtreamContentValue(
         categoryId,
         title,
         rating: String(source.rating || source.rating_imdb || ''),
-        added:
+        added: toXtreamRecentlyAddedEpochSeconds(
             type === 'series'
-                ? String(source.last_modified || '')
-                : String(source.added || ''),
+                ? source.last_modified || source.added
+                : source.added || source.last_modified
+        ),
         posterUrl: String(
             source.stream_icon || source.poster || source.cover || ''
         ),
@@ -300,10 +306,9 @@ export async function saveContent(
             )
         );
 
-    const categoryMap = new Map(categories.map((category) => [
-        category.xtreamId,
-        category.id,
-    ]));
+    const categoryMap = new Map(
+        categories.map((category) => [category.xtreamId, category.id])
+    );
 
     const values = streams
         .map((stream) => toXtreamContentValue(stream, type, categoryMap))
@@ -317,8 +322,7 @@ export async function saveContent(
         await checkpointOperation(control);
         const chunk = values.slice(index, index + chunkSize);
         await db.transaction((tx) => {
-            tx
-                .insert(schema.content)
+            tx.insert(schema.content)
                 .values(chunk)
                 .onConflictDoNothing({
                     target: [
@@ -374,8 +378,7 @@ export async function clearXtreamImportCache(
         100
     )) {
         await db.transaction((tx) => {
-            tx
-                .delete(schema.content)
+            tx.delete(schema.content)
                 .where(inArray(schema.content.id, chunk))
                 .run();
         });
@@ -383,8 +386,7 @@ export async function clearXtreamImportCache(
 
     for (const chunk of chunkValues(categoryIds, 100)) {
         await db.transaction((tx) => {
-            tx
-                .delete(schema.categories)
+            tx.delete(schema.categories)
                 .where(inArray(schema.categories.id, chunk))
                 .run();
         });
@@ -440,7 +442,10 @@ export async function searchContent(
 
     const conditions = [
         eq(schema.categories.playlistId, playlistId),
-        inArray(schema.content.type, types as Array<'live' | 'movie' | 'series'>),
+        inArray(
+            schema.content.type,
+            types as Array<'live' | 'movie' | 'series'>
+        ),
         or(...likeConditions),
     ];
 
@@ -482,7 +487,10 @@ export async function globalSearch(
     );
 
     const conditions = [
-        inArray(schema.content.type, types as Array<'live' | 'movie' | 'series'>),
+        inArray(
+            schema.content.type,
+            types as Array<'live' | 'movie' | 'series'>
+        ),
         or(...likeConditions),
     ];
 

--- a/docs/architecture/date-handling.md
+++ b/docs/architecture/date-handling.md
@@ -12,14 +12,26 @@
 
 - Date display should follow the user-selected app language from `TranslateService`.
 - When a template renders localized month or weekday names, pass the normalized app locale explicitly to `DatePipe`.
-- Angular locale data is registered in [apps/web/src/app/app-date-locales.ts](/Users/4gray/Code/iptvnator/apps/web/src/app/app-date-locales.ts).
-- App language aliases are normalized in [libs/ui/pipes/src/lib/date-format.util.ts](/Users/4gray/Code/iptvnator/libs/ui/pipes/src/lib/date-format.util.ts):
-  - `ary` -> `ar-MA`
-  - `by` -> `be`
-  - `zhtw` -> `zh-Hant`
+- Angular locale data is registered in [apps/web/src/app/app-date-locales.ts](/apps/web/src/app/app-date-locales.ts).
+- App language aliases are normalized in [libs/ui/pipes/src/lib/date-format.util.ts](/libs/ui/pipes/src/lib/date-format.util.ts):
+    - `ary` -> `ar-MA`
+    - `by` -> `be`
+    - `zhtw` -> `zh-Hant`
 
 ## Parsing Boundaries
 
 - Normalize provider-specific or legacy date strings to ISO as early as possible.
 - Keep optional epoch fields such as `startTimestamp` and `stopTimestamp` when the provider already supplies them.
 - Avoid new non-standard `Date.parse(...)` usage for provider formats; prefer explicit `date-fns` parsing when the input is not ISO.
+- Xtream `added` / `last_modified` values are provider-supplied epoch fields.
+  Normalize them through `toXtreamRecentlyAddedTimestamp()` /
+  `toXtreamRecentlyAddedEpochSeconds()` from `@iptvnator/shared/interfaces`
+  before ranking or storing recently-added content. Values more than 24 hours
+  in the future are treated as invalid so provider placeholders such as
+  `2030-01-01` cannot permanently pin the top of recently-added rails.
+  Recently-added ranking uses `added` before `last_modified` for live/VOD
+  content and `last_modified` before `added` for series. The VOD/live fallback
+  is intentional for providers that omit `added` but still expose a valid
+  `last_modified` epoch. Legacy cached millisecond epochs in `content.added`
+  are migrated to epoch seconds during database startup so indexed dashboard
+  queries can continue to compare and sort text timestamps directly.

--- a/libs/portal/xtream/feature/src/lib/recently-added/recently-added.component.html
+++ b/libs/portal/xtream/feature/src/lib/recently-added/recently-added.component.html
@@ -55,7 +55,7 @@
                         [title]="item.title || item.name"
                         [posterUrl]="item.poster_url || item.cover"
                         [type]="'series'"
-                        [date]="getDate(item)"
+                        [date]="getDate(item, true)"
                         (cardClick)="openItem(item, 'series')"
                     />
                 }

--- a/libs/portal/xtream/feature/src/lib/recently-added/recently-added.component.spec.ts
+++ b/libs/portal/xtream/feature/src/lib/recently-added/recently-added.component.spec.ts
@@ -1,0 +1,164 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
+import { RecentlyAddedComponent } from './recently-added.component';
+
+jest.mock('@iptvnator/portal/shared/ui', () => ({
+    ContentCardComponent: class {},
+    ContentRailShellComponent: class {},
+}));
+
+interface TestRecentlyAddedItem {
+    readonly added?: string;
+    readonly category_id: number;
+    readonly last_modified?: string;
+    readonly poster_url: string;
+    readonly title: string;
+    readonly xtream_id: number;
+}
+
+function toEpochSeconds(iso: string): string {
+    return String(Math.floor(Date.parse(iso) / 1000));
+}
+
+function createItem(
+    index: number,
+    overrides: Partial<TestRecentlyAddedItem> = {}
+): TestRecentlyAddedItem {
+    return {
+        added: toEpochSeconds('2026-05-18T00:00:00.000Z'),
+        category_id: 10,
+        poster_url: '',
+        title: `Item ${index}`,
+        xtream_id: index,
+        ...overrides,
+    };
+}
+
+class MockXtreamStore {
+    readonly liveStreams = signal<TestRecentlyAddedItem[]>([]);
+    readonly vodStreams = signal<TestRecentlyAddedItem[]>([]);
+    readonly serialStreams = signal<TestRecentlyAddedItem[]>([]);
+    readonly currentPlaylist = signal({ id: 'playlist-1' });
+    readonly isLoadingContent = signal(false);
+    readonly isLoadingCategories = signal(false);
+    readonly isImporting = signal(false);
+    readonly setSelectedContentType = jest.fn();
+}
+
+describe('RecentlyAddedComponent', () => {
+    let store: MockXtreamStore;
+    let dateNowSpy: jest.SpyInstance<number, []>;
+
+    beforeEach(() => {
+        dateNowSpy = jest
+            .spyOn(Date, 'now')
+            .mockReturnValue(Date.parse('2026-05-19T00:00:00.000Z'));
+
+        TestBed.configureTestingModule({
+            providers: [
+                {
+                    provide: XtreamStore,
+                    useClass: MockXtreamStore,
+                },
+                {
+                    provide: Router,
+                    useValue: {
+                        navigate: jest.fn(),
+                    },
+                },
+                {
+                    provide: ActivatedRoute,
+                    useValue: {},
+                },
+                {
+                    provide: TranslateService,
+                    useValue: {
+                        currentLang: 'en',
+                        defaultLang: 'en',
+                        instant: jest.fn((key: string) => key),
+                        onLangChange: of(null),
+                    },
+                },
+            ],
+        });
+
+        store = TestBed.inject(XtreamStore) as unknown as MockXtreamStore;
+    });
+
+    afterEach(() => {
+        dateNowSpy.mockRestore();
+    });
+
+    it('does not let far-future provider dates pin the first VOD rail slots', () => {
+        const freshItems = Array.from({ length: 21 }, (_, index) =>
+            createItem(index + 1, {
+                added: String(
+                    Math.floor(
+                        (Date.parse('2026-05-18T00:00:00.000Z') -
+                            index * 60_000) /
+                            1000
+                    )
+                ),
+                title: `Fresh ${index + 1}`,
+                xtream_id: index + 1,
+            })
+        );
+        const futureItem = createItem(999, {
+            added: toEpochSeconds('2030-01-01T00:00:00.000Z'),
+            title: 'Future Provider Item',
+            xtream_id: 999,
+        });
+
+        store.vodStreams.set([futureItem, ...freshItems]);
+
+        const component = TestBed.runInInjectionContext(
+            () => new RecentlyAddedComponent()
+        );
+        const titles = component.recentlyAddedVod().map((item) => item.title);
+
+        expect(titles).toHaveLength(20);
+        expect(titles[0]).toBe('Fresh 1');
+        expect(titles).not.toContain('Future Provider Item');
+    });
+
+    it('filters invalid provider dates before slicing small VOD rails', () => {
+        const futureItem = createItem(999, {
+            added: toEpochSeconds('2030-01-01T00:00:00.000Z'),
+            title: 'Future Provider Item',
+            xtream_id: 999,
+        });
+
+        store.vodStreams.set([
+            futureItem,
+            createItem(1, { title: 'Fresh 1', xtream_id: 1 }),
+            createItem(2, { title: 'Fresh 2', xtream_id: 2 }),
+        ]);
+
+        const component = TestBed.runInInjectionContext(
+            () => new RecentlyAddedComponent()
+        );
+        const titles = component.recentlyAddedVod().map((item) => item.title);
+
+        expect(titles).toEqual(['Fresh 1', 'Fresh 2']);
+    });
+
+    it('uses the series sort timestamp priority for displayed dates', () => {
+        const component = TestBed.runInInjectionContext(
+            () => new RecentlyAddedComponent()
+        );
+
+        expect(
+            component.getDate(
+                createItem(1, {
+                    added: toEpochSeconds('2026-05-01T00:00:00.000Z'),
+                    last_modified: toEpochSeconds('2026-05-15T00:00:00.000Z'),
+                }),
+                true
+            )
+        ).toBe(Date.parse('2026-05-15T00:00:00.000Z'));
+    });
+});

--- a/libs/portal/xtream/feature/src/lib/recently-added/recently-added.component.ts
+++ b/libs/portal/xtream/feature/src/lib/recently-added/recently-added.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    computed,
+    inject,
+} from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
@@ -7,6 +12,7 @@ import {
     ContentCardComponent,
     ContentRailShellComponent,
 } from '@iptvnator/portal/shared/ui';
+import { toXtreamRecentlyAddedTimestamp } from '@iptvnator/shared/interfaces';
 import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
 import { ContentType } from '@iptvnator/portal/xtream/data-access';
 
@@ -97,9 +103,7 @@ export class RecentlyAddedComponent {
     );
 
     readonly vodSeeAllLink = computed(() => this.buildSectionLink('vod'));
-    readonly seriesSeeAllLink = computed(() =>
-        this.buildSectionLink('series')
-    );
+    readonly seriesSeeAllLink = computed(() => this.buildSectionLink('series'));
     readonly liveSeeAllLink = computed(() => this.buildSectionLink('live'));
 
     readonly vodSeeAllLabel = computed(() =>
@@ -112,7 +116,9 @@ export class RecentlyAddedComponent {
         this.translateWithTick('PORTALS.BROWSE_ALL_LIVE')
     );
 
-    private buildSectionLink(section: 'vod' | 'series' | 'live'): string[] | null {
+    private buildSectionLink(
+        section: 'vod' | 'series' | 'live'
+    ): string[] | null {
         const id = this.playlistId();
         if (!id) return null;
         return ['/workspace', 'xtreams', id, section];
@@ -127,20 +133,64 @@ export class RecentlyAddedComponent {
         items: T[],
         isSeries = false
     ): T[] {
-        return [...items]
+        const nowMs = Date.now();
+
+        return items
+            .map((item) => ({
+                item,
+                sortTimestamp: this.getSortTimestamp(item, isSeries, nowMs),
+            }))
+            .filter(({ sortTimestamp }) => sortTimestamp > 0)
             .sort((a, b) => {
-                const dateA =
-                    parseInt(isSeries ? a.last_modified : a.added) || 0;
-                const dateB =
-                    parseInt(isSeries ? b.last_modified : b.added) || 0;
-                return dateB - dateA;
+                return b.sortTimestamp - a.sortTimestamp;
             })
-            .slice(0, 20);
+            .slice(0, 20)
+            .map(({ item }) => item);
     }
 
-    getDate(item: RecentlyAddedItem): number {
-        const timestamp = item.added || item.last_modified;
-        return parseInt(timestamp) * 1000;
+    getDate(item: RecentlyAddedItem, isSeries = false): number {
+        const nowMs = Date.now();
+        return (
+            toXtreamRecentlyAddedTimestamp(
+                this.getPrimaryTimestamp(item, isSeries),
+                nowMs
+            ) ||
+            toXtreamRecentlyAddedTimestamp(
+                this.getFallbackTimestamp(item, isSeries),
+                nowMs
+            )
+        );
+    }
+
+    private getSortTimestamp(
+        item: RecentlyAddedItem,
+        isSeries: boolean,
+        nowMs: number
+    ): number {
+        return (
+            toXtreamRecentlyAddedTimestamp(
+                this.getPrimaryTimestamp(item, isSeries),
+                nowMs
+            ) ||
+            toXtreamRecentlyAddedTimestamp(
+                this.getFallbackTimestamp(item, isSeries),
+                nowMs
+            )
+        );
+    }
+
+    private getPrimaryTimestamp(
+        item: RecentlyAddedItem,
+        isSeries: boolean
+    ): string | undefined {
+        return isSeries ? item.last_modified : item.added;
+    }
+
+    private getFallbackTimestamp(
+        item: RecentlyAddedItem,
+        isSeries: boolean
+    ): string | undefined {
+        return isSeries ? item.added : item.last_modified;
     }
 
     openItem(item: RecentlyAddedItem, type: ContentType) {

--- a/libs/shared/database/src/lib/connection.spec.ts
+++ b/libs/shared/database/src/lib/connection.spec.ts
@@ -22,6 +22,7 @@ describe('database schema statements', () => {
         createTableStatements,
         columnMigrationStatements,
         indexMigrationStatements,
+        normalizeXtreamContentAddedEpochs,
     } = __databaseConnectionTestHooks;
 
     it('defines the core fresh-install tables, indexes, and FTS triggers', () => {
@@ -116,5 +117,57 @@ describe('database schema statements', () => {
         ];
 
         expect(objectNames).toHaveLength(new Set(objectNames).size);
+    });
+
+    it('runs the legacy millisecond Xtream timestamp normalization once', () => {
+        const selectGet = jest.fn().mockReturnValue(undefined);
+        const updateRun = jest.fn();
+        const stateRun = jest.fn();
+        const prepare = jest.fn((statement: string) => {
+            if (statement.includes('SELECT value FROM app_state')) {
+                return { get: selectGet };
+            }
+            if (statement.includes('UPDATE content')) {
+                return { run: updateRun };
+            }
+            if (statement.includes('INSERT INTO app_state')) {
+                return { run: stateRun };
+            }
+
+            throw new Error(`Unexpected statement: ${compactSql(statement)}`);
+        });
+        const transaction = jest.fn((callback: () => void) => callback);
+        const sqlite = {
+            prepare,
+            transaction,
+        } as unknown as Parameters<typeof normalizeXtreamContentAddedEpochs>[0];
+
+        normalizeXtreamContentAddedEpochs(sqlite);
+
+        expect(transaction).toHaveBeenCalledTimes(1);
+        expect(updateRun).toHaveBeenCalledWith(10_000_000_000, 10_000_000_000);
+        expect(stateRun).toHaveBeenCalledWith(
+            'migration:xtream-content-added-epoch-seconds:v1'
+        );
+    });
+
+    it('skips legacy Xtream timestamp normalization after it has run', () => {
+        const selectGet = jest.fn().mockReturnValue({ value: 'done' });
+        const prepare = jest.fn((statement: string) => {
+            if (statement.includes('SELECT value FROM app_state')) {
+                return { get: selectGet };
+            }
+
+            throw new Error(`Unexpected statement: ${compactSql(statement)}`);
+        });
+        const transaction = jest.fn((callback: () => void) => callback);
+        const sqlite = {
+            prepare,
+            transaction,
+        } as unknown as Parameters<typeof normalizeXtreamContentAddedEpochs>[0];
+
+        normalizeXtreamContentAddedEpochs(sqlite);
+
+        expect(transaction).not.toHaveBeenCalled();
     });
 });

--- a/libs/shared/database/src/lib/connection.ts
+++ b/libs/shared/database/src/lib/connection.ts
@@ -23,6 +23,10 @@ let db: DatabaseInstance | null = null;
 let sqlite: Database.Database | null = null;
 let initPromise: Promise<DatabaseInstance> | null = null;
 
+const XTREAM_ADDED_EPOCH_MILLISECONDS_THRESHOLD = 10_000_000_000;
+const XTREAM_ADDED_EPOCH_SECONDS_MIGRATION_KEY =
+    'migration:xtream-content-added-epoch-seconds:v1';
+
 function readTraceFlag(name: string): boolean {
     const value = process.env[name]?.trim().toLowerCase();
     return value ? TRACE_ENV_TRUE_VALUES.has(value) : false;
@@ -298,6 +302,7 @@ export const __databaseConnectionTestHooks = {
     createTableStatements: CREATE_TABLE_STATEMENTS,
     columnMigrationStatements: COLUMN_MIGRATION_STATEMENTS,
     indexMigrationStatements: INDEX_MIGRATION_STATEMENTS,
+    normalizeXtreamContentAddedEpochs,
 } as const;
 
 /**
@@ -437,7 +442,9 @@ function deduplicateXtreamCache(sqliteDb: Database.Database): void {
         const deleteRecentlyViewed = sqliteDb.prepare(
             `DELETE FROM recently_viewed WHERE content_id = ?`
         );
-        const deleteContent = sqliteDb.prepare(`DELETE FROM content WHERE id = ?`);
+        const deleteContent = sqliteDb.prepare(
+            `DELETE FROM content WHERE id = ?`
+        );
 
         for (const group of duplicateContentGroups) {
             const candidates = selectContentCandidates.all(
@@ -462,6 +469,58 @@ function deduplicateXtreamCache(sqliteDb: Database.Database): void {
     });
 
     executeCleanup();
+}
+
+function normalizeXtreamContentAddedEpochs(sqliteDb: Database.Database): void {
+    try {
+        const migrationState = sqliteDb
+            .prepare(`SELECT value FROM app_state WHERE key = ?`)
+            .get(XTREAM_ADDED_EPOCH_SECONDS_MIGRATION_KEY) as
+            | { value?: unknown }
+            | undefined;
+
+        if (migrationState?.value === 'done') {
+            return;
+        }
+
+        const executeMigration = sqliteDb.transaction(() => {
+            sqliteDb
+                .prepare(
+                    `UPDATE content
+                     SET added = CAST(CAST(added AS INTEGER) / 1000 AS TEXT)
+                     WHERE added IS NOT NULL
+                       AND added <> ''
+                       AND added NOT GLOB '*[^0-9]*'
+                       AND CAST(added AS INTEGER) >= ?
+                       AND CAST(added AS INTEGER) / 1000 < ?`
+                )
+                .run(
+                    XTREAM_ADDED_EPOCH_MILLISECONDS_THRESHOLD,
+                    XTREAM_ADDED_EPOCH_MILLISECONDS_THRESHOLD
+                );
+
+            sqliteDb
+                .prepare(
+                    `INSERT INTO app_state (key, value, updated_at)
+                     VALUES (?, 'done', datetime('now'))
+                     ON CONFLICT(key) DO UPDATE SET
+                        value = excluded.value,
+                        updated_at = excluded.updated_at`
+                )
+                .run(XTREAM_ADDED_EPOCH_SECONDS_MIGRATION_KEY);
+        });
+
+        executeMigration();
+    } catch (error) {
+        const message =
+            typeof error === 'object' && error !== null && 'message' in error
+                ? String((error as { message?: unknown }).message ?? error)
+                : String(error);
+
+        console.warn(
+            `Xtream added timestamp normalization failed (continuing): ${message}`
+        );
+    }
 }
 
 function runMigrationStatements(
@@ -498,6 +557,7 @@ function runMigrationStatements(
 function runMigrations(sqliteDb: Database.Database): void {
     runMigrationStatements(sqliteDb, COLUMN_MIGRATION_STATEMENTS);
     deduplicateXtreamCache(sqliteDb);
+    normalizeXtreamContentAddedEpochs(sqliteDb);
     runMigrationStatements(sqliteDb, INDEX_MIGRATION_STATEMENTS);
 }
 

--- a/libs/shared/interfaces/src/index.ts
+++ b/libs/shared/interfaces/src/index.ts
@@ -36,6 +36,7 @@ export * from './lib/xtream-item.interface';
 export * from './lib/xtream-live-stream.interface';
 export * from './lib/xtream-response.interface';
 export * from './lib/xtream-restore-state.util';
+export * from './lib/xtream-recently-added.utils';
 export * from './lib/xtream-serie-details.interface';
 export * from './lib/xtream-serie-item.interface';
 export * from './lib/xtream-vod-details.interface';

--- a/libs/shared/interfaces/src/lib/xtream-recently-added.utils.spec.ts
+++ b/libs/shared/interfaces/src/lib/xtream-recently-added.utils.spec.ts
@@ -1,0 +1,28 @@
+import {
+    getXtreamRecentlyAddedMaxEpochSeconds,
+    toXtreamRecentlyAddedTimestamp,
+} from './xtream-recently-added.utils';
+
+describe('Xtream recently-added timestamp helpers', () => {
+    const now = Date.parse('2026-05-19T00:00:00.000Z');
+
+    it('treats far-future provider timestamps as invalid for recent ranking', () => {
+        expect(toXtreamRecentlyAddedTimestamp('1893456000', now)).toBe(0);
+    });
+
+    it('normalizes valid epoch seconds to milliseconds', () => {
+        expect(toXtreamRecentlyAddedTimestamp('1779062400', now)).toBe(
+            Date.parse('2026-05-18T00:00:00.000Z')
+        );
+    });
+
+    it('treats the epoch unit threshold itself as milliseconds', () => {
+        expect(toXtreamRecentlyAddedTimestamp('10000000000', now)).toBe(
+            10_000_000_000
+        );
+    });
+
+    it('builds the query upper-bound with the same future grace window', () => {
+        expect(getXtreamRecentlyAddedMaxEpochSeconds(now)).toBe('1779235200');
+    });
+});

--- a/libs/shared/interfaces/src/lib/xtream-recently-added.utils.ts
+++ b/libs/shared/interfaces/src/lib/xtream-recently-added.utils.ts
@@ -1,0 +1,60 @@
+const EPOCH_MILLISECONDS_THRESHOLD = 10_000_000_000;
+
+export const XTREAM_RECENTLY_ADDED_FUTURE_GRACE_MS = 24 * 60 * 60 * 1000;
+
+function normalizeEpochNumber(value: number): number {
+    return value >= EPOCH_MILLISECONDS_THRESHOLD ? value : value * 1000;
+}
+
+function parseTimestampMs(value: unknown): number {
+    if (typeof value === 'number') {
+        return normalizeEpochNumber(value);
+    }
+
+    if (typeof value !== 'string') {
+        return 0;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return 0;
+    }
+
+    if (/^\d+$/.test(trimmed)) {
+        return normalizeEpochNumber(Number(trimmed));
+    }
+
+    return 0;
+}
+
+export function toXtreamRecentlyAddedTimestamp(
+    value: unknown,
+    nowMs = Date.now()
+): number {
+    const timestampMs = parseTimestampMs(value);
+    if (!Number.isFinite(timestampMs) || timestampMs <= 0) {
+        return 0;
+    }
+
+    if (timestampMs > nowMs + XTREAM_RECENTLY_ADDED_FUTURE_GRACE_MS) {
+        return 0;
+    }
+
+    return timestampMs;
+}
+
+export function toXtreamRecentlyAddedEpochSeconds(
+    value: unknown,
+    nowMs = Date.now()
+): string {
+    const timestampMs = toXtreamRecentlyAddedTimestamp(value, nowMs);
+    return timestampMs > 0 ? String(Math.floor(timestampMs / 1000)) : '';
+}
+
+export function getXtreamRecentlyAddedMaxEpochSeconds(
+    nowMs = Date.now()
+): string {
+    return String(
+        Math.floor((nowMs + XTREAM_RECENTLY_ADDED_FUTURE_GRACE_MS) / 1000)
+    );
+}


### PR DESCRIPTION
## Summary
- Prevent Xtream provider timestamps from the future from pinning content at the top of Recently Added.
- Normalize Recently Added timestamps so frontend sorting, Electron persistence/query behavior, and legacy cached values stay consistent.
- Add regression coverage for future timestamps, series date display, legacy millisecond cache migration, and import fallback behavior.

## Changes
- Add Xtream Recently Added timestamp helpers with a 24-hour future grace window.
- Filter future timestamps in the Electron global Recently Added query and sanitize imported content timestamps.
- Normalize legacy millisecond `content.added` values to epoch seconds during database startup.
- Filter invalid timestamps before slicing Recently Added rails and use series-aware date priority for displayed dates.
- Document the Xtream timestamp contract in date-handling architecture docs.

## Testing
- [x] `pnpm nx test shared-interfaces --runInBand`
- [x] `pnpm nx test database --runInBand`
- [x] `pnpm nx test portal-xtream-feature --runInBand`
- [x] `pnpm nx test electron-backend --runInBand`
- [x] `pnpm nx test portal-xtream-data-access --runInBand`
- [x] `pnpm nx run-many --target=lint --projects=shared-interfaces,database,portal-xtream-feature,electron-backend --parallel=4`
- [x] `pnpm run typecheck:web`
- [x] `pnpm run typecheck:backend`
- [x] `pnpm prettier --check apps/electron-backend/src/app/database/operations/content.operations.ts apps/electron-backend/src/app/database/operations/content.operations.spec.ts docs/architecture/date-handling.md libs/portal/xtream/feature/src/lib/recently-added/recently-added.component.ts libs/portal/xtream/feature/src/lib/recently-added/recently-added.component.html libs/portal/xtream/feature/src/lib/recently-added/recently-added.component.spec.ts libs/shared/database/src/lib/connection.ts libs/shared/database/src/lib/connection.spec.ts libs/shared/interfaces/src/lib/xtream-recently-added.utils.ts libs/shared/interfaces/src/lib/xtream-recently-added.utils.spec.ts`
- [x] `git diff --check`
- [x] `pnpm nx run electron-backend-e2e:e2e-ci--src/catalog-sorting.e2e.ts`
