### PR TITLE
refactor(epg): gate source freshness by runtime capability

### DIFF
--- a/libs/ui/epg/src/lib/epg-source-status/epg-source-status.component.spec.ts
+++ b/libs/ui/epg/src/lib/epg-source-status/epg-source-status.component.spec.ts
@@ -1,0 +1,82 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { EpgProgressService } from '@iptvnator/epg/data-access';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
+import { EpgSourceStatusComponent } from './epg-source-status.component';
+
+describe('EpgSourceStatusComponent', () => {
+    let fixture: ComponentFixture<EpgSourceStatusComponent>;
+    let component: EpgSourceStatusComponent;
+    let runtimeCapabilities: { supportsEpg: boolean };
+    const imports = signal([]);
+    const originalElectron = window.electron;
+
+    beforeEach(async () => {
+        runtimeCapabilities = { supportsEpg: false };
+        imports.set([]);
+
+        await TestBed.configureTestingModule({
+            imports: [EpgSourceStatusComponent, TranslateModule.forRoot()],
+            providers: [
+                {
+                    provide: EpgProgressService,
+                    useValue: { imports },
+                },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtimeCapabilities,
+                },
+            ],
+        }).compileComponents();
+    });
+
+    afterEach(() => {
+        window.electron = originalElectron;
+        fixture?.destroy();
+    });
+
+    function createComponent(url = 'https://example.com/epg.xml'): void {
+        fixture = TestBed.createComponent(EpgSourceStatusComponent);
+        component = fixture.componentInstance;
+        fixture.componentRef.setInput('url', url);
+    }
+
+    it('does not check source freshness when runtime EPG support is disabled', async () => {
+        const checkEpgFreshness = jest.fn().mockResolvedValue({
+            freshUrls: ['https://example.com/epg.xml'],
+            staleUrls: [],
+        });
+        window.electron = {
+            ...window.electron,
+            checkEpgFreshness,
+        } as unknown as typeof window.electron;
+        createComponent();
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(checkEpgFreshness).not.toHaveBeenCalled();
+        expect(component.status()).toBe('unknown');
+    });
+
+    it('loads source freshness when runtime EPG support is enabled', async () => {
+        const url = 'https://example.com/epg.xml';
+        const checkEpgFreshness = jest.fn().mockResolvedValue({
+            freshUrls: [url],
+            staleUrls: [],
+        });
+        window.electron = {
+            ...window.electron,
+            checkEpgFreshness,
+        } as unknown as typeof window.electron;
+        runtimeCapabilities.supportsEpg = true;
+        createComponent(url);
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(checkEpgFreshness).toHaveBeenCalledWith([url], 12);
+        expect(component.status()).toBe('fresh');
+    });
+});

--- a/libs/ui/epg/src/lib/epg-source-status/epg-source-status.component.ts
+++ b/libs/ui/epg/src/lib/epg-source-status/epg-source-status.component.ts
@@ -12,6 +12,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslatePipe } from '@ngx-translate/core';
 import { EpgProgressService } from '@iptvnator/epg/data-access';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 
 type BadgeStatus =
     | 'loading'
@@ -37,6 +38,7 @@ export class EpgSourceStatusComponent implements OnInit {
     readonly url = input.required<string>();
 
     private readonly epgProgress = inject(EpgProgressService);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
 
     private readonly freshnessLoaded = signal(false);
     private readonly isFresh = signal(false);
@@ -78,7 +80,7 @@ export class EpgSourceStatusComponent implements OnInit {
     }
 
     async ngOnInit(): Promise<void> {
-        if (!window.electron?.checkEpgFreshness) {
+        if (!this.runtime.supportsEpg || !window.electron?.checkEpgFreshness) {
             return;
         }
         const url = this.url();


### PR DESCRIPTION
## Summary
- Gate EPG source freshness checks on the shared runtime EPG capability.
- Prevent PWA/no-EPG runtime from probing Electron-only freshness APIs.

## Changes
- Inject `RuntimeCapabilitiesService` into `EpgSourceStatusComponent`.
- Use `supportsEpg` before calling `checkEpgFreshness`.
- Add component coverage for disabled-runtime behavior and enabled-runtime freshness loading.

## Testing
- [x] `pnpm nx test ui-epg --runTestsByPath libs/ui/epg/src/lib/epg-source-status/epg-source-status.component.spec.ts`
- [x] `pnpm nx lint ui-epg`
- [x] `pnpm run typecheck:web`
- [x] `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- [x] `pnpm nx build web --configuration=pwa --skip-nx-cache`