### PR TITLE
refactor(channels): gate list epg by runtime capability

### DIFF
--- a/libs/ui/components/src/lib/channel-list-container/channel-list-container.component.spec.ts
+++ b/libs/ui/components/src/lib/channel-list-container/channel-list-container.component.spec.ts
@@ -12,7 +12,11 @@ import { BehaviorSubject, firstValueFrom, of, Subject } from 'rxjs';
 import { EpgService } from '@iptvnator/epg/data-access';
 import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
 import { ChannelActions, PlaylistActions } from '@iptvnator/m3u-state';
-import { PlaylistsService, SettingsStore } from '@iptvnator/services';
+import {
+    PlaylistsService,
+    RuntimeCapabilitiesService,
+    SettingsStore,
+} from '@iptvnator/services';
 import { Channel, PlaylistMeta } from '@iptvnator/shared/interfaces';
 import { ChannelListContainerComponent } from './channel-list-container.component';
 
@@ -62,11 +66,15 @@ describe('ChannelListContainerComponent', () => {
     let dispatch: jest.Mock;
     let activePlaylistSignal: ReturnType<typeof signal<PlaylistMeta | null>>;
     let favoriteChannelIds$: BehaviorSubject<string[]>;
+    let runtimeCapabilities: { supportsEpg: boolean };
+    let storageGet: jest.Mock;
 
     beforeEach(async () => {
         const routerEvents$ = new Subject<NavigationEnd>();
         dispatch = jest.fn();
         favoriteChannelIds$ = new BehaviorSubject<string[]>([]);
+        runtimeCapabilities = { supportsEpg: true };
+        storageGet = jest.fn().mockReturnValue(of({}));
         activePlaylistSignal = signal<PlaylistMeta | null>({
             _id: 'playlist-1',
             title: 'Playlist One',
@@ -124,8 +132,12 @@ describe('ChannelListContainerComponent', () => {
                 {
                     provide: StorageMap,
                     useValue: {
-                        get: jest.fn().mockReturnValue(of({})),
+                        get: storageGet,
                     },
+                },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: runtimeCapabilities,
                 },
                 {
                     provide: Store,
@@ -179,6 +191,16 @@ describe('ChannelListContainerComponent', () => {
         expect(dispatch).toHaveBeenCalledWith(
             ChannelActions.resetActiveChannel()
         );
+    });
+
+    it('does not enable EPG rows when runtime EPG support is unavailable', () => {
+        runtimeCapabilities.supportsEpg = false;
+        storageGet.mockReturnValue(of({ epgUrl: ['https://example.com/epg.xml'] }));
+
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.shouldShowEpg()).toBe(false);
+        expect(storageGet).not.toHaveBeenCalled();
     });
 
     it('dispatches playlist meta updates when hidden group titles change', () => {

--- a/libs/ui/components/src/lib/channel-list-container/channel-list-container.component.ts
+++ b/libs/ui/components/src/lib/channel-list-container/channel-list-container.component.ts
@@ -40,7 +40,11 @@ import {
     firstValueFrom,
     map,
 } from 'rxjs';
-import { PlaylistsService, SettingsStore } from '@iptvnator/services';
+import {
+    PlaylistsService,
+    RuntimeCapabilitiesService,
+    SettingsStore,
+} from '@iptvnator/services';
 import {
     Channel,
     EpgProgram,
@@ -109,6 +113,7 @@ export class ChannelListContainerComponent implements OnInit, OnDestroy {
     private readonly router = inject(Router);
     private readonly route = inject(ActivatedRoute);
     private readonly playlistContext = inject(PlaylistContextFacade);
+    private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly settingsStore = inject(SettingsStore);
 
     /** Map of channel ID to current EPG program */
@@ -287,8 +292,7 @@ export class ChannelListContainerComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         // Check if EPG should be shown (only in Electron with configured EPG URL)
-        const isElectron = !!window['electron'];
-        if (isElectron) {
+        if (this.runtime.supportsEpg) {
             this.storage
                 .get(STORE_KEY.Settings)
                 .subscribe((settings: unknown) => {


### PR DESCRIPTION
## Summary
- Gate channel-list EPG row visibility on the shared runtime EPG capability.
- Avoid reading persisted EPG settings in PWA/no-EPG runtime just to decide row height and EPG state.

## Changes
- Inject `RuntimeCapabilitiesService` into `ChannelListContainerComponent`.
- Use `supportsEpg` before loading EPG settings and enabling EPG rows.
- Add coverage proving a PWA/no-EPG runtime keeps EPG rows disabled even when saved settings contain EPG URLs.

## Testing
- [x] `pnpm nx test components --runTestsByPath libs/ui/components/src/lib/channel-list-container/channel-list-container.component.spec.ts`
- [x] `pnpm nx lint components`
- [x] `pnpm run typecheck:web`
- [x] `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- [x] `pnpm nx build web --configuration=pwa --skip-nx-cache`