### PR TITLE
refactor(settings): use runtime capabilities for platform state

### DIFF
--- a/apps/web/src/app/app.component.spec.ts
+++ b/apps/web/src/app/app.component.spec.ts
@@ -8,7 +8,7 @@ import { EpgService } from '@iptvnator/epg/data-access';
 import { WORKSPACE_SHELL_ACTIONS } from '@iptvnator/workspace/shell/util';
 import { MockProvider } from 'ng-mocks';
 import { EMPTY, of } from 'rxjs';
-import { DataService } from '@iptvnator/services';
+import { DataService, RuntimeCapabilitiesService } from '@iptvnator/services';
 import {
     Language,
     Settings,
@@ -64,9 +64,20 @@ describe('AppComponent', () => {
     let snackBar: MatSnackBar;
     let store: MockStore;
     let translateService: TranslateService;
+    let runtimeCapabilities: {
+        isElectron: boolean;
+        isMacOS: boolean;
+        supportsEpg: boolean;
+    };
     const originalElectron = window.electron;
 
     beforeEach(waitForAsync(() => {
+        runtimeCapabilities = {
+            isElectron: true,
+            isMacOS: false,
+            supportsEpg: true,
+        };
+
         TestBed.configureTestingModule({
             imports: [AppComponent],
             providers: [
@@ -82,6 +93,10 @@ describe('AppComponent', () => {
                 {
                     provide: SettingsService,
                     useClass: MockSettingsService,
+                },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtimeCapabilities,
                 },
                 MockProvider(EpgService, {
                     fetchEpg: jest.fn(),
@@ -211,5 +226,20 @@ describe('AppComponent', () => {
         expect(checkEpgFreshness).toHaveBeenCalledWith(settings.epgUrl, 12);
         expect(epgService.fetchEpg).toHaveBeenCalledWith(settings.epgUrl);
         expect(snackBar.open).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch EPG settings when runtime does not support EPG', async () => {
+        const settings: Settings = {
+            ...DEFAULT_SETTINGS,
+            epgUrl: ['https://example.com/epg.xml'],
+        };
+        runtimeCapabilities.supportsEpg = false;
+        settingsService.getValueFromLocalStorage.mockReturnValue(of(settings));
+
+        component.initSettings();
+        await fixture.whenStable();
+
+        expect(window.electron?.checkEpgFreshness).not.toHaveBeenCalled();
+        expect(epgService.fetchEpg).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -49,14 +49,16 @@ export class AppComponent implements OnInit {
     private readonly DEFAULT_LANG = Language.ENGLISH;
 
     constructor() {
+        const electronProcess = this.dataService.remote?.process;
         if (
-            ((this.dataService.isElectron &&
-                this.dataService?.remote?.process.platform === 'linux') ||
-                this.dataService?.remote?.process.platform === 'win32') &&
-            this.dataService.remote.process.argv.length > 2
+            this.dataService.isElectron &&
+            electronProcess &&
+            (electronProcess.platform === 'linux' ||
+                electronProcess.platform === 'win32') &&
+            electronProcess.argv.length > 2
         ) {
-            const filePath = this.dataService.remote.process.argv.find(
-                (filepath) =>
+            const filePath = electronProcess.argv.find(
+                (filepath: string) =>
                     filepath.endsWith('.m3u') || filepath.endsWith('.m3u8')
             );
             if (filePath) {
@@ -102,7 +104,7 @@ export class AppComponent implements OnInit {
      */
     initSettings(): void {
         this.settingsService
-            .getValueFromLocalStorage(STORE_KEY.Settings)
+            .getValueFromLocalStorage<Settings>(STORE_KEY.Settings)
             .subscribe((settings: Settings) => {
                 if (settings && Object.keys(settings).length > 0) {
                     // No need to send settings to Electron on init

--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -9,7 +9,11 @@ import { WORKSPACE_SHELL_ACTIONS } from '@iptvnator/workspace/shell/util';
 import { EpgProgressPanelComponent } from '@iptvnator/ui/epg/progress-panel';
 import { PlaylistActions, selectAllPlaylistsMeta } from '@iptvnator/m3u-state';
 import { filter, take } from 'rxjs';
-import { DataService, SettingsStore } from '@iptvnator/services';
+import {
+    DataService,
+    RuntimeCapabilitiesService,
+    SettingsStore,
+} from '@iptvnator/services';
 import {
     AUTO_UPDATE_PLAYLISTS,
     Language,
@@ -30,9 +34,7 @@ const debugAppComponent = createDevLogger('AppComponent');
 })
 export class AppComponent implements OnInit {
     @HostBinding('class.macos-platform') get isMacOS() {
-        return (
-            window.electron && navigator.platform.toLowerCase().includes('mac')
-        );
+        return this.runtime.isMacOS;
     }
     private actions$ = inject(Actions);
     private dataService = inject(DataService);
@@ -43,6 +45,7 @@ export class AppComponent implements OnInit {
     private translate = inject(TranslateService);
     private settingsService = inject(SettingsService);
     private settingsStore = inject(SettingsStore);
+    private runtime = inject(RuntimeCapabilitiesService);
     private readonly workspaceShellActions = inject(WORKSPACE_SHELL_ACTIONS);
 
     /** Default language as fallback */
@@ -75,7 +78,7 @@ export class AppComponent implements OnInit {
             document.documentElement.dataset.coverSize = size;
         });
 
-        if (window.electron) {
+        if (this.runtime.isElectron) {
             document.addEventListener('keydown', (event) => {
                 if (event.ctrlKey || event.metaKey) {
                     if (event.key === 'f') {
@@ -128,7 +131,7 @@ export class AppComponent implements OnInit {
 
                     // Fetch EPG if URLs are configured (only fetch stale data)
                     if (
-                        window.electron &&
+                        this.runtime.supportsEpg &&
                         settings.epgUrl?.length > 0 &&
                         settings.epgUrl?.some((u) => u !== '')
                     ) {

--- a/apps/web/src/app/services/electron.service.ts
+++ b/apps/web/src/app/services/electron.service.ts
@@ -117,7 +117,7 @@ export class ElectronService extends DataService {
         payload?: unknown
     ): Promise<T> {
         if (type === PLAYLIST_PARSE_BY_URL) {
-            this.fetchM3uPlaylistFromUrl(payload);
+            this.fetchM3uPlaylistFromUrl(payload as Partial<Playlist>);
             return undefined as T;
         }
 
@@ -156,7 +156,7 @@ export class ElectronService extends DataService {
                     data.url,
                     data.title ?? '',
                     data.thumbnail ?? '',
-                    data['user-agent'] ?? undefined,
+                    data['user-agent'] ?? '',
                     data.referer ?? undefined,
                     data.origin ?? undefined,
                     data.contentInfo,
@@ -185,7 +185,7 @@ export class ElectronService extends DataService {
                     data.url,
                     data.title ?? '',
                     data.thumbnail ?? '',
-                    data['user-agent'] ?? undefined,
+                    data['user-agent'] ?? '',
                     data.referer ?? undefined,
                     data.origin ?? undefined,
                     data.contentInfo,
@@ -219,7 +219,7 @@ export class ElectronService extends DataService {
                 this.translateService.instant(
                     'HOME.PLAYLISTS.AUTO_REFRESH_UPDATE_SUCCESS'
                 ),
-                null,
+                undefined,
                 { duration: 2000 }
             );
             return playlists as T;
@@ -266,6 +266,10 @@ export class ElectronService extends DataService {
     }
 
     private async fetchM3uPlaylistFromUrl(payload: Partial<Playlist>) {
+        if (!payload.url) {
+            return;
+        }
+
         const title = payload.title?.trim() || undefined;
 
         window.electron
@@ -353,7 +357,7 @@ export class ElectronService extends DataService {
                 this.translateService.instant(
                     'HOME.PLAYLISTS.PLAYLIST_UPDATE_SUCCESS'
                 ),
-                null,
+                undefined,
                 { duration: 2000 }
             );
         } catch (error: unknown) {

--- a/apps/web/src/app/services/pwa.service.spec.ts
+++ b/apps/web/src/app/services/pwa.service.spec.ts
@@ -1,0 +1,78 @@
+import {
+    HttpClientTestingModule,
+    HttpTestingController,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { SwUpdate } from '@angular/service-worker';
+import { Store } from '@ngrx/store';
+import { TranslateService } from '@ngx-translate/core';
+import { EMPTY } from 'rxjs';
+import {
+    PLAYLIST_PARSE_BY_URL,
+    PLAYLIST_UPDATE,
+} from '@iptvnator/shared/interfaces';
+import { PwaService } from './pwa.service';
+
+describe('PwaService', () => {
+    let http: HttpTestingController;
+    let service: PwaService;
+
+    beforeEach(() => {
+        jest.spyOn(console, 'log').mockImplementation(() => undefined);
+
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [
+                PwaService,
+                {
+                    provide: MatSnackBar,
+                    useValue: {
+                        open: jest.fn(),
+                    },
+                },
+                {
+                    provide: Store,
+                    useValue: {
+                        dispatch: jest.fn(),
+                    },
+                },
+                {
+                    provide: SwUpdate,
+                    useValue: {
+                        versionUpdates: EMPTY,
+                    },
+                },
+                {
+                    provide: TranslateService,
+                    useValue: {
+                        instant: jest.fn((key: string) => key),
+                    },
+                },
+            ],
+        });
+
+        http = TestBed.inject(HttpTestingController);
+        service = TestBed.inject(PwaService);
+    });
+
+    afterEach(() => {
+        http.verify();
+        jest.restoreAllMocks();
+    });
+
+    it('ignores URL imports without a URL instead of calling the backend', () => {
+        service.sendIpcEvent(PLAYLIST_PARSE_BY_URL, {});
+
+        expect(http.match(() => true)).toHaveLength(0);
+    });
+
+    it('ignores playlist refreshes without a URL or id instead of calling the backend', () => {
+        service.sendIpcEvent(PLAYLIST_UPDATE, { id: 'playlist-1' });
+        service.sendIpcEvent(PLAYLIST_UPDATE, {
+            url: 'https://example.test/playlist.m3u',
+        });
+
+        expect(http.match(() => true)).toHaveLength(0);
+    });
+});

--- a/apps/web/src/app/services/pwa.service.ts
+++ b/apps/web/src/app/services/pwa.service.ts
@@ -5,7 +5,14 @@ import { SwUpdate } from '@angular/service-worker';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { PlaylistActions } from '@iptvnator/m3u-state';
-import { catchError, firstValueFrom, from, switchMap, throwError } from 'rxjs';
+import {
+    catchError,
+    firstValueFrom,
+    from,
+    Observable,
+    switchMap,
+    throwError,
+} from 'rxjs';
 import { DataService } from '@iptvnator/services';
 import {
     ERROR,
@@ -108,12 +115,12 @@ export class PwaService extends DataService {
      */
     sendIpcEvent<T = unknown>(type: string, payload?: unknown): T {
         if (type === PLAYLIST_PARSE_BY_URL) {
-            this.fetchFromUrl(payload);
+            this.fetchFromUrl(payload as Partial<Playlist>);
             return undefined as T;
         }
 
         if (type === PLAYLIST_UPDATE) {
-            this.refreshPlaylist(payload);
+            this.refreshPlaylist(payload as Partial<Playlist & { id: string }>);
             return undefined as T;
         }
 
@@ -138,6 +145,10 @@ export class PwaService extends DataService {
     }
 
     refreshPlaylist(payload: Partial<Playlist & { id: string }>) {
+        if (!payload.url || !payload.id) {
+            return;
+        }
+
         this.getPlaylistFromUrl(payload.url)
             .pipe(
                 catchError((error) => {
@@ -163,7 +174,7 @@ export class PwaService extends DataService {
                     this.translateService.instant(
                         'HOME.PLAYLISTS.PLAYLIST_UPDATE_SUCCESS'
                     ),
-                    null,
+                    undefined,
                     { duration: 2000 }
                 );
             });
@@ -193,13 +204,19 @@ export class PwaService extends DataService {
      * @param payload playlist payload
      */
     fetchFromUrl(payload: Partial<Playlist>): void {
+        if (!payload.url) {
+            return;
+        }
+
         const title = payload.title?.trim() || undefined;
 
         this.getPlaylistFromUrl(payload.url)
             .pipe(
                 catchError((error) => {
                     this.snackBar.open(
-                        this.getErrorMessageByStatusCode(error.status),
+                        this.getErrorMessageByStatusCode(
+                            this.extractHttpStatusCode(error)
+                        ),
                         'Close',
                         {
                             duration: 5000,
@@ -226,7 +243,7 @@ export class PwaService extends DataService {
             });
     }
 
-    getErrorMessageByStatusCode(status: number) {
+    getErrorMessageByStatusCode(status: number | null | undefined) {
         let messageKey = 'HOME.URL_UPLOAD.ERROR_FETCH_FAILED';
         switch (status) {
             case 413:
@@ -524,10 +541,10 @@ export class PwaService extends DataService {
         }
     }
 
-    getPlaylistFromUrl(url: string) {
+    getPlaylistFromUrl(url: string): Observable<Playlist> {
         return from(this.getProviderTargetId(url)).pipe(
             switchMap((targetId) =>
-                this.http.get(`${this.corsProxyUrl}/parse`, {
+                this.http.get<Playlist>(`${this.corsProxyUrl}/parse`, {
                     params: { targetId },
                 })
             )

--- a/apps/web/src/app/services/settings.service.ts
+++ b/apps/web/src/app/services/settings.service.ts
@@ -147,8 +147,8 @@ export class SettingsService {
      * @param key key to get
      * @returns returns the value of the given key
      */
-    getValueFromLocalStorage(key: STORE_KEY) {
-        return this.storage.get(key);
+    getValueFromLocalStorage<T = unknown>(key: STORE_KEY): Observable<T> {
+        return this.storage.get(key) as Observable<T>;
     }
 
     /**

--- a/apps/web/src/app/settings/settings.component.spec.ts
+++ b/apps/web/src/app/settings/settings.component.spec.ts
@@ -702,6 +702,10 @@ describe('SettingsComponent', () => {
             .mockResolvedValue(undefined);
         browserFixture.detectChanges();
 
+        expect(browserComponent.isDesktop).toBe(false);
+        expect(browserComponent.isPwa).toBe(true);
+        expect(browserComponent.settingsForm.get('epgUrl')).toBeNull();
+
         mockStore.overrideSelector(selectAllPlaylistsMeta, [
             createPlaylistMeta({ _id: 'browser-m3u' }),
         ]);

--- a/apps/web/src/app/settings/settings.component.ts
+++ b/apps/web/src/app/settings/settings.component.ts
@@ -42,6 +42,7 @@ import {
     PlaylistBackupImportSummary,
     PlaylistBackupService,
     PlaylistsService,
+    RuntimeCapabilitiesService,
 } from '@iptvnator/services';
 import {
     EmbeddedMpvSupport,
@@ -119,6 +120,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     private matDialog = inject(MatDialog);
     private playlistBackupService = inject(PlaylistBackupService);
     private readonly databaseService = inject(DatabaseService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly dialogData = inject<{ isDialog: boolean } | null>(
         MAT_DIALOG_DATA,
         { optional: true }
@@ -132,13 +134,13 @@ export class SettingsComponent implements OnInit, OnDestroy {
     readonly streamFormatEnum = StreamFormat;
 
     /** Flag that indicates whether the app runs in electron environment */
-    readonly isDesktop = !!window.electron;
+    readonly isDesktop = this.runtime.isElectron;
     readonly embeddedMpvSupport = signal<EmbeddedMpvSupport | null>(null);
     readonly supportsEmbeddedMpv = computed(
         () => this.isDesktop && !!this.embeddedMpvSupport()?.supported
     );
 
-    isPwa = this.dataService.getAppEnvironment() === 'pwa';
+    readonly isPwa = this.runtime.isPwa;
 
     private readonly settingsCtx = inject(SettingsContextService);
     readonly activeSection = this.settingsCtx.activeSection;

--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -64,6 +64,13 @@ The PWA continues to use `PwaService`; only the backend base URL is resolved at
 runtime. Electron routes remain owned by the Electron backend and preload
 bridge.
 
+Renderer code that needs to branch by runtime should use
+`RuntimeCapabilitiesService` from `@iptvnator/services` instead of adding new
+direct `window.electron` or `DataService.getAppEnvironment()` checks. Keep
+feature decisions expressed as capabilities such as `supportsEpg`,
+`supportsSqlite`, `supportsDownloads`, or `supportsManagedExternalPlayers` so
+PWA and Electron behavior stays auditable from one shared boundary.
+
 ## Runtime Limitations
 
 The self-hosted build is the browser PWA, not the Electron desktop app. Keep

--- a/libs/playlist/import/feature/src/lib/url-upload/url-upload.component.spec.ts
+++ b/libs/playlist/import/feature/src/lib/url-upload/url-upload.component.spec.ts
@@ -4,13 +4,21 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockModule } from 'ng-mocks';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { UrlUploadComponent } from './url-upload.component';
 
 describe('UrlUploadComponent', () => {
     let component: UrlUploadComponent;
     let fixture: ComponentFixture<UrlUploadComponent>;
+    let runtime: {
+        isElectron: boolean;
+    };
 
     beforeEach(waitForAsync(() => {
+        runtime = {
+            isElectron: true,
+        };
+
         TestBed.configureTestingModule({
             imports: [
                 UrlUploadComponent,
@@ -19,6 +27,12 @@ describe('UrlUploadComponent', () => {
                 MockModule(ReactiveFormsModule),
                 TranslateModule.forRoot(),
                 NoopAnimationsModule,
+            ],
+            providers: [
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtime,
+                },
             ],
         }).compileComponents();
     }));
@@ -31,6 +45,21 @@ describe('UrlUploadComponent', () => {
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    it('shows the CORS note only when Electron is unavailable', () => {
+        expect(
+            (fixture.nativeElement as HTMLElement).querySelector('.cors-note')
+        ).toBeNull();
+
+        fixture.destroy();
+        runtime.isElectron = false;
+        fixture = TestBed.createComponent(UrlUploadComponent);
+        fixture.detectChanges();
+
+        expect(
+            (fixture.nativeElement as HTMLElement).querySelector('.cors-note')
+        ).not.toBeNull();
     });
 
     it('accepts an optional playlist name without affecting url validation', () => {

--- a/libs/playlist/import/feature/src/lib/url-upload/url-upload.component.ts
+++ b/libs/playlist/import/feature/src/lib/url-upload/url-upload.component.ts
@@ -9,6 +9,7 @@ import {
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { TranslatePipe } from '@ngx-translate/core';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 
 @Component({
     selector: 'app-url-upload',
@@ -22,12 +23,13 @@ import { TranslatePipe } from '@ngx-translate/core';
 })
 export class UrlUploadComponent implements OnInit {
     private readonly fb = inject(FormBuilder);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
 
     form!: FormGroup<{
         playlistName: FormControl<string>;
         playlistUrl: FormControl<string>;
     }>;
-    readonly isDesktop = !!window.electron;
+    readonly isDesktop = this.runtime.isElectron;
 
     ngOnInit(): void {
         const urlRegex = '(https?://.*?)';

--- a/libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.ts
+++ b/libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.ts
@@ -80,6 +80,7 @@ import { ChannelListLoadingStateComponent } from '@iptvnator/ui/components';
 import {
     DataService,
     PlaylistsService,
+    RuntimeCapabilitiesService,
     SettingsStore,
 } from '@iptvnator/services';
 import {
@@ -133,6 +134,7 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
     private readonly playlistsService = inject(PlaylistsService);
     private readonly playlistContext = inject(PlaylistContextFacade);
     private readonly router = inject(Router);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly settingsStore = inject(SettingsStore);
     private readonly storage = inject(StorageMap);
     private readonly store = inject(Store);
@@ -250,8 +252,8 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
         showCaptions: false,
     };
 
-    readonly isDesktop = !!window['electron'];
-    readonly supportsEpg = this.isDesktop;
+    readonly isDesktop = this.runtime.isElectron;
+    readonly supportsEpg = this.runtime.supportsEpg;
     readonly isWorkspaceLayout = isWorkspaceLayoutRoute(this.activatedRoute);
 
     /** EPG overlay reference */

--- a/libs/playlist/shared/ui/src/index.ts
+++ b/libs/playlist/shared/ui/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/playlist-switcher/playlist-switcher.component';
 export * from './lib/recent-playlists/playlist-info/playlist-info.component';
 export * from './lib/recent-playlists/recent-playlists.component';
 export * from './lib/recent-playlists/empty-state/empty-state.component';
+export * from './lib/playlist-refresh-action.service';

--- a/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts
@@ -7,12 +7,13 @@ import { TranslateService } from '@ngx-translate/core';
 import { DialogService } from '@iptvnator/ui/components';
 import {
     DatabaseService,
+    DbOperationEvent,
     PlaybackPositionService,
     PlaylistRefreshService,
 } from '@iptvnator/services';
 import { ChannelActions, PlaylistActions } from '@iptvnator/m3u-state';
 import { Playlist, PlaylistMeta } from '@iptvnator/shared/interfaces';
-import { PlaylistContextFacade } from './playlist-context.facade';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import { PlaylistRefreshActionService } from './playlist-refresh-action.service';
 
 function createDeferred<T>() {
@@ -343,7 +344,7 @@ describe('PlaylistRefreshActionService', () => {
                 _playlistId: string,
                 options?: {
                     operationId?: string;
-                    onEvent?: (event: any) => void;
+                    onEvent?: (event: DbOperationEvent) => void;
                 }
             ) => {
                 options?.onEvent?.({

--- a/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts
@@ -10,6 +10,7 @@ import {
     DbOperationEvent,
     PlaybackPositionService,
     PlaylistRefreshService,
+    RuntimeCapabilitiesService,
 } from '@iptvnator/services';
 import { ChannelActions, PlaylistActions } from '@iptvnator/m3u-state';
 import { Playlist, PlaylistMeta } from '@iptvnator/shared/interfaces';
@@ -75,6 +76,9 @@ describe('PlaylistRefreshActionService', () => {
     let playbackPositionService: {
         getAllPlaybackPositions: jest.Mock;
     };
+    let runtime: {
+        isElectron: boolean;
+    };
     let routeProvider: ReturnType<
         typeof signal<'playlists' | 'xtreams' | null>
     >;
@@ -126,6 +130,9 @@ describe('PlaylistRefreshActionService', () => {
         playbackPositionService = {
             getAllPlaybackPositions: jest.fn().mockResolvedValue([]),
         };
+        runtime = {
+            isElectron: true,
+        };
         routeProvider = signal<'playlists' | 'xtreams' | null>('xtreams');
         resolvedPlaylistId = signal<string | null>(null);
 
@@ -167,6 +174,10 @@ describe('PlaylistRefreshActionService', () => {
                     useValue: playbackPositionService,
                 },
                 {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtime,
+                },
+                {
                     provide: PlaylistContextFacade,
                     useValue: {
                         routeProvider,
@@ -185,7 +196,7 @@ describe('PlaylistRefreshActionService', () => {
     });
 
     it('treats file-backed M3U playlists as refreshable in Electron', () => {
-        window.electron = { platform: 'darwin' } as typeof window.electron;
+        runtime.isElectron = true;
 
         expect(
             service.canRefresh(
@@ -200,7 +211,7 @@ describe('PlaylistRefreshActionService', () => {
     });
 
     it('does not expose filesystem refresh outside Electron', () => {
-        window.electron = undefined as unknown as typeof window.electron;
+        runtime.isElectron = false;
 
         expect(
             service.canRefresh(

--- a/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.ts
@@ -10,6 +10,7 @@ import {
     isDbAbortError,
     PlaybackPositionService,
     PlaylistRefreshService,
+    RuntimeCapabilitiesService,
     XtreamPendingRestoreService,
 } from '@iptvnator/services';
 import { ChannelActions, PlaylistActions } from '@iptvnator/m3u-state';
@@ -34,6 +35,7 @@ export class PlaylistRefreshActionService {
     private readonly databaseService = inject(DatabaseService);
     private readonly playbackPositionService = inject(PlaybackPositionService);
     private readonly playlistRefreshService = inject(PlaylistRefreshService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly playlistContext = inject(PlaylistContextFacade);
     private readonly pendingRestoreService = inject(
         XtreamPendingRestoreService
@@ -46,7 +48,7 @@ export class PlaylistRefreshActionService {
     readonly refreshPreparation = this.refreshPreparationState.asReadonly();
 
     canRefresh(playlist: PlaylistMeta | null): boolean {
-        if (!playlist || !window.electron) {
+        if (!playlist || !this.runtime.isElectron) {
             return false;
         }
 

--- a/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.ts
@@ -14,7 +14,7 @@ import {
 } from '@iptvnator/services';
 import { ChannelActions, PlaylistActions } from '@iptvnator/m3u-state';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
-import { PlaylistContextFacade } from './playlist-context.facade';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 
 export interface XtreamRefreshPreparationState {
     playlistId: string;

--- a/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.spec.ts
@@ -12,16 +12,14 @@ import { Store } from '@ngrx/store';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { PlaylistActions } from '@iptvnator/m3u-state';
-import {
-    PlaylistContextFacade,
-    PlaylistRefreshActionService,
-} from '@iptvnator/playlist/shared/util';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import { DialogService } from '@iptvnator/ui/components';
 import {
     PlaylistDeleteActionService,
     PortalStatusService,
 } from '@iptvnator/services';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
+import { PlaylistRefreshActionService } from '../playlist-refresh-action.service';
 import { PlaylistSwitcherComponent } from './playlist-switcher.component';
 
 const SEARCH_QUERY_STORAGE_KEY = 'playlist-switcher:search-query';

--- a/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.spec.ts
@@ -11,7 +11,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Store } from '@ngrx/store';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
-import { of } from 'rxjs';
 import { PlaylistActions } from '@iptvnator/m3u-state';
 import {
     PlaylistContextFacade,
@@ -19,8 +18,7 @@ import {
 } from '@iptvnator/playlist/shared/util';
 import { DialogService } from '@iptvnator/ui/components';
 import {
-    DatabaseService,
-    PlaylistsService,
+    PlaylistDeleteActionService,
     PortalStatusService,
 } from '@iptvnator/services';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
@@ -75,11 +73,7 @@ describe('PlaylistSwitcherComponent', () => {
     let dialogService: {
         openConfirmDialog: jest.Mock;
     };
-    let databaseService: {
-        createOperationId: jest.Mock;
-        deletePlaylist: jest.Mock;
-    };
-    let playlistsService: {
+    let playlistDeleteAction: {
         deletePlaylist: jest.Mock;
     };
     let snackBar: {
@@ -134,20 +128,16 @@ describe('PlaylistSwitcherComponent', () => {
                     useValue: refreshActionService,
                 },
                 {
+                    provide: PlaylistDeleteActionService,
+                    useValue: playlistDeleteAction,
+                },
+                {
                     provide: MatDialog,
                     useValue: dialog,
                 },
                 {
                     provide: DialogService,
                     useValue: dialogService,
-                },
-                {
-                    provide: DatabaseService,
-                    useValue: databaseService,
-                },
-                {
-                    provide: PlaylistsService,
-                    useValue: playlistsService,
                 },
                 {
                     provide: MatSnackBar,
@@ -208,12 +198,8 @@ describe('PlaylistSwitcherComponent', () => {
         dialogService = {
             openConfirmDialog: jest.fn(),
         };
-        databaseService = {
-            createOperationId: jest.fn(),
-            deletePlaylist: jest.fn(),
-        };
-        playlistsService = {
-            deletePlaylist: jest.fn(() => of({ success: true })),
+        playlistDeleteAction = {
+            deletePlaylist: jest.fn().mockResolvedValue(true),
         };
         snackBar = {
             open: jest.fn(),
@@ -371,12 +357,7 @@ describe('PlaylistSwitcherComponent', () => {
         expect(component.displayTitle()).toBe('Select playlist');
     });
 
-    it('deletes browser/PWA playlists through PlaylistsService instead of the Electron database service', async () => {
-        Object.defineProperty(window, 'electron', {
-            configurable: true,
-            writable: true,
-            value: undefined,
-        });
+    it('delegates playlist deletion and removes the source after confirmation', async () => {
         await createComponent();
 
         component.removePlaylistFor(xtreamPlaylist);
@@ -384,10 +365,9 @@ describe('PlaylistSwitcherComponent', () => {
             .onConfirm as () => Promise<void>;
         await confirm();
 
-        expect(playlistsService.deletePlaylist).toHaveBeenCalledWith(
-            xtreamPlaylist._id
+        expect(playlistDeleteAction.deletePlaylist).toHaveBeenCalledWith(
+            xtreamPlaylist
         );
-        expect(databaseService.deletePlaylist).not.toHaveBeenCalled();
         expect(store.dispatch).toHaveBeenCalledWith(
             PlaylistActions.removePlaylist({
                 playlistId: xtreamPlaylist._id,

--- a/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.ts
@@ -36,6 +36,7 @@ import {
     PlaylistsService,
     PortalStatus,
     PortalStatusService,
+    RuntimeCapabilitiesService,
 } from '@iptvnator/services';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
 import { firstValueFrom, startWith } from 'rxjs';
@@ -80,6 +81,7 @@ export class PlaylistSwitcherComponent {
     private readonly dialogService = inject(DialogService);
     private readonly databaseService = inject(DatabaseService);
     private readonly playlistsService = inject(PlaylistsService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly snackBar = inject(MatSnackBar);
     private readonly store = inject(Store);
     private focusSearchTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -313,7 +315,7 @@ export class PlaylistSwitcherComponent {
     private async removePlaylistConfirmed(
         playlist: PlaylistMeta
     ): Promise<void> {
-        const deleted = window.electron
+        const deleted = this.runtime.isElectron
             ? await this.deletePlaylistInElectron(playlist)
             : await this.deletePlaylistInBrowser(playlist);
 

--- a/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.ts
@@ -32,14 +32,12 @@ import {
     PlaylistRefreshActionService,
 } from '@iptvnator/playlist/shared/util';
 import {
-    DatabaseService,
-    PlaylistsService,
+    PlaylistDeleteActionService,
     PortalStatus,
     PortalStatusService,
-    RuntimeCapabilitiesService,
 } from '@iptvnator/services';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
-import { firstValueFrom, startWith } from 'rxjs';
+import { startWith } from 'rxjs';
 import { PlaylistInfoComponent } from '../recent-playlists/playlist-info/playlist-info.component';
 
 type PlaylistFilterType = 'm3u' | 'stalker' | 'xtream';
@@ -79,9 +77,7 @@ export class PlaylistSwitcherComponent {
     private readonly refreshAction = inject(PlaylistRefreshActionService);
     private readonly dialog = inject(MatDialog);
     private readonly dialogService = inject(DialogService);
-    private readonly databaseService = inject(DatabaseService);
-    private readonly playlistsService = inject(PlaylistsService);
-    private readonly runtime = inject(RuntimeCapabilitiesService);
+    private readonly playlistDeleteAction = inject(PlaylistDeleteActionService);
     private readonly snackBar = inject(MatSnackBar);
     private readonly store = inject(Store);
     private focusSearchTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -315,9 +311,8 @@ export class PlaylistSwitcherComponent {
     private async removePlaylistConfirmed(
         playlist: PlaylistMeta
     ): Promise<void> {
-        const deleted = this.runtime.isElectron
-            ? await this.deletePlaylistInElectron(playlist)
-            : await this.deletePlaylistInBrowser(playlist);
+        const deleted =
+            await this.playlistDeleteAction.deletePlaylist(playlist);
 
         if (!deleted) {
             return;
@@ -331,28 +326,6 @@ export class PlaylistSwitcherComponent {
             undefined,
             { duration: 2000 }
         );
-    }
-
-    private async deletePlaylistInElectron(
-        playlist: PlaylistMeta
-    ): Promise<boolean> {
-        const operationId = playlist.serverUrl
-            ? this.databaseService.createOperationId('playlist-delete')
-            : undefined;
-
-        return this.databaseService.deletePlaylist(
-            playlist._id,
-            operationId ? { operationId } : undefined
-        );
-    }
-
-    private async deletePlaylistInBrowser(
-        playlist: PlaylistMeta
-    ): Promise<boolean> {
-        const result = await firstValueFrom(
-            this.playlistsService.deletePlaylist(playlist._id)
-        );
-        return result.success;
     }
 
     getPlaylistIcon(playlist: PlaylistMeta): string {

--- a/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.ts
@@ -27,10 +27,7 @@ import { normalizeDateLocale } from '@iptvnator/pipes';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { DialogService } from '@iptvnator/ui/components';
 import { PlaylistActions } from '@iptvnator/m3u-state';
-import {
-    PlaylistContextFacade,
-    PlaylistRefreshActionService,
-} from '@iptvnator/playlist/shared/util';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import {
     PlaylistDeleteActionService,
     PortalStatus,
@@ -38,6 +35,7 @@ import {
 } from '@iptvnator/services';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
 import { startWith } from 'rxjs';
+import { PlaylistRefreshActionService } from '../playlist-refresh-action.service';
 import { PlaylistInfoComponent } from '../recent-playlists/playlist-info/playlist-info.component';
 
 type PlaylistFilterType = 'm3u' | 'stalker' | 'xtream';

--- a/libs/playlist/shared/ui/src/lib/recent-playlists/playlist-info/playlist-info.component.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/recent-playlists/playlist-info/playlist-info.component.spec.ts
@@ -1,0 +1,142 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Store } from '@ngrx/store';
+import { TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import {
+    DatabaseService,
+    PlaylistsService,
+    RuntimeCapabilitiesService,
+} from '@iptvnator/services';
+import { Playlist } from '@iptvnator/shared/interfaces';
+import { PlaylistInfoComponent } from './playlist-info.component';
+
+describe('PlaylistInfoComponent', () => {
+    let component: PlaylistInfoComponent;
+    let fixture: ComponentFixture<PlaylistInfoComponent>;
+    let playlistsService: {
+        getRawPlaylistById: jest.Mock;
+    };
+    let runtime: {
+        isElectron: boolean;
+        supportsDesktopFileSave: boolean;
+    };
+    let snackBar: {
+        open: jest.Mock;
+    };
+    const originalElectron = window.electron;
+
+    const playlist = {
+        id: 'playlist-1',
+        _id: 'playlist-1',
+        title: 'My Playlist',
+        count: 1,
+        importDate: '2026-04-01T00:00:00.000Z',
+        autoRefresh: false,
+        url: 'https://example.com/playlist.m3u',
+    } as Playlist & { id: string };
+
+    beforeEach(async () => {
+        playlistsService = {
+            getRawPlaylistById: jest.fn(() => of('#EXTM3U\n')),
+        };
+        runtime = {
+            isElectron: false,
+            supportsDesktopFileSave: false,
+        };
+        snackBar = {
+            open: jest.fn(),
+        };
+
+        await TestBed.configureTestingModule({
+            imports: [PlaylistInfoComponent],
+            providers: [
+                {
+                    provide: MAT_DIALOG_DATA,
+                    useValue: playlist,
+                },
+                {
+                    provide: PlaylistsService,
+                    useValue: playlistsService,
+                },
+                {
+                    provide: DatabaseService,
+                    useValue: {
+                        updateXtreamPlaylistDetails: jest.fn(),
+                    },
+                },
+                {
+                    provide: Store,
+                    useValue: {
+                        dispatch: jest.fn(),
+                    },
+                },
+                {
+                    provide: MatSnackBar,
+                    useValue: snackBar,
+                },
+                {
+                    provide: TranslateService,
+                    useValue: {
+                        instant: jest.fn((key: string) => key),
+                    },
+                },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtime,
+                },
+            ],
+        }).compileComponents();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        window.electron = originalElectron;
+    });
+
+    function createComponent(): void {
+        fixture = TestBed.createComponent(PlaylistInfoComponent);
+        component = fixture.componentInstance;
+    }
+
+    it('uses the Electron save dialog when desktop file saving is available', async () => {
+        runtime.isElectron = true;
+        runtime.supportsDesktopFileSave = true;
+        window.electron = {
+            saveFileDialog: jest.fn().mockResolvedValue('/tmp/export.m3u8'),
+            writeFile: jest.fn().mockResolvedValue({ success: true }),
+        } as typeof window.electron;
+        createComponent();
+
+        await component.exportPlaylist();
+
+        expect(window.electron.saveFileDialog).toHaveBeenCalledWith(
+            'My Playlist.m3u8',
+            [{ name: 'Playlist', extensions: ['m3u8', 'm3u'] }]
+        );
+        expect(window.electron.writeFile).toHaveBeenCalledWith(
+            '/tmp/export.m3u8',
+            '#EXTM3U\n'
+        );
+        expect(snackBar.open).toHaveBeenCalledWith(
+            'HOME.PLAYLISTS.INFO_DIALOG.PLAYLIST_EXPORT_SUCCESS',
+            'CLOSE',
+            { duration: 3000 }
+        );
+    });
+
+    it('falls back to browser download when desktop file saving is unavailable', async () => {
+        const clickSpy = jest
+            .spyOn(HTMLAnchorElement.prototype, 'click')
+            .mockImplementation();
+        createComponent();
+
+        await component.exportPlaylist();
+
+        expect(playlistsService.getRawPlaylistById).toHaveBeenCalledWith(
+            'playlist-1'
+        );
+        expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/libs/playlist/shared/ui/src/lib/recent-playlists/playlist-info/playlist-info.component.ts
+++ b/libs/playlist/shared/ui/src/lib/recent-playlists/playlist-info/playlist-info.component.ts
@@ -19,7 +19,11 @@ import { Store } from '@ngrx/store';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { PlaylistActions } from '@iptvnator/m3u-state';
 import { firstValueFrom } from 'rxjs';
-import { DatabaseService, PlaylistsService } from '@iptvnator/services';
+import {
+    DatabaseService,
+    PlaylistsService,
+    RuntimeCapabilitiesService,
+} from '@iptvnator/services';
 import { Playlist, PlaylistMeta } from '@iptvnator/shared/interfaces';
 
 @Component({
@@ -80,9 +84,10 @@ export class PlaylistInfoComponent {
     private databaseService = inject(DatabaseService);
     private snackBar = inject(MatSnackBar);
     private translate = inject(TranslateService);
+    private runtime = inject(RuntimeCapabilitiesService);
     public playlistData = inject<Playlist & { id: string }>(MAT_DIALOG_DATA);
 
-    readonly isDesktop = !!window.electron;
+    readonly isDesktop = this.runtime.isElectron;
 
     /** Playlist object */
     playlist: Playlist & { id: string };
@@ -202,7 +207,7 @@ export class PlaylistInfoComponent {
             this.playlistsService.getRawPlaylistById(this.playlist._id)
         );
 
-        if (this.isDesktop) {
+        if (this.runtime.supportsDesktopFileSave && window.electron) {
             try {
                 const savePath = await window.electron.saveFileDialog(
                     `${this.playlist.title || 'exported'}.m3u8`,
@@ -224,6 +229,8 @@ export class PlaylistInfoComponent {
                         { duration: 3000 }
                     );
                 }
+
+                return;
             } catch (error) {
                 console.error('Failed to export playlist:', error);
                 this.snackBar.open(
@@ -235,23 +242,28 @@ export class PlaylistInfoComponent {
                         duration: 3000,
                     }
                 );
+                return;
             }
-        } else {
-            const element = document.createElement('a');
-            element.setAttribute(
-                'href',
-                'data:text/plain;charset=utf-8,' +
-                    encodeURIComponent(playlistAsString)
-            );
-            element.setAttribute(
-                'download',
-                this.playlist.title || 'exported.m3u'
-            );
-            element.style.display = 'none';
-            document.body.appendChild(element);
-            element.click();
-            document.body.removeChild(element);
         }
+
+        this.downloadPlaylistFile(playlistAsString);
+    }
+
+    private downloadPlaylistFile(playlistAsString: string): void {
+        const element = document.createElement('a');
+        element.setAttribute(
+            'href',
+            'data:text/plain;charset=utf-8,' +
+                encodeURIComponent(playlistAsString)
+        );
+        element.setAttribute(
+            'download',
+            this.playlist.title || 'exported.m3u'
+        );
+        element.style.display = 'none';
+        document.body.appendChild(element);
+        element.click();
+        document.body.removeChild(element);
     }
 
     /**

--- a/libs/playlist/shared/ui/src/lib/recent-playlists/playlist-item/playlist-item.component.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/recent-playlists/playlist-item/playlist-item.component.spec.ts
@@ -4,14 +4,24 @@ import { MatListModule } from '@angular/material/list';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockModule } from 'ng-mocks';
-import { PortalStatusService } from '@iptvnator/services';
+import {
+    PortalStatusService,
+    RuntimeCapabilitiesService,
+} from '@iptvnator/services';
 import { PlaylistItemComponent } from './playlist-item.component';
 
 describe('PlaylistItemComponent', () => {
     let component: PlaylistItemComponent;
     let fixture: ComponentFixture<PlaylistItemComponent>;
+    let runtime: {
+        isElectron: boolean;
+    };
 
     beforeEach(waitForAsync(() => {
+        runtime = {
+            isElectron: true,
+        };
+
         TestBed.configureTestingModule({
             imports: [
                 PlaylistItemComponent,
@@ -30,6 +40,10 @@ describe('PlaylistItemComponent', () => {
                         getStatusClass: jest.fn(() => 'status-active'),
                         getStatusIcon: jest.fn(() => 'check_circle'),
                     },
+                },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtime,
                 },
             ],
         }).compileComponents();
@@ -94,21 +108,70 @@ describe('PlaylistItemComponent', () => {
         expect(nativeElement.querySelector('.refresh-btn')).not.toBeNull();
     });
 
+    it('renders the Xtream refresh action only when Electron capabilities are available', () => {
+        fixture.destroy();
+        runtime.isElectron = true;
+        fixture = TestBed.createComponent(PlaylistItemComponent);
+        component = fixture.componentInstance;
+        component.item = {
+            title: 'Xtream Source',
+            _id: 'xtream-source',
+            count: 10,
+            importDate: Date.now().toString(),
+            autoRefresh: false,
+            serverUrl: 'https://example.com',
+            username: 'demo',
+            password: 'secret',
+        };
+        fixture.detectChanges();
+
+        expect(
+            (fixture.nativeElement as HTMLElement).querySelector(
+                '.refresh-btn'
+            )
+        ).not.toBeNull();
+
+        fixture.destroy();
+        runtime.isElectron = false;
+        fixture = TestBed.createComponent(PlaylistItemComponent);
+        component = fixture.componentInstance;
+        component.item = {
+            title: 'Xtream Source',
+            _id: 'xtream-source',
+            count: 10,
+            importDate: Date.now().toString(),
+            autoRefresh: false,
+            serverUrl: 'https://example.com',
+            username: 'demo',
+            password: 'secret',
+        };
+        fixture.detectChanges();
+
+        expect(
+            (fixture.nativeElement as HTMLElement).querySelector(
+                '.refresh-btn'
+            )
+        ).toBeNull();
+    });
+
     it('renders cancel and progress UI for long-running playlist actions', () => {
         fixture.componentRef.setInput('isDeleting', true);
-        fixture.componentRef.setInput('busyMessage', 'Removing cached content...');
+        fixture.componentRef.setInput(
+            'busyMessage',
+            'Removing cached content...'
+        );
         fixture.componentRef.setInput('busyProgress', 42);
         fixture.componentRef.setInput('canCancelBusyAction', true);
         fixture.detectChanges();
 
         const nativeElement = fixture.nativeElement as HTMLElement;
 
-        expect(nativeElement.querySelector('.busy-state__message')?.textContent).toContain(
-            'Removing cached content...'
-        );
-        expect(nativeElement.querySelector('.busy-state__value')?.textContent).toContain(
-            '42%'
-        );
+        expect(
+            nativeElement.querySelector('.busy-state__message')?.textContent
+        ).toContain('Removing cached content...');
+        expect(
+            nativeElement.querySelector('.busy-state__value')?.textContent
+        ).toContain('42%');
         expect(nativeElement.querySelector('.cancel-btn')).not.toBeNull();
     });
 });

--- a/libs/playlist/shared/ui/src/lib/recent-playlists/playlist-item/playlist-item.component.ts
+++ b/libs/playlist/shared/ui/src/lib/recent-playlists/playlist-item/playlist-item.component.ts
@@ -18,7 +18,11 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { normalizeDateLocale } from '@iptvnator/pipes';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { startWith } from 'rxjs';
-import { PortalStatus, PortalStatusService } from '@iptvnator/services';
+import {
+    PortalStatus,
+    PortalStatusService,
+    RuntimeCapabilitiesService,
+} from '@iptvnator/services';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
 
 @Component({
@@ -56,13 +60,14 @@ export class PlaylistItemComponent implements OnInit {
 
     portalStatus: PortalStatus = 'unavailable';
     private readonly portalStatusService = inject(PortalStatusService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly translate = inject(TranslateService);
     private readonly languageTick = toSignal(
         this.translate.onLangChange.pipe(startWith(null)),
         { initialValue: null }
     );
 
-    readonly isElectron = !!window.electron;
+    readonly isElectron = this.runtime.isElectron;
     readonly currentLocale = computed(() => {
         this.languageTick();
         return normalizeDateLocale(

--- a/libs/playlist/shared/ui/src/lib/recent-playlists/recent-playlists.component.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/recent-playlists/recent-playlists.component.spec.ts
@@ -17,8 +17,9 @@ import { DialogService } from '@iptvnator/ui/components';
 import {
     DatabaseService,
     DataService,
+    DbOperationEvent,
     PlaybackPositionService,
-    PlaylistsService,
+    PlaylistDeleteActionService,
     SortBy,
     SortOrder,
     SortService,
@@ -77,7 +78,7 @@ describe('RecentPlaylistsComponent busy state', () => {
     let playbackPositionService: {
         getAllPlaybackPositions: jest.Mock;
     };
-    let playlistsService: {
+    let playlistDeleteAction: {
         deletePlaylist: jest.Mock;
     };
     let router: {
@@ -110,8 +111,8 @@ describe('RecentPlaylistsComponent busy state', () => {
         playbackPositionService = {
             getAllPlaybackPositions: jest.fn().mockResolvedValue([]),
         };
-        playlistsService = {
-            deletePlaylist: jest.fn(),
+        playlistDeleteAction = {
+            deletePlaylist: jest.fn().mockResolvedValue(true),
         };
         router = {
             navigate: jest.fn(),
@@ -152,8 +153,8 @@ describe('RecentPlaylistsComponent busy state', () => {
                     useValue: playbackPositionService,
                 },
                 {
-                    provide: PlaylistsService,
-                    useValue: playlistsService,
+                    provide: PlaylistDeleteActionService,
+                    useValue: playlistDeleteAction,
                 },
                 {
                     provide: PlaylistContextFacade,
@@ -215,12 +216,11 @@ describe('RecentPlaylistsComponent busy state', () => {
         const item = createPlaylistMeta({ _id: 'playlist-delete-1' });
         const deletion = createDeferred<boolean>();
 
-        databaseService.deletePlaylist.mockImplementation(
+        playlistDeleteAction.deletePlaylist.mockImplementation(
             (
-                _playlistId: string,
+                _playlist: PlaylistMeta,
                 options?: {
-                    onEvent?: (event: any) => void;
-                    operationId?: string;
+                    onEvent?: (event: DbOperationEvent) => void;
                 }
             ) => {
                 options?.onEvent?.({
@@ -243,6 +243,9 @@ describe('RecentPlaylistsComponent busy state', () => {
         );
         expect(component.getBusyProgress(item._id)).toBe(25);
         expect(component.canCancelBusyOperation(item)).toBe(true);
+        expect(playlistDeleteAction.deletePlaylist).toHaveBeenCalledWith(item, {
+            onEvent: expect.any(Function),
+        });
 
         await component.cancelBusyOperation(item);
         expect(databaseService.cancelOperation).toHaveBeenCalledWith(
@@ -264,7 +267,7 @@ describe('RecentPlaylistsComponent busy state', () => {
         );
     });
 
-    it('deletes browser/PWA playlists through PlaylistsService instead of the Electron database service', async () => {
+    it('delegates playlist deletion and updates local UI state after success', async () => {
         const item = createPlaylistMeta({
             _id: 'pwa-playlist-1',
             serverUrl: undefined,
@@ -272,17 +275,13 @@ describe('RecentPlaylistsComponent busy state', () => {
             password: undefined,
             url: 'https://example.com/playlist.m3u',
         });
-        window.electron = undefined as unknown as typeof window.electron;
-        (
-            component as unknown as {
-                isElectron: boolean;
-            }
-        ).isElectron = false;
-        playlistsService.deletePlaylist.mockReturnValue(of({ success: true }));
+        playlistDeleteAction.deletePlaylist.mockResolvedValue(true);
 
         await component.removePlaylist(item);
 
-        expect(playlistsService.deletePlaylist).toHaveBeenCalledWith(item._id);
+        expect(playlistDeleteAction.deletePlaylist).toHaveBeenCalledWith(item, {
+            onEvent: expect.any(Function),
+        });
         expect(databaseService.deletePlaylist).not.toHaveBeenCalled();
         expect(store.dispatch).toHaveBeenCalledWith(
             PlaylistActions.removePlaylist({ playlistId: item._id })
@@ -321,7 +320,7 @@ describe('RecentPlaylistsComponent busy state', () => {
             (
                 _playlistId: string,
                 options?: {
-                    onEvent?: (event: any) => void;
+                    onEvent?: (event: DbOperationEvent) => void;
                     operationId?: string;
                 }
             ) => {

--- a/libs/playlist/shared/ui/src/lib/recent-playlists/recent-playlists.component.ts
+++ b/libs/playlist/shared/ui/src/lib/recent-playlists/recent-playlists.component.ts
@@ -36,6 +36,7 @@ import {
     PlaybackPositionService,
     PlaylistRefreshService,
     PlaylistsService,
+    RuntimeCapabilitiesService,
     SortBy,
     SortService,
     XtreamPendingRestoreService,
@@ -83,6 +84,7 @@ export class RecentPlaylistsComponent {
     private readonly snackBar = inject(MatSnackBar);
     private readonly sortService = inject(SortService);
     private readonly store = inject(Store);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly translate = inject(TranslateService);
     private readonly playlistContext = inject(PlaylistContextFacade);
     private readonly playlistsService = inject(PlaylistsService);
@@ -95,7 +97,7 @@ export class RecentPlaylistsComponent {
     readonly playlistClicked = output<string>();
     readonly addPlaylistClicked = output<PlaylistType | undefined>();
 
-    readonly isElectron = !!window.electron;
+    readonly isElectron = this.runtime.isElectron;
 
     readonly allPlaylistsLoaded = this.store.selectSignal(
         selectPlaylistsLoadingFlag

--- a/libs/playlist/shared/ui/src/lib/recent-playlists/recent-playlists.component.ts
+++ b/libs/playlist/shared/ui/src/lib/recent-playlists/recent-playlists.component.ts
@@ -26,7 +26,7 @@ import {
     selectAllPlaylistsMeta,
     selectPlaylistsLoadingFlag,
 } from '@iptvnator/m3u-state';
-import { BehaviorSubject, combineLatest, firstValueFrom, map } from 'rxjs';
+import { BehaviorSubject, combineLatest, map } from 'rxjs';
 import { DialogService } from '@iptvnator/ui/components';
 import {
     DatabaseService,
@@ -34,8 +34,8 @@ import {
     DbOperationEvent,
     isDbAbortError,
     PlaybackPositionService,
+    PlaylistDeleteActionService,
     PlaylistRefreshService,
-    PlaylistsService,
     RuntimeCapabilitiesService,
     SortBy,
     SortService,
@@ -87,7 +87,7 @@ export class RecentPlaylistsComponent {
     private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly translate = inject(TranslateService);
     private readonly playlistContext = inject(PlaylistContextFacade);
-    private readonly playlistsService = inject(PlaylistsService);
+    private readonly playlistDeleteAction = inject(PlaylistDeleteActionService);
     private readonly pendingRestoreService = inject(
         XtreamPendingRestoreService
     );
@@ -253,9 +253,13 @@ export class RecentPlaylistsComponent {
 
         this.setPendingDeletion(item._id, true);
         try {
-            const deleted = this.isElectron
-                ? await this.deletePlaylistInElectron(item)
-                : await this.deletePlaylistInBrowser(item);
+            const deleted = await this.playlistDeleteAction.deletePlaylist(
+                item,
+                {
+                    onEvent: (event) =>
+                        this.updateBusyOperation(item._id, event),
+                }
+            );
             if (deleted) {
                 this.store.dispatch(
                     PlaylistActions.removePlaylist({ playlistId: item._id })
@@ -274,30 +278,6 @@ export class RecentPlaylistsComponent {
             this.clearBusyOperation(item._id);
             this.setPendingDeletion(item._id, false);
         }
-    }
-
-    private async deletePlaylistInElectron(item: PlaylistMeta) {
-        const operationId = item.serverUrl
-            ? this.databaseService.createOperationId('playlist-delete')
-            : undefined;
-
-        return this.databaseService.deletePlaylist(
-            item._id,
-            operationId
-                ? {
-                      operationId,
-                      onEvent: (event) =>
-                          this.updateBusyOperation(item._id, event),
-                  }
-                : undefined
-        );
-    }
-
-    private async deletePlaylistInBrowser(item: PlaylistMeta) {
-        const result = await firstValueFrom(
-            this.playlistsService.deletePlaylist(item._id)
-        );
-        return result.success;
     }
 
     /**

--- a/libs/playlist/shared/ui/src/lib/recent-playlists/recent-playlists.component.ts
+++ b/libs/playlist/shared/ui/src/lib/recent-playlists/recent-playlists.component.ts
@@ -292,7 +292,7 @@ export class RecentPlaylistsComponent {
         if (item.serverUrl) {
             // For Xtream playlists, delete and re-import
             this.refreshXtreamPlaylist(item);
-        } else if (window.electron && (item.url || item.filePath)) {
+        } else if (this.isElectron && (item.url || item.filePath)) {
             void this.refreshM3uPlaylist(item);
         } else {
             // For M3U playlists, use existing refresh logic

--- a/libs/playlist/shared/util/project.json
+++ b/libs/playlist/shared/util/project.json
@@ -4,7 +4,7 @@
     "sourceRoot": "libs/playlist/shared/util/src",
     "prefix": "lib",
     "projectType": "library",
-    "tags": ["scope:playlist", "domain:m3u", "type:util"],
+    "tags": ["scope:playlist", "domain:m3u", "type:data-access"],
     "targets": {
         "test": {
             "executor": "@nx/jest:jest",

--- a/libs/playlist/shared/util/src/index.ts
+++ b/libs/playlist/shared/util/src/index.ts
@@ -1,4 +1,3 @@
 export * from './lib/playlist-player-actions';
 export * from './lib/playlist-context.facade';
 export * from './lib/playlist-file-import.service';
-export * from './lib/playlist-refresh-action.service';

--- a/libs/playlist/shared/util/src/lib/playlist-context.facade.spec.ts
+++ b/libs/playlist/shared/util/src/lib/playlist-context.facade.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@iptvnator/m3u-state';
 import { Subject } from 'rxjs';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import {
     PlaylistContextFacade,
     PlaylistRouteContext,
@@ -43,7 +44,7 @@ describe('PlaylistContextFacade', () => {
     let playlistsSignal: ReturnType<typeof signal<PlaylistMeta[]>>;
     let loadedSignal: ReturnType<typeof signal<boolean>>;
     let activePlaylistIdSignal: ReturnType<typeof signal<string | null>>;
-    let originalElectron: unknown;
+    let runtimeCapabilities: { supportsXtreamSectionNavigation: boolean };
 
     const xtreamA = createPlaylist({
         _id: 'xtream-a',
@@ -82,13 +83,6 @@ describe('PlaylistContextFacade', () => {
         url: 'http://example.test/b.m3u',
     });
 
-    function setElectronAvailability(enabled: boolean): void {
-        Object.defineProperty(window, 'electron', {
-            configurable: true,
-            value: enabled ? {} : undefined,
-        });
-    }
-
     function instantiateFacade(): PlaylistContextFacade {
         facade = TestBed.inject(PlaylistContextFacade);
         dispatch.mockClear();
@@ -98,7 +92,6 @@ describe('PlaylistContextFacade', () => {
 
     beforeEach(() => {
         localStorage.clear();
-        originalElectron = (window as Window & { electron?: unknown }).electron;
 
         routerEvents = new Subject<NavigationEnd>();
         router = {
@@ -117,7 +110,7 @@ describe('PlaylistContextFacade', () => {
         ]);
         loadedSignal = signal(true);
         activePlaylistIdSignal = signal<string | null>(xtreamA._id);
-        setElectronAvailability(true);
+        runtimeCapabilities = { supportsXtreamSectionNavigation: true };
 
         TestBed.configureTestingModule({
             providers: [
@@ -147,16 +140,16 @@ describe('PlaylistContextFacade', () => {
                         }),
                     },
                 },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtimeCapabilities,
+                },
             ],
         });
     });
 
     afterEach(() => {
         localStorage.clear();
-        Object.defineProperty(window, 'electron', {
-            configurable: true,
-            value: originalElectron,
-        });
         routerEvents.complete();
         jest.restoreAllMocks();
     });
@@ -353,8 +346,8 @@ describe('PlaylistContextFacade', () => {
         ).toEqual(['workspace', 'stalker', stalkerB._id, 'search']);
     });
 
-    it('omits Xtream sections outside Electron where section navigation is unsupported', () => {
-        setElectronAvailability(false);
+    it('omits Xtream sections when runtime section navigation is unsupported', () => {
+        runtimeCapabilities.supportsXtreamSectionNavigation = false;
         const service = instantiateFacade();
 
         expect(

--- a/libs/playlist/shared/util/src/lib/playlist-context.facade.ts
+++ b/libs/playlist/shared/util/src/lib/playlist-context.facade.ts
@@ -21,6 +21,7 @@ import {
     PortalProvider,
     PortalRailSection,
 } from '@iptvnator/portal/shared/util';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 
 export interface PlaylistRouteContext {
     inWorkspace: boolean;
@@ -69,6 +70,7 @@ const M3U_SECTIONS = ['all', 'groups', 'favorites', 'recent'] as const;
 @Injectable({ providedIn: 'root' })
 export class PlaylistContextFacade {
     private readonly destroyRef = inject(DestroyRef);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly router = inject(Router);
     private readonly store = inject(Store);
 
@@ -346,7 +348,7 @@ export class PlaylistContextFacade {
 
     private supportsSectionNavigation(provider: PortalProvider): boolean {
         if (provider === 'xtreams') {
-            return Boolean(window.electron);
+            return this.runtime.supportsXtreamSectionNavigation;
         }
 
         return true;

--- a/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
@@ -1,6 +1,10 @@
 import { inject, Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import { DataService, PlaylistsService } from '@iptvnator/services';
+import {
+    DataService,
+    PlaylistsService,
+    RuntimeCapabilitiesService,
+} from '@iptvnator/services';
 import {
     Channel,
     EpgItem,
@@ -59,6 +63,7 @@ export class StreamResolverService {
     private readonly xtreamApi = inject(XtreamApiService);
     private readonly xtreamUrl = inject(XtreamUrlService);
     private readonly dataService = inject(DataService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly stalkerSession = inject(StalkerSessionService);
     private readonly m3uEpgTimeoutMs = 3000;
     private readonly portalEpgTimeoutMs = 3000;
@@ -68,7 +73,7 @@ export class StreamResolverService {
     private readonly xtreamEpgFailureCooldownMs = 60 * 1000;
 
     private get supportsEpg(): boolean {
-        return typeof window !== 'undefined' && !!window.electron;
+        return this.runtime.supportsEpg;
     }
 
     private async getElectronPlaylist(

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
@@ -45,7 +45,7 @@ import {
     WebPlayerViewComponent,
 } from '@iptvnator/ui/playback';
 import { ResizableDirective } from '@iptvnator/ui/components';
-import { SettingsStore } from '@iptvnator/services';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import { EpgItem, EpgProgram } from '@iptvnator/shared/interfaces';
 import {
     EpgViewComponent,
@@ -92,12 +92,13 @@ export class UnifiedLiveTabComponent {
 
     private readonly streamResolver = inject(StreamResolverService);
     private readonly recentData = inject(UnifiedRecentDataService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly settingsStore = inject(SettingsStore);
     private readonly portalPlayer = inject(PORTAL_PLAYER);
     private readonly destroyRef = inject(DestroyRef);
 
     readonly player = this.settingsStore.player;
-    readonly supportsEpg = Boolean(window.electron);
+    readonly supportsEpg = this.runtime.supportsEpg;
     readonly isEmbeddedPlayer = computed(() =>
         this.portalPlayer.isEmbeddedPlayer()
     );

--- a/libs/portal/shared/ui/src/lib/navigation/navigation.component.spec.ts
+++ b/libs/portal/shared/ui/src/lib/navigation/navigation.component.spec.ts
@@ -1,0 +1,102 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { TranslateModule } from '@ngx-translate/core';
+import { PORTAL_NAVIGATION_ACTIONS } from '@iptvnator/portal/shared/util';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
+import { Playlist } from '@iptvnator/shared/interfaces';
+import { NavigationComponent } from './navigation.component';
+
+describe('NavigationComponent', () => {
+    let playlist: ReturnType<typeof signal<Partial<Playlist> | undefined>>;
+    let runtime: {
+        isElectron: boolean;
+    };
+
+    beforeEach(async () => {
+        playlist = signal<Partial<Playlist> | undefined>({
+            _id: 'xtream-1',
+        });
+        runtime = {
+            isElectron: true,
+        };
+
+        await TestBed.configureTestingModule({
+            imports: [TranslateModule.forRoot(), NavigationComponent],
+            providers: [
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        snapshot: {
+                            params: {
+                                id: 'xtream-1',
+                            },
+                        },
+                    },
+                },
+                {
+                    provide: Store,
+                    useValue: {
+                        selectSignal: jest.fn(() => playlist),
+                    },
+                },
+                {
+                    provide: PORTAL_NAVIGATION_ACTIONS,
+                    useValue: {
+                        openAccountInfo: jest.fn(),
+                        openPlaylistInfo: jest.fn(),
+                        openSettings: jest.fn(),
+                    },
+                },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtime,
+                },
+            ],
+        }).compileComponents();
+    });
+
+    function createComponent(): NavigationComponent {
+        return TestBed.createComponent(NavigationComponent).componentInstance;
+    }
+
+    it('includes downloads in portal rail links when Electron is available', () => {
+        runtime.isElectron = true;
+
+        const component = createComponent();
+
+        expect(component.secondaryLinks().map((link) => link.section)).toEqual([
+            'recently-added',
+            'search',
+            'downloads',
+        ]);
+    });
+
+    it('hides downloads in portal rail links when Electron is unavailable', () => {
+        runtime.isElectron = false;
+
+        const component = createComponent();
+
+        expect(component.secondaryLinks().map((link) => link.section)).toEqual([
+            'recently-added',
+            'search',
+        ]);
+    });
+
+    it('uses the Stalker rail shape for Stalker playlists', () => {
+        playlist.set({
+            _id: 'stalker-1',
+            macAddress: '00:1A:79:00:00:01',
+        });
+
+        const component = createComponent();
+
+        expect(component.primaryLinks().map((link) => link.section)).toEqual([
+            'vod',
+            'itv',
+            'radio',
+            'series',
+        ]);
+    });
+});

--- a/libs/portal/shared/ui/src/lib/navigation/navigation.component.ts
+++ b/libs/portal/shared/ui/src/lib/navigation/navigation.component.ts
@@ -12,6 +12,7 @@ import {
     PortalRailSection,
 } from '@iptvnator/portal/shared/util';
 import { selectPlaylistById } from '@iptvnator/m3u-state';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { Playlist } from '@iptvnator/shared/interfaces';
 import { PortalRailLinksComponent } from './portal-rail-links.component';
 
@@ -33,6 +34,7 @@ import { PortalRailLinksComponent } from './portal-rail-links.component';
 export class NavigationComponent {
     private readonly activatedRoute = inject(ActivatedRoute);
     private readonly navigationActions = inject(PORTAL_NAVIGATION_ACTIONS);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly store = inject(Store);
 
     readonly portalStatus = input<
@@ -48,7 +50,7 @@ export class NavigationComponent {
         () => !!(this.currentPlaylist() as Playlist | undefined)?.macAddress
     );
 
-    readonly isElectron = !!window.electron;
+    readonly isElectron = this.runtime.isElectron;
 
     readonly railLinks = computed(() => {
         const playlistId =

--- a/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-epg.feature.spec.ts
+++ b/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-epg.feature.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { signalStore, withState } from '@ngrx/signals';
-import { DataService } from '@iptvnator/services';
+import { DataService, RuntimeCapabilitiesService } from '@iptvnator/services';
 import { EpgItem, Playlist } from '@iptvnator/shared/interfaces';
 import { StalkerSessionService } from '../../stalker-session.service';
 import { withStalkerEpg } from './with-stalker-epg.feature';
@@ -56,6 +56,14 @@ describe('withStalkerEpg', () => {
             providers: [
                 TestStalkerEpgStore,
                 { provide: DataService, useValue: dataService },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: {
+                        get supportsEpg() {
+                            return dataService.getAppEnvironment() !== 'pwa';
+                        },
+                    },
+                },
                 {
                     provide: StalkerSessionService,
                     useValue: stalkerSessionService,

--- a/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-epg.feature.ts
+++ b/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-epg.feature.ts
@@ -7,7 +7,7 @@ import {
     withState,
 } from '@ngrx/signals';
 import { createLogger } from '@iptvnator/portal/shared/util';
-import { DataService } from '@iptvnator/services';
+import { DataService, RuntimeCapabilitiesService } from '@iptvnator/services';
 import {
     EpgItem,
     EpgProgram,
@@ -98,7 +98,8 @@ export function withStalkerEpg() {
             (
                 store,
                 dataService = inject(DataService),
-                stalkerSession = inject(StalkerSessionService)
+                stalkerSession = inject(StalkerSessionService),
+                runtime = inject(RuntimeCapabilitiesService)
             ) => {
                 const storeContext = store as typeof store &
                     StalkerEpgFeatureStoreContract;
@@ -106,9 +107,7 @@ export function withStalkerEpg() {
                     dataService,
                     stalkerSession,
                 };
-                const supportsEpg = (): boolean =>
-                    typeof dataService.getAppEnvironment !== 'function' ||
-                    dataService.getAppEnvironment() !== 'pwa';
+                const supportsEpg = (): boolean => runtime.supportsEpg;
 
                 const requestEpg = async (
                     playlist: NonNullable<

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.ts
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.ts
@@ -25,7 +25,11 @@ import {
     ChannelListSkeletonComponent,
     ResizableDirective,
 } from '@iptvnator/ui/components';
-import { PlaylistsService, SettingsStore } from '@iptvnator/services';
+import {
+    PlaylistsService,
+    RuntimeCapabilitiesService,
+    SettingsStore,
+} from '@iptvnator/services';
 import {
     Channel,
     EpgItem,
@@ -91,6 +95,7 @@ import {
 export class StalkerLiveStreamLayoutComponent implements OnDestroy {
     readonly stalkerStore = inject(StalkerStore);
     private readonly playlistService = inject(PlaylistsService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly settingsStore = inject(SettingsStore);
     private readonly portalPlayer = inject(PORTAL_PLAYER);
     private readonly snackBar = inject(MatSnackBar);
@@ -138,8 +143,8 @@ export class StalkerLiveStreamLayoutComponent implements OnDestroy {
 
     readonly selectedChannelId = this.stalkerStore.selectedItvId;
     protected readonly normalizeStalkerEntityId = normalizeStalkerEntityId;
-    readonly isElectron = Boolean(window.electron);
-    readonly supportsEpg = this.isElectron;
+    readonly isElectron = this.runtime.isElectron;
+    readonly supportsEpg = this.runtime.supportsEpg;
     readonly openStreamOnDoubleClick = computed(() =>
         this.settingsStore.openStreamOnDoubleClick()
     );

--- a/libs/portal/xtream/data-access/src/lib/data-sources/index.ts
+++ b/libs/portal/xtream/data-access/src/lib/data-sources/index.ts
@@ -1,5 +1,8 @@
 import { inject, Provider } from '@angular/core';
-import { PLAYLIST_DELETE_CLEANUP } from '@iptvnator/services';
+import {
+    PLAYLIST_DELETE_CLEANUP,
+    RuntimeCapabilitiesService,
+} from '@iptvnator/services';
 import { ElectronXtreamDataSource } from './electron-xtream-data-source';
 import { PwaXtreamDataSource } from './pwa-xtream-data-source';
 import {
@@ -18,12 +21,12 @@ export { PwaXtreamDataSource } from './pwa-xtream-data-source';
  * - PWA: Uses API-only with in-memory caching and localStorage for user data
  */
 export function xtreamDataSourceFactory(): IXtreamDataSource {
-    // Check if we're in Electron environment
-    if (typeof window !== 'undefined' && window.electron) {
+    const runtime = inject(RuntimeCapabilitiesService);
+
+    if (runtime.isElectron) {
         return inject(ElectronXtreamDataSource);
     }
 
-    // Default to PWA implementation
     return inject(PwaXtreamDataSource);
 }
 
@@ -44,9 +47,10 @@ export function provideXtreamDataSource(): Provider[] {
             multi: true,
             useFactory: () => {
                 const dataSource = inject(XTREAM_DATA_SOURCE);
+                const runtime = inject(RuntimeCapabilitiesService);
 
                 return (playlistId: string) => {
-                    if (typeof window !== 'undefined' && window.electron) {
+                    if (runtime.isElectron) {
                         return Promise.resolve();
                     }
 

--- a/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.spec.ts
+++ b/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { signalStore, withState } from '@ngrx/signals';
-import { DataService, SettingsStore } from '@iptvnator/services';
+import {
+    DataService,
+    RuntimeCapabilitiesService,
+    SettingsStore,
+} from '@iptvnator/services';
 import { EpgItem } from '@iptvnator/shared/interfaces';
 import { XtreamApiService } from '../../services/xtream-api.service';
 import { XtreamXmltvFallbackService } from '../../services/xtream-xmltv-fallback.service';
@@ -85,6 +89,14 @@ function configureStore(setup: TestStoreSetup) {
                         () => setup.appEnvironment ?? 'electron'
                     ),
                     isElectron: setup.isElectron ?? true,
+                },
+            },
+            {
+                provide: RuntimeCapabilitiesService,
+                useValue: {
+                    get supportsEpg() {
+                        return (setup.appEnvironment ?? 'electron') !== 'pwa';
+                    },
                 },
             },
             { provide: XtreamApiService, useValue: xtreamApiService },

--- a/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.ts
+++ b/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.ts
@@ -7,7 +7,11 @@ import {
     withState,
 } from '@ngrx/signals';
 import { EpgItem } from '@iptvnator/shared/interfaces';
-import { DataService, SettingsStore } from '@iptvnator/services';
+import {
+    DataService,
+    RuntimeCapabilitiesService,
+    SettingsStore,
+} from '@iptvnator/services';
 import {
     XtreamApiService,
     XtreamCredentials,
@@ -82,11 +86,10 @@ export function withEpg() {
             const apiService = inject(XtreamApiService);
             const dataService = inject(DataService);
             const fallbackService = inject(XtreamXmltvFallbackService);
+            const runtime = inject(RuntimeCapabilitiesService);
             const settingsStore = inject(SettingsStore);
 
-            const supportsEpg = (): boolean =>
-                typeof dataService.getAppEnvironment !== 'function' ||
-                dataService.getAppEnvironment() !== 'pwa';
+            const supportsEpg = (): boolean => runtime.supportsEpg;
 
             /**
              * Helper to get credentials from parent store

--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.ts
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.ts
@@ -63,7 +63,7 @@ import {
 } from '@iptvnator/shared/interfaces';
 import { PortalChannelsListComponent } from '../portal-channels-list/portal-channels-list.component';
 import { ActivatedRoute } from '@angular/router';
-import { SettingsStore } from '@iptvnator/services';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 
 const LIVE_CHANNEL_SORT_STORAGE_KEY = 'xtream-live-channel-sort-mode';
 
@@ -104,6 +104,7 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
     private readonly favoritesService = inject(FavoritesService);
     private readonly xtreamStore = inject(XtreamStore);
     private readonly xtreamUrlService = inject(XtreamUrlService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly settingsStore = inject(SettingsStore);
     private readonly portalPlayer = inject(PORTAL_PLAYER);
     private readonly liveSidebarStateService = inject(
@@ -119,8 +120,8 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
     readonly isLoadingEpg = this.xtreamStore.isLoadingEpg;
     readonly selectedCategoryId = this.xtreamStore.selectedCategoryId;
     readonly liveChannelSortMode = signal<PortalChannelSortMode>('server');
-    readonly isElectron = Boolean(window.electron);
-    readonly supportsEpg = this.isElectron;
+    readonly isElectron = this.runtime.isElectron;
+    readonly supportsEpg = this.runtime.supportsEpg;
     readonly isWorkspaceLayout = isWorkspaceLayoutRoute(this.route);
     private readonly routeSearchTerm = queryParamSignal(
         this.route,

--- a/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.ts
+++ b/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.ts
@@ -38,6 +38,7 @@ import { EpgQueueService } from '@iptvnator/portal/xtream/data-access';
 import { XtreamCredentials } from '@iptvnator/portal/xtream/data-access';
 import { FavoritesService } from '@iptvnator/portal/xtream/data-access';
 import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 
 export interface XtreamChannelListItem {
     readonly category_id?: string | number;
@@ -80,7 +81,8 @@ export class PortalChannelsListComponent implements AfterViewInit, OnDestroy {
     private readonly favoritesService = inject(FavoritesService);
     private readonly epgQueueService = inject(EpgQueueService);
     private readonly route = inject(ActivatedRoute);
-    readonly supportsEpg = Boolean(window.electron);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
+    readonly supportsEpg = this.runtime.supportsEpg;
     readonly isSelectedTypeContentLoading =
         this.xtreamStore.selectedTypeContentLoading;
     readonly channels = computed(() => {

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/playlist-backup.service';
 export * from './lib/playlist-refresh.service';
 export * from './lib/playlists.service';
 export * from './lib/portal-status.service';
+export * from './lib/runtime-capabilities.service';
 export * from './lib/settings-store.service';
 export * from './lib/sort.service';
 export * from './lib/xtream-pending-restore.service';

--- a/libs/services/src/index.ts
+++ b/libs/services/src/index.ts
@@ -3,6 +3,7 @@ export * from './lib/database-electron.service';
 export * from './lib/downloads.service';
 export * from './lib/playback-position.service';
 export * from './lib/playlist-delete-cleanup.token';
+export * from './lib/playlist-delete-action.service';
 export * from './lib/playlist-backup.service';
 export * from './lib/playlist-refresh.service';
 export * from './lib/playlists.service';

--- a/libs/services/src/lib/data.service.ts
+++ b/libs/services/src/lib/data.service.ts
@@ -4,12 +4,24 @@ type ElectronProcessWindow = Window & {
     };
 };
 
+export interface ElectronRemoteProcess {
+    argv: string[];
+    platform: string;
+}
+
+export interface ElectronRemote {
+    app?: {
+        getVersion: () => string;
+    };
+    process: ElectronRemoteProcess;
+}
+
 export abstract class DataService {
     get isElectron(): boolean {
         const currentWindow = window as ElectronProcessWindow;
         return Boolean(currentWindow.process?.type);
     }
-    get remote() {
+    get remote(): ElectronRemote | null {
         return null;
     }
     get ipcRenderer() {

--- a/libs/services/src/lib/downloads.service.spec.ts
+++ b/libs/services/src/lib/downloads.service.spec.ts
@@ -1,8 +1,11 @@
 import { signal, Signal, WritableSignal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import {
     DownloadItem,
     DownloadsService,
 } from './downloads.service';
+import { RuntimeCapabilitiesService } from './runtime-capabilities.service';
+import { SettingsStore } from './settings-store.service';
 
 type TestDownloadsService = {
     downloads: WritableSignal<DownloadItem[]>;
@@ -27,6 +30,7 @@ describe('DownloadsService', () => {
 
     afterEach(() => {
         testWindow.electron = originalElectron;
+        TestBed.resetTestingModule();
         jest.restoreAllMocks();
     });
 
@@ -73,6 +77,23 @@ describe('DownloadsService', () => {
 
         return service;
     }
+
+    it('reports availability through the runtime capability', () => {
+        TestBed.configureTestingModule({
+            providers: [
+                DownloadsService,
+                { provide: SettingsStore, useValue: {} },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: { supportsDownloads: false },
+                },
+            ],
+        });
+
+        const service = TestBed.inject(DownloadsService);
+
+        expect(service.isAvailable()).toBe(false);
+    });
 
     it('tracks loading and loaded state around a successful download list request', async () => {
         const item = createDownload(1);

--- a/libs/services/src/lib/downloads.service.ts
+++ b/libs/services/src/lib/downloads.service.ts
@@ -1,4 +1,5 @@
 import { computed, inject, Injectable, OnDestroy, signal } from '@angular/core';
+import { RuntimeCapabilitiesService } from './runtime-capabilities.service';
 import { SettingsStore } from './settings-store.service';
 
 export type DownloadStatus =
@@ -31,6 +32,7 @@ export interface DownloadItem {
 
 @Injectable({ providedIn: 'root' })
 export class DownloadsService implements OnDestroy {
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly settingsStore = inject(SettingsStore);
     private unsubscribe?: () => void;
     private loadDownloadsRequestId = 0;
@@ -48,7 +50,7 @@ export class DownloadsService implements OnDestroy {
     readonly hasLoadedDownloads = this._hasLoadedDownloads.asReadonly();
 
     /** Whether the download feature is available (Electron only) */
-    readonly isAvailable = computed(() => !!window.electron?.downloadsGetList);
+    readonly isAvailable = computed(() => this.runtime.supportsDownloads);
 
     /** Whether there are any downloads */
     readonly hasDownloads = computed(() => this.downloads().length > 0);

--- a/libs/services/src/lib/playlist-delete-action.service.spec.ts
+++ b/libs/services/src/lib/playlist-delete-action.service.spec.ts
@@ -1,0 +1,101 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { PlaylistMeta } from '@iptvnator/shared/interfaces';
+import { DatabaseService } from './database-electron.service';
+import { PlaylistDeleteActionService } from './playlist-delete-action.service';
+import { PlaylistsService } from './playlists.service';
+import { RuntimeCapabilitiesService } from './runtime-capabilities.service';
+
+describe('PlaylistDeleteActionService', () => {
+    const playlist = {
+        _id: 'playlist-1',
+        title: 'Demo Playlist',
+        serverUrl: 'http://demo.example',
+    } as PlaylistMeta;
+
+    let databaseService: {
+        createOperationId: jest.Mock<string, [string]>;
+        deletePlaylist: jest.Mock<Promise<boolean>, unknown[]>;
+    };
+    let playlistsService: {
+        deletePlaylist: jest.Mock;
+    };
+    let runtime: {
+        isElectron: boolean;
+    };
+
+    beforeEach(() => {
+        databaseService = {
+            createOperationId: jest
+                .fn<string, [string]>()
+                .mockReturnValue('playlist-delete-1'),
+            deletePlaylist: jest.fn(async () => true),
+        };
+        playlistsService = {
+            deletePlaylist: jest.fn(() => of({ success: true })),
+        };
+        runtime = {
+            isElectron: false,
+        };
+
+        TestBed.configureTestingModule({
+            providers: [
+                PlaylistDeleteActionService,
+                { provide: DatabaseService, useValue: databaseService },
+                { provide: PlaylistsService, useValue: playlistsService },
+                { provide: RuntimeCapabilitiesService, useValue: runtime },
+            ],
+        });
+    });
+
+    it('deletes browser playlists through PlaylistsService', async () => {
+        const service = TestBed.inject(PlaylistDeleteActionService);
+
+        await expect(service.deletePlaylist(playlist)).resolves.toBe(true);
+
+        expect(playlistsService.deletePlaylist).toHaveBeenCalledWith(
+            'playlist-1'
+        );
+        expect(databaseService.deletePlaylist).not.toHaveBeenCalled();
+    });
+
+    it('deletes Electron Xtream playlists through DatabaseService with progress options', async () => {
+        runtime.isElectron = true;
+        const onEvent = jest.fn();
+        const service = TestBed.inject(PlaylistDeleteActionService);
+
+        await expect(
+            service.deletePlaylist(playlist, { onEvent })
+        ).resolves.toBe(true);
+
+        expect(databaseService.createOperationId).toHaveBeenCalledWith(
+            'playlist-delete'
+        );
+        expect(databaseService.deletePlaylist).toHaveBeenCalledWith(
+            'playlist-1',
+            {
+                operationId: 'playlist-delete-1',
+                onEvent,
+            }
+        );
+        expect(playlistsService.deletePlaylist).not.toHaveBeenCalled();
+    });
+
+    it('deletes Electron non-Xtream playlists without progress options', async () => {
+        runtime.isElectron = true;
+        const service = TestBed.inject(PlaylistDeleteActionService);
+
+        await expect(
+            service.deletePlaylist({
+                ...playlist,
+                serverUrl: undefined,
+            } as PlaylistMeta)
+        ).resolves.toBe(true);
+
+        expect(databaseService.createOperationId).not.toHaveBeenCalled();
+        expect(databaseService.deletePlaylist).toHaveBeenCalledWith(
+            'playlist-1',
+            undefined
+        );
+    });
+});

--- a/libs/services/src/lib/playlist-delete-action.service.ts
+++ b/libs/services/src/lib/playlist-delete-action.service.ts
@@ -1,0 +1,53 @@
+import { inject, Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { PlaylistMeta } from '@iptvnator/shared/interfaces';
+import {
+    DatabaseService,
+    type DbOperationEvent,
+} from './database-electron.service';
+import { PlaylistsService } from './playlists.service';
+import { RuntimeCapabilitiesService } from './runtime-capabilities.service';
+
+export interface PlaylistDeleteActionOptions {
+    readonly onEvent?: (event: DbOperationEvent) => void;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PlaylistDeleteActionService {
+    private readonly databaseService = inject(DatabaseService);
+    private readonly playlistsService = inject(PlaylistsService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
+
+    async deletePlaylist(
+        playlist: PlaylistMeta,
+        options: PlaylistDeleteActionOptions = {}
+    ): Promise<boolean> {
+        if (this.runtime.isElectron) {
+            return this.deletePlaylistInElectron(playlist, options);
+        }
+
+        const result = await firstValueFrom(
+            this.playlistsService.deletePlaylist(playlist._id)
+        );
+        return result.success;
+    }
+
+    private deletePlaylistInElectron(
+        playlist: PlaylistMeta,
+        options: PlaylistDeleteActionOptions
+    ): Promise<boolean> {
+        const operationId = playlist.serverUrl
+            ? this.databaseService.createOperationId('playlist-delete')
+            : undefined;
+
+        return this.databaseService.deletePlaylist(
+            playlist._id,
+            operationId
+                ? {
+                      operationId,
+                      onEvent: options.onEvent,
+                  }
+                : undefined
+        );
+    }
+}

--- a/libs/services/src/lib/playlists.service.spec.ts
+++ b/libs/services/src/lib/playlists.service.spec.ts
@@ -36,6 +36,20 @@ describe('PlaylistsService', () => {
             translateService: {
                 instant: jest.fn((key: string) => key),
             },
+            runtime: {
+                get supportsSqlite() {
+                    const electron = testWindow.electron as
+                        | Record<string, unknown>
+                        | undefined;
+                    return (
+                        !!electron &&
+                        typeof electron['dbGetAppPlaylists'] === 'function' &&
+                        typeof electron['dbUpsertAppPlaylist'] === 'function' &&
+                        typeof electron['dbGetAppState'] === 'function' &&
+                        typeof electron['dbSetAppState'] === 'function'
+                    );
+                },
+            },
             electronMigrationPromise: null,
             indexedDbMigrationPromise: null,
             playlistDeleteCleanups: [],

--- a/libs/services/src/lib/playlists.service.ts
+++ b/libs/services/src/lib/playlists.service.ts
@@ -31,6 +31,7 @@ import {
     normalizeStalkerDate,
 } from '@iptvnator/shared/interfaces';
 import { PLAYLIST_DELETE_CLEANUP } from './playlist-delete-cleanup.token';
+import { RuntimeCapabilitiesService } from './runtime-capabilities.service';
 
 const SQLITE_PLAYLIST_MIGRATION_FLAG = 'm3u-playlists-indexeddb-to-sqlite-v1';
 const STALKER_PLAYLIST_METADATA_MIGRATION_FLAG =
@@ -82,6 +83,7 @@ export class PlaylistsService {
     private readonly dbService = inject(NgxIndexedDBService);
     private readonly snackBar = inject(MatSnackBar);
     private readonly translateService = inject(TranslateService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly playlistDeleteCleanups =
         inject(PLAYLIST_DELETE_CLEANUP, { optional: true }) ?? [];
     private electronMigrationPromise: Promise<void> | null = null;
@@ -96,15 +98,7 @@ export class PlaylistsService {
     }
 
     private get isElectronStorageAvailable(): boolean {
-        const electron = this.electronApi;
-
-        return (
-            !!electron &&
-            typeof electron.dbGetAppPlaylists === 'function' &&
-            typeof electron.dbUpsertAppPlaylist === 'function' &&
-            typeof electron.dbGetAppState === 'function' &&
-            typeof electron.dbSetAppState === 'function'
-        );
+        return this.runtime.supportsSqlite;
     }
 
     private runOnSqlite<T>(operation: () => Promise<T>) {

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -23,6 +23,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsDownloads).toBe(false);
         expect(service.supportsManagedExternalPlayers).toBe(false);
         expect(service.supportsEmbeddedMpv).toBe(false);
+        expect(service.supportsDesktopFileSave).toBe(false);
         expect(service.supportsRemoteControl).toBe(false);
     });
 
@@ -34,6 +35,8 @@ describe('RuntimeCapabilitiesService', () => {
             dbSetAppState: jest.fn(),
             downloadsGetList: jest.fn(),
             prepareEmbeddedMpv: jest.fn(),
+            saveFileDialog: jest.fn(),
+            writeFile: jest.fn(),
             updateRemoteControlStatus: jest.fn(),
             onChannelChange: jest.fn(),
             onRemoteControlCommand: jest.fn(),
@@ -49,6 +52,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsDownloads).toBe(true);
         expect(service.supportsManagedExternalPlayers).toBe(true);
         expect(service.supportsEmbeddedMpv).toBe(true);
+        expect(service.supportsDesktopFileSave).toBe(true);
         expect(service.supportsRemoteControl).toBe(true);
     });
 
@@ -64,6 +68,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsSqlite).toBe(false);
         expect(service.supportsDownloads).toBe(false);
         expect(service.supportsEmbeddedMpv).toBe(false);
+        expect(service.supportsDesktopFileSave).toBe(false);
         expect(service.supportsRemoteControl).toBe(false);
     });
 

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -1,0 +1,81 @@
+import { RuntimeCapabilitiesService } from './runtime-capabilities.service';
+
+describe('RuntimeCapabilitiesService', () => {
+    const testWindow = window as unknown as {
+        electron?: Record<string, unknown>;
+    };
+    const originalElectron = testWindow.electron;
+
+    afterEach(() => {
+        testWindow.electron = originalElectron;
+    });
+
+    it('reports browser PWA capabilities when the Electron bridge is absent', () => {
+        testWindow.electron = undefined;
+
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.environment).toBe('pwa');
+        expect(service.isPwa).toBe(true);
+        expect(service.isElectron).toBe(false);
+        expect(service.supportsEpg).toBe(false);
+        expect(service.supportsSqlite).toBe(false);
+        expect(service.supportsDownloads).toBe(false);
+        expect(service.supportsManagedExternalPlayers).toBe(false);
+        expect(service.supportsEmbeddedMpv).toBe(false);
+        expect(service.supportsRemoteControl).toBe(false);
+    });
+
+    it('reports Electron capabilities from the available preload bridge methods', () => {
+        testWindow.electron = {
+            dbGetAppPlaylists: jest.fn(),
+            dbUpsertAppPlaylist: jest.fn(),
+            dbGetAppState: jest.fn(),
+            dbSetAppState: jest.fn(),
+            downloadsGetList: jest.fn(),
+            prepareEmbeddedMpv: jest.fn(),
+            updateRemoteControlStatus: jest.fn(),
+            onChannelChange: jest.fn(),
+            onRemoteControlCommand: jest.fn(),
+        };
+
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.environment).toBe('electron');
+        expect(service.isElectron).toBe(true);
+        expect(service.isPwa).toBe(false);
+        expect(service.supportsEpg).toBe(true);
+        expect(service.supportsSqlite).toBe(true);
+        expect(service.supportsDownloads).toBe(true);
+        expect(service.supportsManagedExternalPlayers).toBe(true);
+        expect(service.supportsEmbeddedMpv).toBe(true);
+        expect(service.supportsRemoteControl).toBe(true);
+    });
+
+    it('keeps feature-specific capabilities false when an Electron bridge is partial', () => {
+        testWindow.electron = {
+            updateRemoteControlStatus: jest.fn(),
+        };
+
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.environment).toBe('electron');
+        expect(service.supportsEpg).toBe(true);
+        expect(service.supportsSqlite).toBe(false);
+        expect(service.supportsDownloads).toBe(false);
+        expect(service.supportsEmbeddedMpv).toBe(false);
+        expect(service.supportsRemoteControl).toBe(false);
+    });
+
+    it('reads the bridge dynamically so tests and late preload setup stay accurate', () => {
+        testWindow.electron = undefined;
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.isPwa).toBe(true);
+
+        testWindow.electron = {};
+
+        expect(service.isElectron).toBe(true);
+        expect(service.environment).toBe('electron');
+    });
+});

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -18,6 +18,8 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.environment).toBe('pwa');
         expect(service.isPwa).toBe(true);
         expect(service.isElectron).toBe(false);
+        expect(service.platform).toBeUndefined();
+        expect(service.isMacOS).toBe(false);
         expect(service.supportsEpg).toBe(false);
         expect(service.supportsSqlite).toBe(false);
         expect(service.supportsDownloads).toBe(false);
@@ -29,6 +31,7 @@ describe('RuntimeCapabilitiesService', () => {
 
     it('reports Electron capabilities from the available preload bridge methods', () => {
         testWindow.electron = {
+            platform: 'darwin',
             dbGetAppPlaylists: jest.fn(),
             dbUpsertAppPlaylist: jest.fn(),
             dbGetAppState: jest.fn(),
@@ -47,6 +50,8 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.environment).toBe('electron');
         expect(service.isElectron).toBe(true);
         expect(service.isPwa).toBe(false);
+        expect(service.platform).toBe('darwin');
+        expect(service.isMacOS).toBe(true);
         expect(service.supportsEpg).toBe(true);
         expect(service.supportsSqlite).toBe(true);
         expect(service.supportsDownloads).toBe(true);
@@ -64,6 +69,8 @@ describe('RuntimeCapabilitiesService', () => {
         const service = new RuntimeCapabilitiesService();
 
         expect(service.environment).toBe('electron');
+        expect(service.platform).toBeUndefined();
+        expect(service.isMacOS).toBe(false);
         expect(service.supportsEpg).toBe(true);
         expect(service.supportsSqlite).toBe(false);
         expect(service.supportsDownloads).toBe(false);

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -23,6 +23,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEpg).toBe(false);
         expect(service.supportsSqlite).toBe(false);
         expect(service.supportsDownloads).toBe(false);
+        expect(service.supportsPortalActivityStorage).toBe(false);
         expect(service.supportsManagedExternalPlayers).toBe(false);
         expect(service.supportsEmbeddedMpv).toBe(false);
         expect(service.supportsDesktopFileSave).toBe(false);
@@ -36,6 +37,11 @@ describe('RuntimeCapabilitiesService', () => {
             dbUpsertAppPlaylist: jest.fn(),
             dbGetAppState: jest.fn(),
             dbSetAppState: jest.fn(),
+            dbGetGlobalRecentlyViewed: jest.fn(),
+            dbGetAllGlobalFavorites: jest.fn(),
+            dbGetGlobalRecentlyAdded: jest.fn(),
+            dbRemoveRecentItem: jest.fn(),
+            dbRemoveFavorite: jest.fn(),
             downloadsGetList: jest.fn(),
             prepareEmbeddedMpv: jest.fn(),
             saveFileDialog: jest.fn(),
@@ -55,6 +61,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEpg).toBe(true);
         expect(service.supportsSqlite).toBe(true);
         expect(service.supportsDownloads).toBe(true);
+        expect(service.supportsPortalActivityStorage).toBe(true);
         expect(service.supportsManagedExternalPlayers).toBe(true);
         expect(service.supportsEmbeddedMpv).toBe(true);
         expect(service.supportsDesktopFileSave).toBe(true);
@@ -74,6 +81,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEpg).toBe(true);
         expect(service.supportsSqlite).toBe(false);
         expect(service.supportsDownloads).toBe(false);
+        expect(service.supportsPortalActivityStorage).toBe(false);
         expect(service.supportsEmbeddedMpv).toBe(false);
         expect(service.supportsDesktopFileSave).toBe(false);
         expect(service.supportsRemoteControl).toBe(false);

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -28,6 +28,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEmbeddedMpv).toBe(false);
         expect(service.supportsDesktopFileSave).toBe(false);
         expect(service.supportsRemoteControl).toBe(false);
+        expect(service.supportsXtreamSectionNavigation).toBe(false);
     });
 
     it('reports Electron capabilities from the available preload bridge methods', () => {
@@ -66,6 +67,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEmbeddedMpv).toBe(true);
         expect(service.supportsDesktopFileSave).toBe(true);
         expect(service.supportsRemoteControl).toBe(true);
+        expect(service.supportsXtreamSectionNavigation).toBe(true);
     });
 
     it('keeps feature-specific capabilities false when an Electron bridge is partial', () => {

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -81,6 +81,10 @@ export class RuntimeCapabilitiesService {
         );
     }
 
+    get supportsXtreamSectionNavigation(): boolean {
+        return this.isElectron;
+    }
+
     hasElectronMethod(methodName: string): boolean {
         return typeof this.electronBridge?.[methodName] === 'function';
     }

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@angular/core';
+
+export type RuntimeEnvironment = 'electron' | 'pwa';
+
+type RuntimeElectronBridge = Record<string, unknown>;
+
+type RuntimeWindow = Window & {
+    electron?: RuntimeElectronBridge;
+};
+
+@Injectable({ providedIn: 'root' })
+export class RuntimeCapabilitiesService {
+    get environment(): RuntimeEnvironment {
+        return this.isElectron ? 'electron' : 'pwa';
+    }
+
+    get isElectron(): boolean {
+        return !!this.electronBridge;
+    }
+
+    get isPwa(): boolean {
+        return !this.isElectron;
+    }
+
+    get supportsEpg(): boolean {
+        return this.isElectron;
+    }
+
+    get supportsSqlite(): boolean {
+        return (
+            this.hasElectronMethod('dbGetAppPlaylists') &&
+            this.hasElectronMethod('dbUpsertAppPlaylist') &&
+            this.hasElectronMethod('dbGetAppState') &&
+            this.hasElectronMethod('dbSetAppState')
+        );
+    }
+
+    get supportsDownloads(): boolean {
+        return this.hasElectronMethod('downloadsGetList');
+    }
+
+    get supportsManagedExternalPlayers(): boolean {
+        return this.isElectron;
+    }
+
+    get supportsEmbeddedMpv(): boolean {
+        return this.hasElectronMethod('prepareEmbeddedMpv');
+    }
+
+    get supportsRemoteControl(): boolean {
+        return (
+            this.hasElectronMethod('updateRemoteControlStatus') &&
+            this.hasElectronMethod('onChannelChange') &&
+            this.hasElectronMethod('onRemoteControlCommand')
+        );
+    }
+
+    hasElectronMethod(methodName: string): boolean {
+        return typeof this.electronBridge?.[methodName] === 'function';
+    }
+
+    private get electronBridge(): RuntimeElectronBridge | undefined {
+        if (typeof window === 'undefined') {
+            return undefined;
+        }
+
+        return (window as RuntimeWindow).electron;
+    }
+}

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -47,6 +47,13 @@ export class RuntimeCapabilitiesService {
         return this.hasElectronMethod('prepareEmbeddedMpv');
     }
 
+    get supportsDesktopFileSave(): boolean {
+        return (
+            this.hasElectronMethod('saveFileDialog') &&
+            this.hasElectronMethod('writeFile')
+        );
+    }
+
     get supportsRemoteControl(): boolean {
         return (
             this.hasElectronMethod('updateRemoteControlStatus') &&

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -22,6 +22,15 @@ export class RuntimeCapabilitiesService {
         return !this.isElectron;
     }
 
+    get platform(): string | undefined {
+        const platform = this.electronBridge?.['platform'];
+        return typeof platform === 'string' ? platform : undefined;
+    }
+
+    get isMacOS(): boolean {
+        return this.platform === 'darwin';
+    }
+
     get supportsEpg(): boolean {
         return this.isElectron;
     }

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -48,6 +48,16 @@ export class RuntimeCapabilitiesService {
         return this.hasElectronMethod('downloadsGetList');
     }
 
+    get supportsPortalActivityStorage(): boolean {
+        return (
+            this.hasElectronMethod('dbGetGlobalRecentlyViewed') &&
+            this.hasElectronMethod('dbGetAllGlobalFavorites') &&
+            this.hasElectronMethod('dbGetGlobalRecentlyAdded') &&
+            this.hasElectronMethod('dbRemoveRecentItem') &&
+            this.hasElectronMethod('dbRemoveFavorite')
+        );
+    }
+
     get supportsManagedExternalPlayers(): boolean {
         return this.isElectron;
     }

--- a/libs/ui/playback/src/lib/web-player-view/web-player-view.component.spec.ts
+++ b/libs/ui/playback/src/lib/web-player-view/web-player-view.component.spec.ts
@@ -9,6 +9,7 @@ import { StorageMap } from '@ngx-pwa/local-storage';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { VideoPlayer } from '@iptvnator/shared/interfaces';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import type { WebPlayerViewComponent as WebPlayerViewComponentInstance } from './web-player-view.component';
 import {
     PlaybackDiagnostic,
@@ -79,7 +80,7 @@ describe('WebPlayerViewComponent', () => {
     const storageMap = {
         get: jest.fn(() => of({ player: VideoPlayer.VideoJs })),
     };
-    const originalElectron = window.electron;
+    let runtimeCapabilities: { supportsManagedExternalPlayers: boolean };
 
     beforeAll(async () => {
         ({ WebPlayerViewComponent } =
@@ -87,9 +88,17 @@ describe('WebPlayerViewComponent', () => {
     });
 
     beforeEach(async () => {
+        runtimeCapabilities = { supportsManagedExternalPlayers: false };
+
         await TestBed.configureTestingModule({
             imports: [WebPlayerViewComponent, TranslateModule.forRoot()],
-            providers: [{ provide: StorageMap, useValue: storageMap }],
+            providers: [
+                { provide: StorageMap, useValue: storageMap },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtimeCapabilities,
+                },
+            ],
         })
             .overrideComponent(WebPlayerViewComponent, {
                 set: {
@@ -119,7 +128,6 @@ describe('WebPlayerViewComponent', () => {
     });
 
     afterEach(() => {
-        window.electron = originalElectron;
         fixture.destroy();
     });
 
@@ -129,17 +137,9 @@ describe('WebPlayerViewComponent', () => {
         expect(fixture.nativeElement.classList).toContain('web-player-view');
     });
 
-    it('renders diagnostics and emits MPV fallback requests on desktop', () => {
+    it('renders diagnostics and emits MPV fallback requests when managed external players are available', () => {
         const requests: unknown[] = [];
-        fixture.destroy();
-        window.electron = {} as typeof window.electron;
-        fixture = TestBed.createComponent(WebPlayerViewComponent);
-        component = fixture.componentInstance;
-        fixture.componentRef.setInput(
-            'streamUrl',
-            'https://example.com/archive/movie.mkv'
-        );
-        fixture.componentRef.setInput('title', 'Example Movie');
+        runtimeCapabilities.supportsManagedExternalPlayers = true;
         component.externalFallbackRequested.subscribe((request) =>
             requests.push(request)
         );

--- a/libs/ui/playback/src/lib/web-player-view/web-player-view.component.ts
+++ b/libs/ui/playback/src/lib/web-player-view/web-player-view.component.ts
@@ -25,6 +25,7 @@ import {
     VideoPlayer,
 } from '@iptvnator/shared/interfaces';
 import type { ExternalPlayerName } from '@iptvnator/shared/interfaces';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { ArtPlayerComponent } from '../art-player/art-player.component';
 import { EmbeddedMpvPlayerComponent } from '../embedded-mpv-player/embedded-mpv-player.component';
 import { HtmlVideoPlayerComponent } from '../html-video-player/html-video-player.component';
@@ -64,6 +65,7 @@ type PlaybackDiagnosticDetail = {
 })
 export class WebPlayerViewComponent {
     storage = inject(StorageMap);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
 
     streamUrl = input.required<string>();
     title = input('');
@@ -89,12 +91,11 @@ export class WebPlayerViewComponent {
         reloadToken: number;
         sources: { src: string; type: string }[];
     };
-    readonly isDesktop = signal(this.detectDesktop());
     readonly reloadToken = signal(0);
     readonly playbackDiagnostic = signal<PlaybackDiagnostic | null>(null);
     readonly canShowExternalFallbackActions = computed(
         () =>
-            this.isDesktop() &&
+            this.runtime.supportsManagedExternalPlayers &&
             !!this.playbackDiagnostic()?.externalFallbackRecommended
     );
     readonly diagnosticHeadlineKey = computed(() =>
@@ -303,10 +304,6 @@ export class WebPlayerViewComponent {
             default:
                 return 'PLAYBACK_DIAGNOSTICS.UNKNOWN_PLAYBACK_ERROR';
         }
-    }
-
-    private detectDesktop(): boolean {
-        return typeof window !== 'undefined' && !!window.electron;
     }
 
     private isLivePlayback(playback: ResolvedPortalPlayback): boolean {

--- a/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.spec.ts
+++ b/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.spec.ts
@@ -157,7 +157,13 @@ describe('DashboardDataService', () => {
 
     beforeEach(() => {
         Object.defineProperty(window, 'electron', {
-            value: {} as Window['electron'],
+            value: {
+                dbGetGlobalRecentlyViewed: jest.fn(),
+                dbGetAllGlobalFavorites: jest.fn(),
+                dbGetGlobalRecentlyAdded: jest.fn(),
+                dbRemoveRecentItem: jest.fn(),
+                dbRemoveFavorite: jest.fn(),
+            } as unknown as Window['electron'],
             configurable: true,
         });
         playlistsLoadedSignal.set(true);

--- a/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
+++ b/libs/workspace/dashboard/data-access/src/lib/dashboard-data.service.ts
@@ -19,6 +19,7 @@ import {
     DatabaseService,
     GlobalRecentlyAddedKind,
     PlaylistsService,
+    RuntimeCapabilitiesService,
 } from '@iptvnator/services';
 import {
     XTREAM_DATA_SOURCE,
@@ -105,6 +106,7 @@ export class DashboardDataService {
     private readonly dbService = inject(DatabaseService);
     private readonly xtreamDataSource = inject(XTREAM_DATA_SOURCE);
     private readonly playlistsService = inject(PlaylistsService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly ngZone = inject(NgZone);
     private readonly translate = inject(TranslateService);
     private readonly playbackPositions = inject(PORTAL_PLAYBACK_POSITIONS);
@@ -158,7 +160,9 @@ export class DashboardDataService {
     );
     private readonly globalRecentLoadingState = signal(true);
     private readonly globalRecentLoadedState = signal(false);
-    private readonly globalRecentDbLoadedState = signal(!window.electron);
+    private readonly globalRecentDbLoadedState = signal(
+        !this.hasPortalActivityStorage
+    );
     private readonly globalFavoritesLoadingState = signal(true);
     private readonly globalFavoritesLoadedState = signal(false);
     private readonly xtreamRecentlyAddedLoadingState = signal(true);
@@ -185,6 +189,11 @@ export class DashboardDataService {
         this.xtreamRecentlyAddedLoadedState.asReadonly();
     readonly xtreamRecentlyAddedItems =
         this.xtreamRecentlyAddedItemsState.asReadonly();
+
+    private get hasPortalActivityStorage(): boolean {
+        return this.runtime.supportsPortalActivityStorage;
+    }
+
     readonly dashboardReady = computed(
         () =>
             this.playlistsLoaded() &&
@@ -479,7 +488,7 @@ export class DashboardDataService {
             this.globalRecentLoadingState.set(true);
         }
 
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             const recentItems = await this.loadPwaXtreamGlobalRecentItems();
             this.ngZone.run(() =>
                 this.xtreamGlobalRecentItems.set(recentItems)
@@ -523,7 +532,7 @@ export class DashboardDataService {
         kind: DashboardRecentlyAddedFilterKind,
         limit = 200
     ): Promise<DashboardRecentlyAddedItem[]> {
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             return [];
         }
 
@@ -536,7 +545,7 @@ export class DashboardDataService {
     async getXtreamRecentlyAddedItems(
         limit = 20
     ): Promise<DashboardRecentlyAddedItem[]> {
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             return [];
         }
 
@@ -555,7 +564,7 @@ export class DashboardDataService {
             this.xtreamRecentlyAddedLoadingState.set(true);
         }
 
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             this.ngZone.run(() => {
                 this.xtreamRecentlyAddedItemsState.set([]);
                 this.xtreamRecentlyAddedLoadingState.set(false);
@@ -584,7 +593,7 @@ export class DashboardDataService {
     }
 
     private async reloadXtreamGlobalFavorites(): Promise<void> {
-        if (!window.electron) {
+        if (!this.hasPortalActivityStorage) {
             const favorites = await this.loadPwaXtreamGlobalFavorites();
             this.ngZone.run(() => this.xtreamGlobalFavorites.set(favorites));
             this.finishInitialGlobalFavoritesLoadIfReady();
@@ -860,7 +869,7 @@ export class DashboardDataService {
 
     async removeGlobalRecentItem(item: GlobalRecentItem): Promise<void> {
         if (item.source === 'xtream') {
-            if (window.electron) {
+            if (this.hasPortalActivityStorage) {
                 await this.dbService.removeRecentItem(
                     item.id as number,
                     item.playlist_id
@@ -1021,7 +1030,7 @@ export class DashboardDataService {
 
     async removeGlobalFavorite(item: DashboardFavoriteItem): Promise<void> {
         if (item.source === 'xtream') {
-            if (window.electron) {
+            if (this.hasPortalActivityStorage) {
                 await this.dbService.removeFromFavorites(
                     item.id as number,
                     item.playlist_id

--- a/libs/workspace/dashboard/feature/src/lib/rails/workspace-dashboard-rails.component.ts
+++ b/libs/workspace/dashboard/feature/src/lib/rails/workspace-dashboard-rails.component.ts
@@ -30,7 +30,11 @@ import {
 } from '@iptvnator/workspace/shell/util';
 import { DialogService } from '@iptvnator/ui/components';
 import { PlaylistActions } from '@iptvnator/m3u-state';
-import { DatabaseService, PlaylistsService } from '@iptvnator/services';
+import {
+    DatabaseService,
+    PlaylistsService,
+    RuntimeCapabilitiesService,
+} from '@iptvnator/services';
 import {
     DashboardDataService,
     DashboardFavoriteItem,
@@ -428,11 +432,12 @@ export class WorkspaceDashboardRailsComponent {
     private readonly shellActions = inject(WORKSPACE_SHELL_ACTIONS);
     private readonly epgService = inject(EpgService);
     private readonly playlistsService = inject(PlaylistsService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
 
     readonly hasPlaylists = computed(() => this.data.playlists().length > 0);
     readonly ready = this.data.dashboardReady;
     readonly xtreamPlaylistCount = this.data.xtreamPlaylistCount;
-    readonly isElectron = !!window.electron;
+    readonly isElectron = this.runtime.isElectron;
 
     readonly skeletonSlots = SKELETON_CARDS_PER_RAIL;
     readonly skeletonRails = SKELETON_RAILS;
@@ -776,7 +781,7 @@ export class WorkspaceDashboardRailsComponent {
     }
 
     private async removePlaylist(playlist: PlaylistMeta): Promise<void> {
-        const deleted = window.electron
+        const deleted = this.runtime.isElectron
             ? await this.deletePlaylistInElectron(playlist)
             : await this.deletePlaylistInBrowser(playlist);
 

--- a/libs/workspace/dashboard/feature/src/lib/rails/workspace-dashboard-rails.component.ts
+++ b/libs/workspace/dashboard/feature/src/lib/rails/workspace-dashboard-rails.component.ts
@@ -21,8 +21,8 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import {
     EmptyStateComponent,
     PlaylistInfoComponent,
+    PlaylistRefreshActionService,
 } from '@iptvnator/playlist/shared/ui';
-import { PlaylistRefreshActionService } from '@iptvnator/playlist/shared/util';
 import {
     WORKSPACE_SHELL_ACTIONS,
     WorkspacePlaylistType,

--- a/libs/workspace/dashboard/feature/src/lib/rails/workspace-dashboard-rails.component.ts
+++ b/libs/workspace/dashboard/feature/src/lib/rails/workspace-dashboard-rails.component.ts
@@ -18,7 +18,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { RouterLink } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { firstValueFrom } from 'rxjs';
 import {
     EmptyStateComponent,
     PlaylistInfoComponent,
@@ -31,8 +30,7 @@ import {
 import { DialogService } from '@iptvnator/ui/components';
 import { PlaylistActions } from '@iptvnator/m3u-state';
 import {
-    DatabaseService,
-    PlaylistsService,
+    PlaylistDeleteActionService,
     RuntimeCapabilitiesService,
 } from '@iptvnator/services';
 import {
@@ -416,9 +414,9 @@ function isXtreamAccountPlaylist(
 })
 export class WorkspaceDashboardRailsComponent {
     readonly data = inject(DashboardDataService);
-    private readonly databaseService = inject(DatabaseService);
     private readonly dialog = inject(MatDialog);
     private readonly dialogService = inject(DialogService);
+    private readonly playlistDeleteAction = inject(PlaylistDeleteActionService);
     private readonly playlistRefreshAction = inject(
         PlaylistRefreshActionService
     );
@@ -431,7 +429,6 @@ export class WorkspaceDashboardRailsComponent {
     );
     private readonly shellActions = inject(WORKSPACE_SHELL_ACTIONS);
     private readonly epgService = inject(EpgService);
-    private readonly playlistsService = inject(PlaylistsService);
     private readonly runtime = inject(RuntimeCapabilitiesService);
 
     readonly hasPlaylists = computed(() => this.data.playlists().length > 0);
@@ -781,9 +778,8 @@ export class WorkspaceDashboardRailsComponent {
     }
 
     private async removePlaylist(playlist: PlaylistMeta): Promise<void> {
-        const deleted = this.runtime.isElectron
-            ? await this.deletePlaylistInElectron(playlist)
-            : await this.deletePlaylistInBrowser(playlist);
+        const deleted =
+            await this.playlistDeleteAction.deletePlaylist(playlist);
 
         if (!deleted) {
             return;
@@ -797,28 +793,6 @@ export class WorkspaceDashboardRailsComponent {
             undefined,
             { duration: 2000 }
         );
-    }
-
-    private async deletePlaylistInElectron(
-        playlist: PlaylistMeta
-    ): Promise<boolean> {
-        const operationId = playlist.serverUrl
-            ? this.databaseService.createOperationId('playlist-delete')
-            : undefined;
-
-        return this.databaseService.deletePlaylist(
-            playlist._id,
-            operationId ? { operationId } : undefined
-        );
-    }
-
-    private async deletePlaylistInBrowser(
-        playlist: PlaylistMeta
-    ): Promise<boolean> {
-        const result = await firstValueFrom(
-            this.playlistsService.deletePlaylist(playlist._id)
-        );
-        return result.success;
     }
 
     private t(key: string): string {

--- a/libs/workspace/shell/feature/src/lib/workspace-keyboard-shortcuts/workspace-keyboard-shortcuts.service.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-keyboard-shortcuts/workspace-keyboard-shortcuts.service.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject } from 'rxjs';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { WorkspaceKeyboardShortcutsService } from './workspace-keyboard-shortcuts.service';
 
 describe('WorkspaceKeyboardShortcutsService', () => {
     let afterClosed$: Subject<void>;
     let dialog: { open: jest.Mock };
+    let runtime: { isElectron: boolean };
     let service: WorkspaceKeyboardShortcutsService;
 
     beforeEach(() => {
@@ -15,11 +17,13 @@ describe('WorkspaceKeyboardShortcutsService', () => {
                 afterClosed: () => afterClosed$.asObservable(),
             }),
         };
+        runtime = { isElectron: true };
 
         TestBed.configureTestingModule({
             providers: [
                 WorkspaceKeyboardShortcutsService,
                 { provide: MatDialog, useValue: dialog },
+                { provide: RuntimeCapabilitiesService, useValue: runtime },
             ],
         });
 
@@ -92,5 +96,18 @@ describe('WorkspaceKeyboardShortcutsService', () => {
             'WORKSPACE.SHORTCUTS.PLATFORM.OTHER'
         );
         expect(commandPaletteShortcut?.chords[0].keys[0].label).toBe('Ctrl');
+    });
+
+    it('uses runtime capabilities for Electron-only shortcuts', () => {
+        runtime.isElectron = false;
+
+        service.openShortcutsDialog();
+
+        const dialogData = dialog.open.mock.calls[0][1].data;
+        const itemIds = dialogData.groups.flatMap((group) =>
+            group.items.map((item) => item.id)
+        );
+
+        expect(itemIds).not.toContain('open-global-search');
     });
 });

--- a/libs/workspace/shell/feature/src/lib/workspace-keyboard-shortcuts/workspace-keyboard-shortcuts.service.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-keyboard-shortcuts/workspace-keyboard-shortcuts.service.ts
@@ -6,6 +6,7 @@ import {
     isKeyboardShortcutHelpTrigger,
     isTypingInInput,
 } from '@iptvnator/portal/shared/util';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import {
     WorkspaceKeyboardShortcutsDialogComponent,
     WorkspaceKeyboardShortcutsDialogData,
@@ -15,6 +16,7 @@ import {
 export class WorkspaceKeyboardShortcutsService {
     private readonly dialog = inject(MatDialog);
     private readonly destroyRef = inject(DestroyRef);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly onDocumentKeydown = (event: KeyboardEvent): void =>
         this.handleKeydown(event);
 
@@ -49,7 +51,7 @@ export class WorkspaceKeyboardShortcutsService {
             data: {
                 groups: getKeyboardShortcutGroups({
                     isMac: platform === 'mac',
-                    isElectron: this.isElectron(),
+                    isElectron: this.runtime.isElectron,
                 }),
                 platformIcon:
                     platform === 'mac' ? 'laptop_mac' : 'desktop_windows',
@@ -93,7 +95,4 @@ export class WorkspaceKeyboardShortcutsService {
         return /Mac|iPhone|iPad|iPod/i.test(platform) ? 'mac' : 'other';
     }
 
-    private isElectron(): boolean {
-        return typeof window !== 'undefined' && !!window.electron;
-    }
 }

--- a/libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.spec.ts
@@ -7,7 +7,7 @@ import {
     WorkspaceCommandContribution,
     WorkspaceViewCommandService,
 } from '@iptvnator/portal/shared/util';
-import { SettingsStore } from '@iptvnator/services';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import { VideoPlayer } from '@iptvnator/shared/interfaces';
 import { WorkspacePlayerCommandsContributor } from './workspace-player-commands.contributor';
 
@@ -46,16 +46,10 @@ describe('WorkspacePlayerCommandsContributor', () => {
     let viewCommands: ViewCommandsMock;
     let settingsStore: SettingsStoreMock;
     let snackBar: SnackBarMock;
+    let runtime: { supportsManagedExternalPlayers: boolean };
     let translate: { instant: jest.Mock; onLangChange: ReturnType<typeof of> };
 
-    function bootstrap(options: { isDesktop: boolean }) {
-        if (options.isDesktop) {
-            window.electron = { platform: 'darwin' } as typeof window.electron;
-        } else {
-            // @ts-expect-error - simulating PWA environment
-            window.electron = undefined;
-        }
-
+    function bootstrap(options: { supportsManagedExternalPlayers: boolean }) {
         viewCommands = {
             registerCommand: jest.fn().mockReturnValue(() => undefined),
             commands: jest.fn().mockReturnValue([]),
@@ -65,6 +59,10 @@ describe('WorkspacePlayerCommandsContributor', () => {
             updateSettings: jest.fn().mockResolvedValue(undefined),
         };
         snackBar = { open: jest.fn() };
+        runtime = {
+            supportsManagedExternalPlayers:
+                options.supportsManagedExternalPlayers,
+        };
         translate = {
             instant: jest.fn(
                 (key: string, params?: Record<string, string | number>) =>
@@ -83,6 +81,7 @@ describe('WorkspacePlayerCommandsContributor', () => {
                     useValue: viewCommands,
                 },
                 { provide: SettingsStore, useValue: settingsStore },
+                { provide: RuntimeCapabilitiesService, useValue: runtime },
                 { provide: MatSnackBar, useValue: snackBar },
                 { provide: TranslateService, useValue: translate },
             ],
@@ -96,7 +95,7 @@ describe('WorkspacePlayerCommandsContributor', () => {
     });
 
     it('registers all five player commands when running in Electron', () => {
-        bootstrap({ isDesktop: true });
+        bootstrap({ supportsManagedExternalPlayers: true });
 
         const ids = getRegistered(viewCommands).map((c) => c.id);
         expect(ids).toEqual([
@@ -108,8 +107,8 @@ describe('WorkspacePlayerCommandsContributor', () => {
         ]);
     });
 
-    it('hides MPV and VLC when window.electron is unavailable', () => {
-        bootstrap({ isDesktop: false });
+    it('hides MPV and VLC when managed external players are unavailable', () => {
+        bootstrap({ supportsManagedExternalPlayers: false });
 
         const registered = getRegistered(viewCommands);
         const visibilityById = Object.fromEntries(
@@ -124,7 +123,7 @@ describe('WorkspacePlayerCommandsContributor', () => {
     });
 
     it('marks the active player command as disabled', () => {
-        bootstrap({ isDesktop: true });
+        bootstrap({ supportsManagedExternalPlayers: true });
         settingsStore.player.set(VideoPlayer.MPV);
 
         const registered = getRegistered(viewCommands);
@@ -138,7 +137,7 @@ describe('WorkspacePlayerCommandsContributor', () => {
     });
 
     it('updates settings and shows feedback on run', () => {
-        bootstrap({ isDesktop: true });
+        bootstrap({ supportsManagedExternalPlayers: true });
 
         const mpvCommand = getRegistered(viewCommands).find(
             (c) => c.id === 'switch-player-mpv'

--- a/libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.ts
@@ -5,7 +5,7 @@ import {
     WorkspaceCommandContribution,
     WorkspaceViewCommandService,
 } from '@iptvnator/portal/shared/util';
-import { SettingsStore } from '@iptvnator/services';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import { VideoPlayer } from '@iptvnator/shared/interfaces';
 
 interface PlayerCommandDefinition {
@@ -73,8 +73,7 @@ export class WorkspacePlayerCommandsContributor {
     private readonly snackBar = inject(MatSnackBar);
     private readonly translate = inject(TranslateService);
     private readonly destroyRef = inject(DestroyRef);
-
-    private readonly isDesktop = !!window.electron;
+    private readonly runtime = inject(RuntimeCapabilitiesService);
 
     constructor() {
         const unregisters = PLAYER_COMMAND_DEFS.map((def) =>
@@ -106,7 +105,8 @@ export class WorkspacePlayerCommandsContributor {
                 this.translate.instant(def.nameKey).toLowerCase(),
             ],
             priority: def.priority,
-            visible: () => !def.desktopOnly || this.isDesktop,
+            visible: () =>
+                !def.desktopOnly || this.runtime.supportsManagedExternalPlayers,
             enabled: () => this.settingsStore.player() !== def.player,
             run: () => this.activate(def),
         };

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-xtream-import.service.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-xtream-import.service.ts
@@ -4,6 +4,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { startWith } from 'rxjs';
 import { PlaylistRefreshActionService } from '@iptvnator/playlist/shared/ui';
 import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import type { XtreamImportPhaseTone } from './helpers/workspace-shell-constants';
 import {
     buildXtreamImportDetailLabel,
@@ -23,8 +24,9 @@ export class WorkspaceShellXtreamImportService {
     private readonly playlistRefreshAction = inject(
         PlaylistRefreshActionService
     );
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly translate = inject(TranslateService);
-    private readonly isElectron = !!window.electron;
+    private readonly isElectron = this.runtime.isElectron;
 
     private readonly languageTick = toSignal(
         this.translate.onLangChange.pipe(startWith(null)),

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-xtream-import.service.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-xtream-import.service.ts
@@ -2,7 +2,7 @@ import { computed, inject, Injectable } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
 import { startWith } from 'rxjs';
-import { PlaylistRefreshActionService } from '@iptvnator/playlist/shared/util';
+import { PlaylistRefreshActionService } from '@iptvnator/playlist/shared/ui';
 import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
 import type { XtreamImportPhaseTone } from './helpers/workspace-shell-constants';
 import {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
@@ -6,10 +6,10 @@ import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import {
-    PlaylistContextFacade,
     PlaylistRefreshActionService,
     type XtreamRefreshPreparationState,
-} from '@iptvnator/playlist/shared/util';
+} from '@iptvnator/playlist/shared/ui';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import {
     PORTAL_EXTERNAL_PLAYBACK,
     WorkspaceHeaderContextService,

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
@@ -17,7 +17,11 @@ import {
 } from '@iptvnator/portal/shared/util';
 import { StalkerStore } from '@iptvnator/portal/stalker/data-access';
 import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
-import { PlaylistsService, SettingsStore } from '@iptvnator/services';
+import {
+    PlaylistsService,
+    RuntimeCapabilitiesService,
+    SettingsStore,
+} from '@iptvnator/services';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
 import {
     WorkspaceStartupPreferencesService,
@@ -135,10 +139,17 @@ describe('WorkspaceShellFacade', () => {
         persistLastRestorablePath: jest.Mock;
         showDashboard: jest.Mock;
     };
+    let runtime: {
+        isElectron: boolean;
+        isMacOS: boolean;
+    };
 
     beforeEach(() => {
-        window.electron = { platform: 'darwin' } as typeof window.electron;
         showDashboardSignal = signal(true);
+        runtime = {
+            isElectron: true,
+            isMacOS: true,
+        };
 
         activePlaylistSignal = signal({
             _id: 'pl-1',
@@ -255,6 +266,10 @@ describe('WorkspaceShellFacade', () => {
                     },
                 },
                 {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtime,
+                },
+                {
                     provide: PlaylistsService,
                     useValue: playlistsService,
                 },
@@ -320,6 +335,11 @@ describe('WorkspaceShellFacade', () => {
         });
 
         facade = TestBed.inject(WorkspaceShellFacade);
+    });
+
+    it('derives desktop shell flags from runtime capabilities', () => {
+        expect(facade.isElectron).toBe(true);
+        expect(facade.isMacOS).toBe(true);
     });
 
     it('routes dashboard search Enter into the active Xtream playlist search', () => {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
@@ -36,6 +36,7 @@ import {
 import {
     DownloadsService,
     PlaylistsService,
+    RuntimeCapabilitiesService,
     SettingsStore,
 } from '@iptvnator/services';
 import { PlaylistActions, selectAllPlaylistsMeta } from '@iptvnator/m3u-state';
@@ -96,6 +97,7 @@ export class WorkspaceShellFacade {
     private readonly playlistRefreshAction = inject(
         PlaylistRefreshActionService
     );
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly downloadsService = inject(DownloadsService);
     readonly hasActiveDownloads = computed(
         () => this.isElectron && this.downloadsService.activeCount() > 0
@@ -137,8 +139,8 @@ export class WorkspaceShellFacade {
 
     readonly searchQuery = signal('');
     readonly appliedSearchQuery = signal('');
-    readonly isElectron = !!window.electron;
-    readonly isMacOS = window.electron?.platform === 'darwin';
+    readonly isElectron = this.runtime.isElectron;
+    readonly isMacOS = this.runtime.isMacOS;
     readonly currentUrl = signal(this.router.url);
     readonly currentRoute = computed(() =>
         parseWorkspaceShellRoute(this.currentUrl())

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
@@ -12,11 +12,11 @@ import { NavigationEnd, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { filter, firstValueFrom, startWith } from 'rxjs';
-import { PlaylistInfoComponent } from '@iptvnator/playlist/shared/ui';
 import {
-    PlaylistContextFacade,
+    PlaylistInfoComponent,
     PlaylistRefreshActionService,
-} from '@iptvnator/playlist/shared/util';
+} from '@iptvnator/playlist/shared/ui';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import {
     buildPortalRailLinks,
     PORTAL_EXTERNAL_PLAYBACK,
@@ -33,7 +33,11 @@ import {
     WorkspaceSearchCapability,
     WorkspaceStartupPreferencesService,
 } from '@iptvnator/workspace/shell/util';
-import { DownloadsService, PlaylistsService, SettingsStore } from '@iptvnator/services';
+import {
+    DownloadsService,
+    PlaylistsService,
+    SettingsStore,
+} from '@iptvnator/services';
 import { PlaylistActions, selectAllPlaylistsMeta } from '@iptvnator/m3u-state';
 import { PlaylistMeta } from '@iptvnator/shared/interfaces';
 import {


### PR DESCRIPTION
## Summary
- Use `RuntimeCapabilitiesService` as the Settings page source for platform state.
- Keep existing Electron bridge calls unchanged, while form shape and PWA/Desktop state come from the shared runtime boundary.

## Changes
- Replaced direct `window.electron` desktop detection with `runtime.isElectron`.
- Replaced `DataService.getAppEnvironment()` PWA detection with `runtime.isPwa`.
- Extended the browser/PWA settings regression test to verify runtime-backed platform state and the PWA form shape.

## Testing
- [x] `pnpm nx test web --runTestsByPath apps/web/src/app/settings/settings.component.spec.ts`
- [x] `pnpm nx lint web`
- [x] `pnpm run typecheck:web`
- [x] `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- [x] `pnpm nx build web --configuration=pwa --skip-nx-cache`