### PR TITLE
refactor(xtream): use epg runtime capability only

### DIFF
--- a/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.spec.ts
+++ b/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.spec.ts
@@ -1,10 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { signalStore, withState } from '@ngrx/signals';
-import {
-    DataService,
-    RuntimeCapabilitiesService,
-    SettingsStore,
-} from '@iptvnator/services';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import { EpgItem } from '@iptvnator/shared/interfaces';
 import { XtreamApiService } from '../../services/xtream-api.service';
 import { XtreamXmltvFallbackService } from '../../services/xtream-xmltv-fallback.service';
@@ -48,7 +44,6 @@ function buildProgram(
 
 interface TestStoreSetup {
     appEnvironment?: 'electron' | 'pwa';
-    isElectron?: boolean;
     selectedItem: { xtream_id: number; epg_channel_id?: string | null };
     preferUploaded?: boolean;
 }
@@ -82,15 +77,6 @@ function configureStore(setup: TestStoreSetup) {
     TestBed.configureTestingModule({
         providers: [
             TestEpgStore,
-            {
-                provide: DataService,
-                useValue: {
-                    getAppEnvironment: jest.fn(
-                        () => setup.appEnvironment ?? 'electron'
-                    ),
-                    isElectron: setup.isElectron ?? true,
-                },
-            },
             {
                 provide: RuntimeCapabilitiesService,
                 useValue: {
@@ -180,7 +166,6 @@ describe('withEpg', () => {
     it('does not load Xtream or XMLTV EPG in browser/PWA mode', async () => {
         const { store, xtreamApiService, fallbackService } = configureStore({
             appEnvironment: 'pwa',
-            isElectron: false,
             selectedItem: { xtream_id: 101, epg_channel_id: 'rtl.de' },
         });
 

--- a/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.ts
+++ b/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.ts
@@ -8,7 +8,6 @@ import {
 } from '@ngrx/signals';
 import { EpgItem } from '@iptvnator/shared/interfaces';
 import {
-    DataService,
     RuntimeCapabilitiesService,
     SettingsStore,
 } from '@iptvnator/services';
@@ -84,7 +83,6 @@ export function withEpg() {
 
         withMethods((store) => {
             const apiService = inject(XtreamApiService);
-            const dataService = inject(DataService);
             const fallbackService = inject(XtreamXmltvFallbackService);
             const runtime = inject(RuntimeCapabilitiesService);
             const settingsStore = inject(SettingsStore);
@@ -116,13 +114,9 @@ export function withEpg() {
                 credentials: XtreamCredentials,
                 xtreamId: number
             ): Promise<EpgItem[]> =>
-                dataService.isElectron
-                    ? apiService.getFullEpg(credentials, xtreamId, {
-                          suppressErrorLog: true,
-                      })
-                    : apiService.getShortEpg(credentials, xtreamId, 10, {
-                          suppressErrorLog: true,
-                      });
+                apiService.getFullEpg(credentials, xtreamId, {
+                    suppressErrorLog: true,
+                });
 
             return {
                 /**


### PR DESCRIPTION
## Summary
- Remove the redundant `DataService.isElectron` branch from the Xtream EPG store.
- Make `RuntimeCapabilitiesService.supportsEpg` the single gate for whether Xtream EPG loading can run.
- Simplify the EPG spec setup by dropping platform state from `DataService` mocks.

## Changes
- `loadEpg` still exits before any provider/XMLTV calls when EPG is unsupported, including PWA.
- Provider EPG loading now calls the full provider only after the runtime capability gate passes.

## Testing
- [x] `pnpm nx test portal-xtream-data-access --runTestsByPath libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.spec.ts`
- [x] `pnpm nx lint portal-xtream-data-access`
- [x] `pnpm run typecheck:web`
- [x] `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- [x] `pnpm nx build web --configuration=pwa --skip-nx-cache`