### PR TITLE
refactor(app): use runtime capabilities for shell gates

### DIFF
--- a/apps/web/src/app/app.component.spec.ts
+++ b/apps/web/src/app/app.component.spec.ts
@@ -8,7 +8,7 @@ import { EpgService } from '@iptvnator/epg/data-access';
 import { WORKSPACE_SHELL_ACTIONS } from '@iptvnator/workspace/shell/util';
 import { MockProvider } from 'ng-mocks';
 import { EMPTY, of } from 'rxjs';
-import { DataService } from '@iptvnator/services';
+import { DataService, RuntimeCapabilitiesService } from '@iptvnator/services';
 import {
     Language,
     Settings,
@@ -64,9 +64,16 @@ describe('AppComponent', () => {
     let snackBar: MatSnackBar;
     let store: MockStore;
     let translateService: TranslateService;
+    let runtimeCapabilities: Partial<RuntimeCapabilitiesService>;
     const originalElectron = window.electron;
 
     beforeEach(waitForAsync(() => {
+        runtimeCapabilities = {
+            isElectron: true,
+            isMacOS: false,
+            supportsEpg: true,
+        };
+
         TestBed.configureTestingModule({
             imports: [AppComponent],
             providers: [
@@ -82,6 +89,10 @@ describe('AppComponent', () => {
                 {
                     provide: SettingsService,
                     useClass: MockSettingsService,
+                },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtimeCapabilities as RuntimeCapabilitiesService,
                 },
                 MockProvider(EpgService, {
                     fetchEpg: jest.fn(),
@@ -211,5 +222,20 @@ describe('AppComponent', () => {
         expect(checkEpgFreshness).toHaveBeenCalledWith(settings.epgUrl, 12);
         expect(epgService.fetchEpg).toHaveBeenCalledWith(settings.epgUrl);
         expect(snackBar.open).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch EPG settings when runtime does not support EPG', async () => {
+        const settings: Settings = {
+            ...DEFAULT_SETTINGS,
+            epgUrl: ['https://example.com/epg.xml'],
+        };
+        Object.assign(runtimeCapabilities, { supportsEpg: false });
+        settingsService.getValueFromLocalStorage.mockReturnValue(of(settings));
+
+        component.initSettings();
+        await fixture.whenStable();
+
+        expect(window.electron?.checkEpgFreshness).not.toHaveBeenCalled();
+        expect(epgService.fetchEpg).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -9,7 +9,11 @@ import { WORKSPACE_SHELL_ACTIONS } from '@iptvnator/workspace/shell/util';
 import { EpgProgressPanelComponent } from '@iptvnator/ui/epg/progress-panel';
 import { PlaylistActions, selectAllPlaylistsMeta } from '@iptvnator/m3u-state';
 import { filter, take } from 'rxjs';
-import { DataService, SettingsStore } from '@iptvnator/services';
+import {
+    DataService,
+    RuntimeCapabilitiesService,
+    SettingsStore,
+} from '@iptvnator/services';
 import {
     AUTO_UPDATE_PLAYLISTS,
     Language,
@@ -30,9 +34,7 @@ const debugAppComponent = createDevLogger('AppComponent');
 })
 export class AppComponent implements OnInit {
     @HostBinding('class.macos-platform') get isMacOS() {
-        return (
-            window.electron && navigator.platform.toLowerCase().includes('mac')
-        );
+        return this.runtime.isMacOS;
     }
     private actions$ = inject(Actions);
     private dataService = inject(DataService);
@@ -43,6 +45,7 @@ export class AppComponent implements OnInit {
     private translate = inject(TranslateService);
     private settingsService = inject(SettingsService);
     private settingsStore = inject(SettingsStore);
+    private runtime = inject(RuntimeCapabilitiesService);
     private readonly workspaceShellActions = inject(WORKSPACE_SHELL_ACTIONS);
 
     /** Default language as fallback */
@@ -75,7 +78,7 @@ export class AppComponent implements OnInit {
             document.documentElement.dataset.coverSize = size;
         });
 
-        if (window.electron) {
+        if (this.runtime.isElectron) {
             document.addEventListener('keydown', (event) => {
                 if (event.ctrlKey || event.metaKey) {
                     if (event.key === 'f') {
@@ -128,7 +131,7 @@ export class AppComponent implements OnInit {
 
                     // Fetch EPG if URLs are configured (only fetch stale data)
                     if (
-                        window.electron &&
+                        this.runtime.supportsEpg &&
                         settings.epgUrl?.length > 0 &&
                         settings.epgUrl?.some((u) => u !== '')
                     ) {


### PR DESCRIPTION
## Summary
- inject `RuntimeCapabilitiesService` into `AppComponent`
- gate macOS host class, workspace shell keyboard shortcuts, and EPG startup fetching through runtime capabilities
- add AppComponent coverage for runtimes where EPG is unavailable
- address review feedback by typing the runtime capability mock as `Partial<RuntimeCapabilitiesService>`

## Validation
- pnpm nx test web -- --runTestsByPath apps/web/src/app/app.component.spec.ts
- pnpm nx lint web
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache (passes with existing Angular diagnostics warnings)
- pnpm nx build web --configuration=pwa --skip-nx-cache (passes with existing Angular diagnostics/budget/CommonJS warnings)
- git diff --check

Docs: no canonical docs changed; this is internal runtime capability plumbing for app shell gates.