### PR TITLE
refactor(workspace): use runtime player capability

### DIFF
--- a/libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.spec.ts
@@ -7,7 +7,7 @@ import {
     WorkspaceCommandContribution,
     WorkspaceViewCommandService,
 } from '@iptvnator/portal/shared/util';
-import { SettingsStore } from '@iptvnator/services';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import { VideoPlayer } from '@iptvnator/shared/interfaces';
 import { WorkspacePlayerCommandsContributor } from './workspace-player-commands.contributor';
 
@@ -46,16 +46,10 @@ describe('WorkspacePlayerCommandsContributor', () => {
     let viewCommands: ViewCommandsMock;
     let settingsStore: SettingsStoreMock;
     let snackBar: SnackBarMock;
+    let runtime: { supportsManagedExternalPlayers: boolean };
     let translate: { instant: jest.Mock; onLangChange: ReturnType<typeof of> };
 
-    function bootstrap(options: { isDesktop: boolean }) {
-        if (options.isDesktop) {
-            window.electron = { platform: 'darwin' } as typeof window.electron;
-        } else {
-            // @ts-expect-error - simulating PWA environment
-            window.electron = undefined;
-        }
-
+    function bootstrap(options: { supportsManagedExternalPlayers: boolean }) {
         viewCommands = {
             registerCommand: jest.fn().mockReturnValue(() => undefined),
             commands: jest.fn().mockReturnValue([]),
@@ -65,6 +59,10 @@ describe('WorkspacePlayerCommandsContributor', () => {
             updateSettings: jest.fn().mockResolvedValue(undefined),
         };
         snackBar = { open: jest.fn() };
+        runtime = {
+            supportsManagedExternalPlayers:
+                options.supportsManagedExternalPlayers,
+        };
         translate = {
             instant: jest.fn(
                 (key: string, params?: Record<string, string | number>) =>
@@ -83,6 +81,7 @@ describe('WorkspacePlayerCommandsContributor', () => {
                     useValue: viewCommands,
                 },
                 { provide: SettingsStore, useValue: settingsStore },
+                { provide: RuntimeCapabilitiesService, useValue: runtime },
                 { provide: MatSnackBar, useValue: snackBar },
                 { provide: TranslateService, useValue: translate },
             ],
@@ -96,7 +95,7 @@ describe('WorkspacePlayerCommandsContributor', () => {
     });
 
     it('registers all five player commands when running in Electron', () => {
-        bootstrap({ isDesktop: true });
+        bootstrap({ supportsManagedExternalPlayers: true });
 
         const ids = getRegistered(viewCommands).map((c) => c.id);
         expect(ids).toEqual([
@@ -108,8 +107,8 @@ describe('WorkspacePlayerCommandsContributor', () => {
         ]);
     });
 
-    it('hides MPV and VLC when window.electron is unavailable', () => {
-        bootstrap({ isDesktop: false });
+    it('hides MPV and VLC when managed external players are unavailable', () => {
+        bootstrap({ supportsManagedExternalPlayers: false });
 
         const registered = getRegistered(viewCommands);
         const visibilityById = Object.fromEntries(
@@ -124,7 +123,7 @@ describe('WorkspacePlayerCommandsContributor', () => {
     });
 
     it('marks the active player command as disabled', () => {
-        bootstrap({ isDesktop: true });
+        bootstrap({ supportsManagedExternalPlayers: true });
         settingsStore.player.set(VideoPlayer.MPV);
 
         const registered = getRegistered(viewCommands);
@@ -138,7 +137,7 @@ describe('WorkspacePlayerCommandsContributor', () => {
     });
 
     it('updates settings and shows feedback on run', () => {
-        bootstrap({ isDesktop: true });
+        bootstrap({ supportsManagedExternalPlayers: true });
 
         const mpvCommand = getRegistered(viewCommands).find(
             (c) => c.id === 'switch-player-mpv'

--- a/libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.ts
@@ -5,7 +5,7 @@ import {
     WorkspaceCommandContribution,
     WorkspaceViewCommandService,
 } from '@iptvnator/portal/shared/util';
-import { SettingsStore } from '@iptvnator/services';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import { VideoPlayer } from '@iptvnator/shared/interfaces';
 
 interface PlayerCommandDefinition {
@@ -73,8 +73,7 @@ export class WorkspacePlayerCommandsContributor {
     private readonly snackBar = inject(MatSnackBar);
     private readonly translate = inject(TranslateService);
     private readonly destroyRef = inject(DestroyRef);
-
-    private readonly isDesktop = !!window.electron;
+    private readonly runtime = inject(RuntimeCapabilitiesService);
 
     constructor() {
         const unregisters = PLAYER_COMMAND_DEFS.map((def) =>
@@ -106,7 +105,8 @@ export class WorkspacePlayerCommandsContributor {
                 this.translate.instant(def.nameKey).toLowerCase(),
             ],
             priority: def.priority,
-            visible: () => !def.desktopOnly || this.isDesktop,
+            visible: () =>
+                !def.desktopOnly || this.runtime.supportsManagedExternalPlayers,
             enabled: () => this.settingsStore.player() !== def.player,
             run: () => this.activate(def),
         };


### PR DESCRIPTION
## Summary
- inject `RuntimeCapabilitiesService` into workspace player commands
- gate MPV/VLC workspace command visibility on `supportsManagedExternalPlayers` instead of raw Electron detection
- update command tests to mock runtime player capabilities directly

## Validation
- pnpm nx test workspace-shell-feature --runTestsByPath libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.spec.ts
- pnpm nx lint workspace-shell-feature
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache (passes with existing Angular diagnostics warnings)
- pnpm nx build web --configuration=pwa --skip-nx-cache (passes with existing Angular diagnostics/budget/CommonJS warnings)
- git diff --check

Docs: no canonical docs changed; this is internal runtime capability plumbing for workspace command visibility.