### PR TITLE
refactor(import): use runtime capability for url hint

### DIFF
--- a/libs/playlist/import/feature/src/lib/url-upload/url-upload.component.spec.ts
+++ b/libs/playlist/import/feature/src/lib/url-upload/url-upload.component.spec.ts
@@ -4,13 +4,21 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockModule } from 'ng-mocks';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { UrlUploadComponent } from './url-upload.component';
 
 describe('UrlUploadComponent', () => {
     let component: UrlUploadComponent;
     let fixture: ComponentFixture<UrlUploadComponent>;
+    let runtime: {
+        isElectron: boolean;
+    };
 
     beforeEach(waitForAsync(() => {
+        runtime = {
+            isElectron: true,
+        };
+
         TestBed.configureTestingModule({
             imports: [
                 UrlUploadComponent,
@@ -19,6 +27,12 @@ describe('UrlUploadComponent', () => {
                 MockModule(ReactiveFormsModule),
                 TranslateModule.forRoot(),
                 NoopAnimationsModule,
+            ],
+            providers: [
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtime,
+                },
             ],
         }).compileComponents();
     }));
@@ -31,6 +45,22 @@ describe('UrlUploadComponent', () => {
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    it('shows the CORS note only when Electron is unavailable', () => {
+        expect(
+            (fixture.nativeElement as HTMLElement).querySelector('.cors-note')
+        ).toBeNull();
+
+        fixture.destroy();
+        runtime.isElectron = false;
+        fixture = TestBed.createComponent(UrlUploadComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+
+        expect(
+            (fixture.nativeElement as HTMLElement).querySelector('.cors-note')
+        ).not.toBeNull();
     });
 
     it('accepts an optional playlist name without affecting url validation', () => {

--- a/libs/playlist/import/feature/src/lib/url-upload/url-upload.component.ts
+++ b/libs/playlist/import/feature/src/lib/url-upload/url-upload.component.ts
@@ -9,6 +9,7 @@ import {
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { TranslatePipe } from '@ngx-translate/core';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 
 @Component({
     selector: 'app-url-upload',
@@ -22,12 +23,13 @@ import { TranslatePipe } from '@ngx-translate/core';
 })
 export class UrlUploadComponent implements OnInit {
     private readonly fb = inject(FormBuilder);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
 
     form!: FormGroup<{
         playlistName: FormControl<string>;
         playlistUrl: FormControl<string>;
     }>;
-    readonly isDesktop = !!window.electron;
+    readonly isDesktop = this.runtime.isElectron;
 
     ngOnInit(): void {
         const urlRegex = '(https?://.*?)';


### PR DESCRIPTION
## Summary
- inject `RuntimeCapabilitiesService` into URL playlist import
- show the CORS/import URL note only when Electron support is unavailable
- add URL upload coverage for Electron vs PWA runtime states

## Review Fixes
- refreshed the local `component` reference after recreating the fixture in the CORS note spec

## Validation
- pnpm nx test playlist-import-feature --runTestsByPath libs/playlist/import/feature/src/lib/url-upload/url-upload.component.spec.ts
- pnpm nx lint playlist-import-feature (passes with existing Stalker import warnings)
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache (passes with existing Angular diagnostics warnings)
- pnpm nx build web --configuration=pwa --skip-nx-cache (passes with existing Angular diagnostics/budget/CommonJS warnings)
- git diff --check

Docs: no canonical docs changed; this is a copy/gating behavior already covered by the existing import UI.