### PR TITLE
refactor(epg): gate multi epg queries by runtime capability

### DIFF
--- a/libs/ui/epg/src/lib/multi-epg/multi-epg-container.component.spec.ts
+++ b/libs/ui/epg/src/lib/multi-epg/multi-epg-container.component.spec.ts
@@ -1,4 +1,14 @@
-import { isSelectedEpgDayToday } from './multi-epg-container.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { OverlayRef } from '@angular/cdk/overlay';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
+import {
+    MultiEpgContainerComponent,
+    isSelectedEpgDayToday,
+} from './multi-epg-container.component';
+import { COMPONENT_OVERLAY_REF } from './overlay-ref.token';
 
 describe('isSelectedEpgDayToday', () => {
     it('returns true only when the selected EPG day is the actual current day', () => {
@@ -7,5 +17,89 @@ describe('isSelectedEpgDayToday', () => {
         expect(isSelectedEpgDayToday('20260521', now)).toBe(true);
         expect(isSelectedEpgDayToday('20260520', now)).toBe(false);
         expect(isSelectedEpgDayToday('20260522', now)).toBe(false);
+    });
+});
+
+describe('MultiEpgContainerComponent runtime gates', () => {
+    let fixture: ComponentFixture<MultiEpgContainerComponent>;
+    let component: MultiEpgContainerComponent;
+    let runtimeCapabilities: { supportsEpg: boolean };
+    const originalElectron = window.electron;
+
+    beforeEach(async () => {
+        runtimeCapabilities = { supportsEpg: false };
+
+        await TestBed.configureTestingModule({
+            imports: [MultiEpgContainerComponent],
+            providers: [
+                { provide: MatDialog, useValue: { open: jest.fn() } },
+                {
+                    provide: COMPONENT_OVERLAY_REF,
+                    useValue: { detach: jest.fn() },
+                },
+                {
+                    provide: OverlayRef,
+                    useValue: { detach: jest.fn() },
+                },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtimeCapabilities,
+                },
+                {
+                    provide: TranslateService,
+                    useValue: {
+                        currentLang: 'en',
+                        defaultLang: 'en',
+                        onLangChange: of(null),
+                    },
+                },
+            ],
+        })
+            .overrideComponent(MultiEpgContainerComponent, {
+                set: { template: '' },
+            })
+            .compileComponents();
+
+        fixture = TestBed.createComponent(MultiEpgContainerComponent);
+        component = fixture.componentInstance;
+    });
+
+    afterEach(() => {
+        window.electron = originalElectron;
+        fixture.destroy();
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+    });
+
+    it('does not request EPG channel ranges when runtime EPG support is disabled', async () => {
+        const getEpgChannelsByRange = jest.fn().mockResolvedValue([]);
+        window.electron = {
+            ...window.electron,
+            getEpgChannelsByRange,
+        } as unknown as typeof window.electron;
+        jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        await component.requestPrograms();
+
+        expect(getEpgChannelsByRange).not.toHaveBeenCalled();
+        expect(component.isLoading()).toBe(false);
+    });
+
+    it('does not search EPG programs when runtime EPG support is disabled', () => {
+        jest.useFakeTimers();
+        const searchEpgPrograms = jest.fn().mockResolvedValue([]);
+        window.electron = {
+            ...window.electron,
+            searchEpgPrograms,
+        } as unknown as typeof window.electron;
+
+        component.onProgramSearchInput({
+            target: { value: 'news' },
+        } as unknown as Event);
+        jest.advanceTimersByTime(600);
+
+        expect(searchEpgPrograms).not.toHaveBeenCalled();
+        expect(component.isSearchingPrograms()).toBe(false);
+        expect(component.programSearchResults()).toEqual([]);
     });
 });

--- a/libs/ui/epg/src/lib/multi-epg/multi-epg-container.component.ts
+++ b/libs/ui/epg/src/lib/multi-epg/multi-epg-container.component.ts
@@ -29,6 +29,7 @@ import {
     EpgChannelWithPrograms,
     EpgProgram,
 } from '@iptvnator/shared/interfaces';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { EpgItemDescriptionComponent } from '../epg-list/epg-item-description/epg-item-description.component';
 import { COMPONENT_OVERLAY_REF } from './overlay-ref.token';
 
@@ -181,6 +182,7 @@ export class MultiEpgContainerComponent
 
     private readonly dialog = inject(MatDialog);
     private readonly overlayRef = inject<OverlayRef>(COMPONENT_OVERLAY_REF);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
 
     ngOnInit() {
         // Update current time line every minute
@@ -267,8 +269,8 @@ export class MultiEpgContainerComponent
     }
 
     async requestPrograms(): Promise<void> {
-        if (!window.electron) {
-            console.warn('Multi-EPG not available: Electron not detected');
+        if (!this.runtime.supportsEpg) {
+            console.warn('Multi-EPG not available in this runtime');
             return;
         }
 
@@ -455,6 +457,12 @@ export class MultiEpgContainerComponent
         }
 
         if (query.length < 2) {
+            this.programSearchResults.set([]);
+            this.isSearchingPrograms.set(false);
+            return;
+        }
+
+        if (!this.runtime.supportsEpg) {
             this.programSearchResults.set([]);
             this.isSearchingPrograms.set(false);
             return;


### PR DESCRIPTION
## Summary
- Gate Multi EPG range loading and program search on the shared runtime EPG capability.
- Keep the existing Electron EPG APIs localized while preventing PWA/no-EPG runtime from scheduling those queries.

## Changes
- Inject `RuntimeCapabilitiesService` into `MultiEpgContainerComponent`.
- Use `supportsEpg` before `getEpgChannelsByRange` and `searchEpgPrograms` paths.
- Add unit coverage for disabled-runtime range loading and program search behavior.

## Testing
- [x] `pnpm nx test ui-epg --runTestsByPath libs/ui/epg/src/lib/multi-epg/multi-epg-container.component.spec.ts`
- [x] `pnpm nx lint ui-epg`
- [x] `pnpm run typecheck:web`
- [x] `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- [x] `pnpm nx build web --configuration=pwa --skip-nx-cache`