### PR TITLE
refactor(playlists): move refresh action to ui boundary

### DIFF
--- a/libs/playlist/shared/ui/src/index.ts
+++ b/libs/playlist/shared/ui/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/playlist-switcher/playlist-switcher.component';
 export * from './lib/recent-playlists/playlist-info/playlist-info.component';
 export * from './lib/recent-playlists/recent-playlists.component';
 export * from './lib/recent-playlists/empty-state/empty-state.component';
+export * from './lib/playlist-refresh-action.service';

--- a/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts
@@ -7,12 +7,13 @@ import { TranslateService } from '@ngx-translate/core';
 import { DialogService } from '@iptvnator/ui/components';
 import {
     DatabaseService,
+    DbOperationEvent,
     PlaybackPositionService,
     PlaylistRefreshService,
 } from '@iptvnator/services';
 import { ChannelActions, PlaylistActions } from '@iptvnator/m3u-state';
 import { Playlist, PlaylistMeta } from '@iptvnator/shared/interfaces';
-import { PlaylistContextFacade } from './playlist-context.facade';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import { PlaylistRefreshActionService } from './playlist-refresh-action.service';
 
 function createDeferred<T>() {
@@ -343,7 +344,7 @@ describe('PlaylistRefreshActionService', () => {
                 _playlistId: string,
                 options?: {
                     operationId?: string;
-                    onEvent?: (event: any) => void;
+                    onEvent?: (event: DbOperationEvent) => void;
                 }
             ) => {
                 options?.onEvent?.({

--- a/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.ts
@@ -14,7 +14,7 @@ import {
 } from '@iptvnator/services';
 import { ChannelActions, PlaylistActions } from '@iptvnator/m3u-state';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
-import { PlaylistContextFacade } from './playlist-context.facade';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 
 export interface XtreamRefreshPreparationState {
     playlistId: string;

--- a/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.spec.ts
@@ -12,16 +12,14 @@ import { Store } from '@ngrx/store';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { PlaylistActions } from '@iptvnator/m3u-state';
-import {
-    PlaylistContextFacade,
-    PlaylistRefreshActionService,
-} from '@iptvnator/playlist/shared/util';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import { DialogService } from '@iptvnator/ui/components';
 import {
     PlaylistDeleteActionService,
     PortalStatusService,
 } from '@iptvnator/services';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
+import { PlaylistRefreshActionService } from '../playlist-refresh-action.service';
 import { PlaylistSwitcherComponent } from './playlist-switcher.component';
 
 const SEARCH_QUERY_STORAGE_KEY = 'playlist-switcher:search-query';

--- a/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.ts
@@ -27,10 +27,7 @@ import { normalizeDateLocale } from '@iptvnator/pipes';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { DialogService } from '@iptvnator/ui/components';
 import { PlaylistActions } from '@iptvnator/m3u-state';
-import {
-    PlaylistContextFacade,
-    PlaylistRefreshActionService,
-} from '@iptvnator/playlist/shared/util';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import {
     PlaylistDeleteActionService,
     PortalStatus,
@@ -38,6 +35,7 @@ import {
 } from '@iptvnator/services';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
 import { startWith } from 'rxjs';
+import { PlaylistRefreshActionService } from '../playlist-refresh-action.service';
 import { PlaylistInfoComponent } from '../recent-playlists/playlist-info/playlist-info.component';
 
 type PlaylistFilterType = 'm3u' | 'stalker' | 'xtream';

--- a/libs/playlist/shared/util/project.json
+++ b/libs/playlist/shared/util/project.json
@@ -4,7 +4,7 @@
     "sourceRoot": "libs/playlist/shared/util/src",
     "prefix": "lib",
     "projectType": "library",
-    "tags": ["scope:playlist", "domain:m3u", "type:util"],
+    "tags": ["scope:playlist", "domain:m3u", "type:data-access"],
     "targets": {
         "test": {
             "executor": "@nx/jest:jest",

--- a/libs/playlist/shared/util/src/index.ts
+++ b/libs/playlist/shared/util/src/index.ts
@@ -1,4 +1,3 @@
 export * from './lib/playlist-player-actions';
 export * from './lib/playlist-context.facade';
 export * from './lib/playlist-file-import.service';
-export * from './lib/playlist-refresh-action.service';

--- a/libs/workspace/dashboard/feature/src/lib/rails/workspace-dashboard-rails.component.ts
+++ b/libs/workspace/dashboard/feature/src/lib/rails/workspace-dashboard-rails.component.ts
@@ -21,8 +21,8 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import {
     EmptyStateComponent,
     PlaylistInfoComponent,
+    PlaylistRefreshActionService,
 } from '@iptvnator/playlist/shared/ui';
-import { PlaylistRefreshActionService } from '@iptvnator/playlist/shared/util';
 import {
     WORKSPACE_SHELL_ACTIONS,
     WorkspacePlaylistType,

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-xtream-import.service.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-xtream-import.service.ts
@@ -2,7 +2,7 @@ import { computed, inject, Injectable } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
 import { startWith } from 'rxjs';
-import { PlaylistRefreshActionService } from '@iptvnator/playlist/shared/util';
+import { PlaylistRefreshActionService } from '@iptvnator/playlist/shared/ui';
 import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
 import type { XtreamImportPhaseTone } from './helpers/workspace-shell-constants';
 import {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
@@ -6,10 +6,10 @@ import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import {
-    PlaylistContextFacade,
     PlaylistRefreshActionService,
     type XtreamRefreshPreparationState,
-} from '@iptvnator/playlist/shared/util';
+} from '@iptvnator/playlist/shared/ui';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import {
     PORTAL_EXTERNAL_PLAYBACK,
     WorkspaceHeaderContextService,

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
@@ -12,11 +12,11 @@ import { NavigationEnd, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { filter, firstValueFrom, startWith } from 'rxjs';
-import { PlaylistInfoComponent } from '@iptvnator/playlist/shared/ui';
 import {
-    PlaylistContextFacade,
+    PlaylistInfoComponent,
     PlaylistRefreshActionService,
-} from '@iptvnator/playlist/shared/util';
+} from '@iptvnator/playlist/shared/ui';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import {
     buildPortalRailLinks,
     PORTAL_EXTERNAL_PLAYBACK,
@@ -33,7 +33,11 @@ import {
     WorkspaceSearchCapability,
     WorkspaceStartupPreferencesService,
 } from '@iptvnator/workspace/shell/util';
-import { DownloadsService, PlaylistsService, SettingsStore } from '@iptvnator/services';
+import {
+    DownloadsService,
+    PlaylistsService,
+    SettingsStore,
+} from '@iptvnator/services';
 import { PlaylistActions, selectAllPlaylistsMeta } from '@iptvnator/m3u-state';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
 import {


### PR DESCRIPTION
## Summary
- move PlaylistRefreshActionService from playlist-shared-util to playlist-shared-ui because it owns dialog/snackbar/router refresh orchestration
- export the service from the playlist shared UI public API and update workspace/dashboard/shell imports
- retag playlist-shared-util as type:data-access to match its remaining Angular facade/store services and satisfy Nx boundaries

## Validation
- pnpm nx lint playlist-shared-util
- pnpm nx run-many -t lint -p playlist-shared-util,playlist-shared-ui,workspace-shell-feature,workspace-dashboard-feature --parallel=4
- pnpm nx test playlist-shared-util
- pnpm nx test playlist-shared-ui --runTestsByPath libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts
- pnpm nx test playlist-shared-ui --runTestsByPath libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.spec.ts
- pnpm nx test workspace-shell-feature --runTestsByPath libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
- pnpm nx test workspace-dashboard-feature --runTestsByPath libs/workspace/dashboard/feature/src/lib/rails/workspace-dashboard-rails.component.spec.ts
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache
- pnpm nx build web --configuration=pwa --skip-nx-cache

Notes: PWA build still reports existing SCSS budget/CommonJS warnings.