### PR TITLE
refactor(dashboard): use runtime activity capability

### DIFF
--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -23,6 +23,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEpg).toBe(false);
         expect(service.supportsSqlite).toBe(false);
         expect(service.supportsDownloads).toBe(false);
+        expect(service.supportsPortalActivityStorage).toBe(false);
         expect(service.supportsManagedExternalPlayers).toBe(false);
         expect(service.supportsEmbeddedMpv).toBe(false);
         expect(service.supportsDesktopFileSave).toBe(false);
@@ -36,6 +37,11 @@ describe('RuntimeCapabilitiesService', () => {
             dbUpsertAppPlaylist: jest.fn(),
             dbGetAppState: jest.fn(),
             dbSetAppState: jest.fn(),
+            dbGetRecentlyViewed: jest.fn(),
+            dbGetAllGlobalFavorites: jest.fn(),
+            dbGetGlobalRecentlyAdded: jest.fn(),
+            dbRemoveRecentItem: jest.fn(),
+            dbRemoveFavorite: jest.fn(),
             downloadsGetList: jest.fn(),
             prepareEmbeddedMpv: jest.fn(),
             saveFileDialog: jest.fn(),
@@ -55,6 +61,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEpg).toBe(true);
         expect(service.supportsSqlite).toBe(true);
         expect(service.supportsDownloads).toBe(true);
+        expect(service.supportsPortalActivityStorage).toBe(true);
         expect(service.supportsManagedExternalPlayers).toBe(true);
         expect(service.supportsEmbeddedMpv).toBe(true);
         expect(service.supportsDesktopFileSave).toBe(true);
@@ -74,6 +81,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEpg).toBe(true);
         expect(service.supportsSqlite).toBe(false);
         expect(service.supportsDownloads).toBe(false);
+        expect(service.supportsPortalActivityStorage).toBe(false);
         expect(service.supportsEmbeddedMpv).toBe(false);
         expect(service.supportsDesktopFileSave).toBe(false);
         expect(service.supportsRemoteControl).toBe(false);

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -48,6 +48,16 @@ export class RuntimeCapabilitiesService {
         return this.hasElectronMethod('downloadsGetList');
     }
 
+    get supportsPortalActivityStorage(): boolean {
+        return (
+            this.hasElectronMethod('dbGetRecentlyViewed') &&
+            this.hasElectronMethod('dbGetAllGlobalFavorites') &&
+            this.hasElectronMethod('dbGetGlobalRecentlyAdded') &&
+            this.hasElectronMethod('dbRemoveRecentItem') &&
+            this.hasElectronMethod('dbRemoveFavorite')
+        );
+    }
+
     get supportsManagedExternalPlayers(): boolean {
         return this.isElectron;
     }

--- a/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.spec.ts
+++ b/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.spec.ts
@@ -157,7 +157,13 @@ describe('DashboardDataService', () => {
 
     beforeEach(() => {
         Object.defineProperty(window, 'electron', {
-            value: {} as Window['electron'],
+            value: {
+                dbGetRecentlyViewed: jest.fn(),
+                dbGetAllGlobalFavorites: jest.fn(),
+                dbGetGlobalRecentlyAdded: jest.fn(),
+                dbRemoveRecentItem: jest.fn(),
+                dbRemoveFavorite: jest.fn(),
+            } as unknown as Window['electron'],
             configurable: true,
         });
         playlistsLoadedSignal.set(true);

--- a/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
+++ b/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
@@ -19,6 +19,7 @@ import {
     DatabaseService,
     GlobalRecentlyAddedKind,
     PlaylistsService,
+    RuntimeCapabilitiesService,
 } from '@iptvnator/services';
 import {
     XTREAM_DATA_SOURCE,
@@ -105,6 +106,7 @@ export class DashboardDataService {
     private readonly dbService = inject(DatabaseService);
     private readonly xtreamDataSource = inject(XTREAM_DATA_SOURCE);
     private readonly playlistsService = inject(PlaylistsService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly ngZone = inject(NgZone);
     private readonly translate = inject(TranslateService);
     private readonly playbackPositions = inject(PORTAL_PLAYBACK_POSITIONS);
@@ -158,7 +160,9 @@ export class DashboardDataService {
     );
     private readonly globalRecentLoadingState = signal(true);
     private readonly globalRecentLoadedState = signal(false);
-    private readonly globalRecentDbLoadedState = signal(!window.electron);
+    private readonly globalRecentDbLoadedState = signal(
+        !this.hasPortalActivityStorage
+    );
     private readonly globalFavoritesLoadingState = signal(true);
     private readonly globalFavoritesLoadedState = signal(false);
     private readonly xtreamRecentlyAddedLoadingState = signal(true);
@@ -185,6 +189,11 @@ export class DashboardDataService {
         this.xtreamRecentlyAddedLoadedState.asReadonly();
     readonly xtreamRecentlyAddedItems =
         this.xtreamRecentlyAddedItemsState.asReadonly();
+
+    private get hasPortalActivityStorage(): boolean {
+        return this.runtime.supportsPortalActivityStorage;
+    }
+
     readonly dashboardReady = computed(
         () =>
             this.playlistsLoaded() &&
@@ -479,7 +488,7 @@ export class DashboardDataService {
             this.globalRecentLoadingState.set(true);
         }
 
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             const recentItems = await this.loadPwaXtreamGlobalRecentItems();
             this.ngZone.run(() =>
                 this.xtreamGlobalRecentItems.set(recentItems)
@@ -523,7 +532,7 @@ export class DashboardDataService {
         kind: DashboardRecentlyAddedFilterKind,
         limit = 200
     ): Promise<DashboardRecentlyAddedItem[]> {
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             return [];
         }
 
@@ -536,7 +545,7 @@ export class DashboardDataService {
     async getXtreamRecentlyAddedItems(
         limit = 20
     ): Promise<DashboardRecentlyAddedItem[]> {
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             return [];
         }
 
@@ -555,7 +564,7 @@ export class DashboardDataService {
             this.xtreamRecentlyAddedLoadingState.set(true);
         }
 
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             this.ngZone.run(() => {
                 this.xtreamRecentlyAddedItemsState.set([]);
                 this.xtreamRecentlyAddedLoadingState.set(false);
@@ -584,7 +593,7 @@ export class DashboardDataService {
     }
 
     private async reloadXtreamGlobalFavorites(): Promise<void> {
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             const favorites = await this.loadPwaXtreamGlobalFavorites();
             this.ngZone.run(() => this.xtreamGlobalFavorites.set(favorites));
             this.finishInitialGlobalFavoritesLoadIfReady();
@@ -860,7 +869,7 @@ export class DashboardDataService {
 
     async removeGlobalRecentItem(item: GlobalRecentItem): Promise<void> {
         if (item.source === 'xtream') {
-            if (window.electron) {
+            if (this.hasPortalActivityStorage) {
                 await this.dbService.removeRecentItem(
                     item.id as number,
                     item.playlist_id
@@ -1021,7 +1030,7 @@ export class DashboardDataService {
 
     async removeGlobalFavorite(item: DashboardFavoriteItem): Promise<void> {
         if (item.source === 'xtream') {
-            if (window.electron) {
+            if (this.hasPortalActivityStorage) {
                 await this.dbService.removeFromFavorites(
                     item.id as number,
                     item.playlist_id


### PR DESCRIPTION
## Summary
- add `supportsPortalActivityStorage` to `RuntimeCapabilitiesService` using the actual dashboard activity bridge methods
- route dashboard global recent/favorites/recently-added data paths through the runtime capability instead of raw `window.electron` checks
- keep PWA dashboard activity paths on the active Xtream data source fallback

## Review Fixes
- fixed the capability probe to check `dbGetRecentlyViewed`, matching the preload/typings contract

## Validation
- pnpm nx test services --runTestsByPath libs/services/src/lib/runtime-capabilities.service.spec.ts
- pnpm nx test workspace-dashboard-data-access --runTestsByPath libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.spec.ts
- pnpm nx run-many -t lint -p services,workspace-dashboard-data-access --parallel=2 (passes with existing warnings)
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache (passes with existing Angular diagnostics warnings)
- pnpm nx build web --configuration=pwa --skip-nx-cache (passes with existing Angular diagnostics/budget/CommonJS warnings)
- git diff --check

Docs: no canonical docs changed; this is an internal runtime capability plumbing change.