### PR TITLE
refactor(workspace): use runtime shortcuts capability

### DIFF
--- a/libs/workspace/shell/feature/src/lib/workspace-keyboard-shortcuts/workspace-keyboard-shortcuts.service.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-keyboard-shortcuts/workspace-keyboard-shortcuts.service.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { WorkspaceKeyboardShortcutsService } from './workspace-keyboard-shortcuts.service';
 
 describe('WorkspaceKeyboardShortcutsService', () => {
     let afterClosed$: Subject<void>;
     let dialog: { open: jest.Mock };
+    let runtime: { isElectron: boolean };
     let service: WorkspaceKeyboardShortcutsService;
 
     beforeEach(() => {
@@ -15,11 +17,13 @@ describe('WorkspaceKeyboardShortcutsService', () => {
                 afterClosed: () => afterClosed$.asObservable(),
             }),
         };
+        runtime = { isElectron: true };
 
         TestBed.configureTestingModule({
             providers: [
                 WorkspaceKeyboardShortcutsService,
                 { provide: MatDialog, useValue: dialog },
+                { provide: RuntimeCapabilitiesService, useValue: runtime },
             ],
         });
 
@@ -92,5 +96,29 @@ describe('WorkspaceKeyboardShortcutsService', () => {
             'WORKSPACE.SHORTCUTS.PLATFORM.OTHER'
         );
         expect(commandPaletteShortcut?.chords[0].keys[0].label).toBe('Ctrl');
+    });
+
+    it('includes Electron-only shortcuts when runtime supports Electron', () => {
+        service.openShortcutsDialog();
+
+        const dialogData = dialog.open.mock.calls[0][1].data;
+        const itemIds = dialogData.groups.flatMap((group) =>
+            group.items.map((item) => item.id)
+        );
+
+        expect(itemIds).toContain('open-global-search');
+    });
+
+    it('uses runtime capabilities for Electron-only shortcuts', () => {
+        runtime.isElectron = false;
+
+        service.openShortcutsDialog();
+
+        const dialogData = dialog.open.mock.calls[0][1].data;
+        const itemIds = dialogData.groups.flatMap((group) =>
+            group.items.map((item) => item.id)
+        );
+
+        expect(itemIds).not.toContain('open-global-search');
     });
 });

--- a/libs/workspace/shell/feature/src/lib/workspace-keyboard-shortcuts/workspace-keyboard-shortcuts.service.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-keyboard-shortcuts/workspace-keyboard-shortcuts.service.ts
@@ -6,6 +6,7 @@ import {
     isKeyboardShortcutHelpTrigger,
     isTypingInInput,
 } from '@iptvnator/portal/shared/util';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import {
     WorkspaceKeyboardShortcutsDialogComponent,
     WorkspaceKeyboardShortcutsDialogData,
@@ -15,6 +16,7 @@ import {
 export class WorkspaceKeyboardShortcutsService {
     private readonly dialog = inject(MatDialog);
     private readonly destroyRef = inject(DestroyRef);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly onDocumentKeydown = (event: KeyboardEvent): void =>
         this.handleKeydown(event);
 
@@ -49,7 +51,7 @@ export class WorkspaceKeyboardShortcutsService {
             data: {
                 groups: getKeyboardShortcutGroups({
                     isMac: platform === 'mac',
-                    isElectron: this.isElectron(),
+                    isElectron: this.runtime.isElectron,
                 }),
                 platformIcon:
                     platform === 'mac' ? 'laptop_mac' : 'desktop_windows',
@@ -93,7 +95,4 @@ export class WorkspaceKeyboardShortcutsService {
         return /Mac|iPhone|iPad|iPod/i.test(platform) ? 'mac' : 'other';
     }
 
-    private isElectron(): boolean {
-        return typeof window !== 'undefined' && !!window.electron;
-    }
 }


### PR DESCRIPTION
## Summary
- inject `RuntimeCapabilitiesService` into workspace keyboard shortcut help
- gate Electron-only shortcut rows from runtime capabilities instead of raw `window.electron`
- add shortcut-dialog coverage for both Electron-present and non-Electron runtime paths

## Review Fixes
- added a positive assertion that `open-global-search` is present when Electron runtime support is enabled

## Validation
- pnpm nx test workspace-shell-feature --runTestsByPath libs/workspace/shell/feature/src/lib/workspace-keyboard-shortcuts/workspace-keyboard-shortcuts.service.spec.ts
- pnpm nx lint workspace-shell-feature
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache (passes with existing Angular diagnostics warnings)
- pnpm nx build web --configuration=pwa --skip-nx-cache (passes with existing Angular diagnostics/budget/CommonJS warnings)
- git diff --check

Docs: no canonical docs changed; this is internal runtime capability plumbing for the shortcut help surface.