### PR TITLE
refactor(epg): gate progress bridge by runtime capability

### DIFF
--- a/libs/epg/data-access/src/lib/epg-progress.service.spec.ts
+++ b/libs/epg/data-access/src/lib/epg-progress.service.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
+import {
+    EpgImportProgress,
+    EpgProgressService,
+} from './epg-progress.service';
+
+describe('EpgProgressService', () => {
+    let runtimeCapabilities: { supportsEpg: boolean };
+    const originalElectron = window.electron;
+
+    beforeEach(() => {
+        runtimeCapabilities = { supportsEpg: false };
+    });
+
+    afterEach(() => {
+        window.electron = originalElectron;
+        TestBed.resetTestingModule();
+        jest.restoreAllMocks();
+    });
+
+    function configureService(): EpgProgressService {
+        TestBed.configureTestingModule({
+            providers: [
+                EpgProgressService,
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtimeCapabilities,
+                },
+            ],
+        });
+
+        return TestBed.inject(EpgProgressService);
+    }
+
+    it('does not subscribe to Electron progress events when runtime EPG support is disabled', () => {
+        const onEpgProgress = jest.fn();
+        window.electron = {
+            ...window.electron,
+            onEpgProgress,
+        } as unknown as typeof window.electron;
+
+        configureService();
+
+        expect(onEpgProgress).not.toHaveBeenCalled();
+    });
+
+    it('does not force retry when runtime EPG support is disabled', () => {
+        const forceFetchEpg = jest.fn();
+        window.electron = {
+            ...window.electron,
+            forceFetchEpg,
+        } as unknown as typeof window.electron;
+        const service = configureService();
+
+        service.retry('https://example.com/epg.xml');
+
+        expect(forceFetchEpg).not.toHaveBeenCalled();
+    });
+
+    it('updates imports from Electron progress events when runtime EPG support is enabled', () => {
+        let listener: ((progress: EpgImportProgress) => void) | undefined;
+        window.electron = {
+            ...window.electron,
+            onEpgProgress: jest.fn((callback) => {
+                listener = callback;
+            }),
+        } as unknown as typeof window.electron;
+        runtimeCapabilities.supportsEpg = true;
+        const service = configureService();
+
+        listener?.({
+            url: 'https://example.com/epg.xml',
+            status: 'loading',
+        });
+
+        expect(window.electron?.onEpgProgress).toHaveBeenCalledTimes(1);
+        expect(service.imports()).toEqual([
+            {
+                url: 'https://example.com/epg.xml',
+                status: 'loading',
+            },
+        ]);
+    });
+});

--- a/libs/epg/data-access/src/lib/epg-progress.service.ts
+++ b/libs/epg/data-access/src/lib/epg-progress.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, computed, signal } from '@angular/core';
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 
 export interface EpgImportProgress {
     url: string;
@@ -10,6 +11,7 @@ export interface EpgImportProgress {
 
 @Injectable({ providedIn: 'root' })
 export class EpgProgressService {
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly importsMap = signal<Map<string, EpgImportProgress>>(
         new Map()
     );
@@ -48,6 +50,9 @@ export class EpgProgressService {
         // Clear the errored row so the backend's subsequent 'queued' event
         // reappears cleanly rather than updating an existing error row.
         this.removeImport(url);
+        if (!this.runtime.supportsEpg) {
+            return;
+        }
         void window.electron?.forceFetchEpg?.(url);
     }
 
@@ -57,7 +62,7 @@ export class EpgProgressService {
         }
         this.initialized = true;
 
-        if (window.electron?.onEpgProgress) {
+        if (this.runtime.supportsEpg && window.electron?.onEpgProgress) {
             window.electron.onEpgProgress((data) => {
                 this.updateProgress(data);
             });


### PR DESCRIPTION
## Summary
- Gate EPG progress listener and retry calls on the shared runtime EPG capability.
- Prevent PWA/no-EPG runtime from touching Electron-only EPG progress bridge methods.

## Changes
- Inject `RuntimeCapabilitiesService` into `EpgProgressService`.
- Use `supportsEpg` before subscribing to `onEpgProgress` or invoking `forceFetchEpg` retry.
- Add unit coverage for disabled-runtime behavior and enabled-runtime progress updates.

## Testing
- [x] `pnpm nx test epg-data-access --runTestsByPath libs/epg/data-access/src/lib/epg-progress.service.spec.ts`
- [x] `pnpm nx lint epg-data-access`
- [x] `pnpm run typecheck:web`
- [x] `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- [x] `pnpm nx build web --configuration=pwa --skip-nx-cache`