### PR TITLE
refactor(epg): use runtime capability for desktop guards

### DIFF
--- a/libs/epg/data-access/src/lib/epg.service.spec.ts
+++ b/libs/epg/data-access/src/lib/epg.service.spec.ts
@@ -2,15 +2,24 @@ import { TestBed } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
 import { firstValueFrom } from 'rxjs';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { EpgService } from './epg.service';
 
 describe('EpgService', () => {
     let service: EpgService;
+    let runtimeCapabilities: { supportsEpg: boolean };
+    const originalElectron = window.electron;
 
     beforeEach(() => {
+        runtimeCapabilities = { supportsEpg: false };
+
         TestBed.configureTestingModule({
             providers: [
                 EpgService,
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtimeCapabilities,
+                },
                 {
                     provide: MatSnackBar,
                     useValue: {
@@ -27,6 +36,22 @@ describe('EpgService', () => {
         });
 
         service = TestBed.inject(EpgService);
+    });
+
+    afterEach(() => {
+        window.electron = originalElectron;
+    });
+
+    it('does not fetch EPG when runtime EPG support is disabled', () => {
+        const fetchEpg = jest.fn();
+        window.electron = {
+            ...window.electron,
+            fetchEpg,
+        } as unknown as typeof window.electron;
+
+        service.fetchEpg(['https://example.com/epg.xml']);
+
+        expect(fetchEpg).not.toHaveBeenCalled();
     });
 
     it('returns an empty batch result when the desktop bridge is unavailable', async () => {

--- a/libs/epg/data-access/src/lib/epg.service.ts
+++ b/libs/epg/data-access/src/lib/epg.service.ts
@@ -8,6 +8,7 @@ import {
     EpgChannelMetadata,
     EpgProgram,
 } from '@iptvnator/shared/interfaces';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { normalizeEpgPrograms } from './epg-program-normalization.util';
 
 interface CachedProgram {
@@ -29,6 +30,7 @@ const debugEpgService = createDevLogger('EpgService');
 export class EpgService {
     private snackBar = inject(MatSnackBar);
     private translate = inject(TranslateService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
 
     private epgAvailable = new BehaviorSubject<boolean>(false);
     private currentEpgPrograms = new BehaviorSubject<EpgProgram[]>([]);
@@ -37,8 +39,6 @@ export class EpgService {
     private programCache = new Map<string, CachedProgram>();
     private readonly CACHE_TTL = 60000; // 60 seconds
 
-    private readonly isDesktop = !!window.electron;
-
     readonly epgAvailable$ = this.epgAvailable.asObservable();
     readonly currentEpgPrograms$ = this.currentEpgPrograms.asObservable();
 
@@ -46,7 +46,7 @@ export class EpgService {
      * Fetches EPG from the given URLs
      */
     fetchEpg(urls: string[]): void {
-        if (!this.isDesktop) return;
+        if (!this.runtime.supportsEpg) return;
 
         // Filter out empty URLs and send all URLs at once
         const validUrls = urls.filter((url) => url?.trim());
@@ -76,7 +76,7 @@ export class EpgService {
      * Gets EPG programs for a specific channel
      */
     getChannelPrograms(channelId: string): void {
-        if (!this.isDesktop) return;
+        if (!this.runtime.supportsEpg) return;
         debugEpgService('Fetching EPG for channel ID:', channelId);
 
         from(window.electron.getChannelPrograms(channelId))
@@ -116,7 +116,7 @@ export class EpgService {
     getCurrentProgramForChannel(
         channelId: string
     ): Observable<EpgProgram | null> {
-        if (!this.isDesktop || !channelId) {
+        if (!this.runtime.supportsEpg || !channelId) {
             return of(null);
         }
 
@@ -184,7 +184,7 @@ export class EpgService {
     getCurrentProgramsForChannels(
         channelIds: string[]
     ): Observable<Map<string, EpgProgram | null>> {
-        if (!this.isDesktop) {
+        if (!this.runtime.supportsEpg) {
             return of(new Map());
         }
 
@@ -263,7 +263,7 @@ export class EpgService {
     getChannelMetadataForChannels(
         channelIds: string[]
     ): Observable<Map<string, EpgChannelMetadata | null>> {
-        if (!this.isDesktop) {
+        if (!this.runtime.supportsEpg) {
             return of(new Map());
         }
 


### PR DESCRIPTION
## Summary
- Replace EPG data-access local desktop detection with the shared runtime EPG capability.
- Keep existing Electron EPG bridge calls in place, but make the PWA/Electron guard consistent with the rest of the runtime boundary.

## Changes
- Inject `RuntimeCapabilitiesService` into `EpgService`.
- Use `supportsEpg` for fetch/program/metadata guards instead of a `window.electron` snapshot.
- Add coverage proving EPG fetch does not run when runtime EPG support is disabled.

## Testing
- [x] `pnpm nx test epg-data-access --runTestsByPath libs/epg/data-access/src/lib/epg.service.spec.ts`
- [x] `pnpm nx lint epg-data-access`
- [x] `pnpm run typecheck:web`
- [x] `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- [x] `pnpm nx build web --configuration=pwa --skip-nx-cache`