### PR TITLE
refactor(remote-control): gate live bridge by capability

### DIFF
--- a/docs/architecture/remote-control.md
+++ b/docs/architecture/remote-control.md
@@ -97,6 +97,13 @@ Type definitions:
 
 ## Renderer Integrations
 
+All renderer integrations resolve the Electron remote-control bridge through
+`RuntimeCapabilitiesService.supportsRemoteControl`. A partial Electron bridge
+is treated as unsupported unless it exposes all remote-control methods:
+`updateRemoteControlStatus`, `onChannelChange`, and
+`onRemoteControlCommand`. This keeps PWA/self-hosted builds and partial test
+bridges from accidentally activating desktop-only remote-control behavior.
+
 ## Shared helpers
 
 - File: `libs/portal/shared/util/src/lib/remote-channel-navigation.ts`

--- a/libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.spec.ts
+++ b/libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.spec.ts
@@ -285,6 +285,9 @@ describe('VideoPlayerComponent', () => {
     beforeEach(async () => {
         window.electron = {
             platform: 'darwin',
+            updateRemoteControlStatus: jest.fn(),
+            onChannelChange: jest.fn(() => jest.fn()),
+            onRemoteControlCommand: jest.fn(() => jest.fn()),
         } as typeof window.electron;
 
         syncStoreState(null);
@@ -450,6 +453,21 @@ describe('VideoPlayerComponent', () => {
         expect(fixture.nativeElement.querySelector('.epg')).toBeNull();
         expect(fixture.nativeElement.querySelector('app-epg-list')).toBeNull();
         expect(headerContext.action()).toBeNull();
+    });
+
+    it('does not publish remote-control status when the bridge is incomplete', () => {
+        fixture.destroy();
+        const updateRemoteControlStatus = jest.fn();
+        window.electron = {
+            updateRemoteControlStatus,
+        } as typeof window.electron;
+
+        fixture = TestBed.createComponent(VideoPlayerComponent);
+        component = fixture.componentInstance;
+        syncStoreState(sampleChannel);
+        fixture.detectChanges();
+
+        expect(updateRemoteControlStatus).not.toHaveBeenCalled();
     });
 
     it('opens MPV fallback with the active channel headers preserved', () => {

--- a/libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.ts
+++ b/libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.ts
@@ -383,8 +383,9 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
         this.registerHeaderShortcut();
 
         // Setup remote control channel change listener (Electron only)
-        if (this.isDesktop && window.electron?.onChannelChange) {
-            const unsubscribe = window.electron.onChannelChange(
+        const remoteControl = this.remoteControlBridge;
+        if (remoteControl?.onChannelChange) {
+            const unsubscribe = remoteControl.onChannelChange(
                 (data: { direction: 'up' | 'down' }) => {
                     this.handleRemoteChannelChange(data.direction);
                 }
@@ -393,8 +394,8 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
                 this.unsubscribeRemoteChannelChange = unsubscribe;
             }
         }
-        if (this.isDesktop && window.electron?.onRemoteControlCommand) {
-            const unsubscribe = window.electron.onRemoteControlCommand(
+        if (remoteControl?.onRemoteControlCommand) {
+            const unsubscribe = remoteControl.onRemoteControlCommand(
                 (command) => {
                     this.handleRemoteControlCommand(command);
                 }
@@ -409,7 +410,8 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
             this.store.select(selectActive),
             this.store.select(selectCurrentEpgProgram).pipe(startWith(null)),
         ]).subscribe(([channels, activeChannel, epgProgram]) => {
-            if (!window.electron?.updateRemoteControlStatus || !activeChannel) {
+            const remoteControl = this.remoteControlBridge;
+            if (!remoteControl?.updateRemoteControlStatus || !activeChannel) {
                 return;
             }
 
@@ -421,7 +423,7 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
                 (channel) => channel.url === activeChannel.url
             );
 
-            window.electron.updateRemoteControlStatus({
+            remoteControl.updateRemoteControlStatus({
                 portal: 'm3u',
                 isLiveView: true,
                 channelName: activeChannel.name ?? activeChannel.tvg?.name,
@@ -805,8 +807,9 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
         }
         localStorage.setItem('volume', String(clamped));
 
-        if (window.electron?.updateRemoteControlStatus) {
-            window.electron.updateRemoteControlStatus({
+        const remoteControl = this.remoteControlBridge;
+        if (remoteControl?.updateRemoteControlStatus) {
+            remoteControl.updateRemoteControlStatus({
                 portal: 'm3u',
                 isLiveView: true,
                 supportsVolume: true,
@@ -814,6 +817,10 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
                 muted: this.volume === 0,
             });
         }
+    }
+
+    private get remoteControlBridge(): Window['electron'] | undefined {
+        return this.runtime.supportsRemoteControl ? window.electron : undefined;
     }
 
     shouldShowInlinePlayer(channel: Channel | null | undefined): boolean {

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.spec.ts
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.spec.ts
@@ -239,6 +239,9 @@ describe('StalkerLiveStreamLayoutComponent', () => {
     beforeEach(async () => {
         window.electron = {
             platform: 'darwin',
+            updateRemoteControlStatus: jest.fn(),
+            onChannelChange: jest.fn(() => jest.fn()),
+            onRemoteControlCommand: jest.fn(() => jest.fn()),
         } as typeof window.electron;
 
         fetchChannelEpg = stalkerStore.fetchChannelEpg;
@@ -488,6 +491,20 @@ describe('StalkerLiveStreamLayoutComponent', () => {
         await component.playChannel(itvChannels()[0]);
 
         expect(finallySpy).not.toHaveBeenCalled();
+    });
+
+    it('does not publish remote-control status when the bridge is incomplete', () => {
+        fixture.destroy();
+        const updateRemoteControlStatus = jest.fn();
+        window.electron = {
+            updateRemoteControlStatus,
+        } as typeof window.electron;
+
+        fixture = TestBed.createComponent(StalkerLiveStreamLayoutComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+
+        expect(updateRemoteControlStatus).not.toHaveBeenCalled();
     });
 
     it('starts external playback from remote channel navigation when double-click opening is enabled', async () => {

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.ts
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.ts
@@ -326,7 +326,8 @@ export class StalkerLiveStreamLayoutComponent implements OnDestroy {
         });
 
         effect(() => {
-            if (!window.electron?.updateRemoteControlStatus) {
+            const remoteControl = this.remoteControlBridge;
+            if (!remoteControl?.updateRemoteControlStatus) {
                 return;
             }
 
@@ -335,7 +336,7 @@ export class StalkerLiveStreamLayoutComponent implements OnDestroy {
             const channels = this.visibleChannels();
 
             if (selectedType !== 'itv' || !selectedItem?.id) {
-                window.electron.updateRemoteControlStatus({
+                remoteControl.updateRemoteControlStatus({
                     portal: 'stalker',
                     isLiveView: false,
                     supportsVolume: false,
@@ -348,7 +349,7 @@ export class StalkerLiveStreamLayoutComponent implements OnDestroy {
             );
             const currentProgram = this.currentProgram();
 
-            window.electron.updateRemoteControlStatus({
+            remoteControl.updateRemoteControlStatus({
                 portal: 'stalker',
                 isLiveView: true,
                 channelName: selectedItem.o_name || selectedItem.name,
@@ -360,8 +361,9 @@ export class StalkerLiveStreamLayoutComponent implements OnDestroy {
             });
         });
 
-        if (window.electron?.onChannelChange) {
-            const unsubscribe = window.electron.onChannelChange(
+        const remoteControl = this.remoteControlBridge;
+        if (remoteControl?.onChannelChange) {
+            const unsubscribe = remoteControl.onChannelChange(
                 (data: { direction: 'up' | 'down' }) => {
                     this.handleRemoteChannelChange(data.direction);
                 }
@@ -370,8 +372,8 @@ export class StalkerLiveStreamLayoutComponent implements OnDestroy {
                 this.unsubscribeRemoteChannelChange = unsubscribe;
             }
         }
-        if (window.electron?.onRemoteControlCommand) {
-            const unsubscribe = window.electron.onRemoteControlCommand(
+        if (remoteControl?.onRemoteControlCommand) {
+            const unsubscribe = remoteControl.onRemoteControlCommand(
                 (command) => {
                     this.handleRemoteControlCommand(command);
                 }
@@ -779,6 +781,10 @@ export class StalkerLiveStreamLayoutComponent implements OnDestroy {
             requestId === this.epgLoadRequestId &&
             this.selectedChannelId() === normalizedChannelId
         );
+    }
+
+    private get remoteControlBridge(): Window['electron'] | undefined {
+        return this.runtime.supportsRemoteControl ? window.electron : undefined;
     }
 
     private handleRemoteChannelChange(direction: 'up' | 'down'): void {

--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.spec.ts
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.spec.ts
@@ -179,6 +179,8 @@ describe('LiveStreamLayoutComponent', () => {
 
         window.electron = {
             updateRemoteControlStatus: jest.fn(),
+            onChannelChange: jest.fn(() => jest.fn()),
+            onRemoteControlCommand: jest.fn(() => jest.fn()),
         } as typeof window.electron;
 
         xtreamStore.constructStreamUrl.mockClear();
@@ -471,6 +473,20 @@ describe('LiveStreamLayoutComponent', () => {
                 epgTitle: 'Current Show',
             })
         );
+    });
+
+    it('does not publish remote-control status when the bridge is incomplete', () => {
+        fixture.destroy();
+        const updateRemoteControlStatus = jest.fn();
+        window.electron = {
+            updateRemoteControlStatus,
+        } as typeof window.electron;
+
+        fixture = TestBed.createComponent(LiveStreamLayoutComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+
+        expect(updateRemoteControlStatus).not.toHaveBeenCalled();
     });
 
     it('resolves a catchup url for archived program activation', async () => {

--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.ts
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.ts
@@ -267,7 +267,8 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
         });
 
         effect(() => {
-            if (!window.electron?.updateRemoteControlStatus) {
+            const remoteControl = this.remoteControlBridge;
+            if (!remoteControl?.updateRemoteControlStatus) {
                 return;
             }
 
@@ -277,7 +278,7 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
             const currentProgram = this.currentEpgItem();
 
             if (selectedContentType !== 'live' || !selectedItem?.xtream_id) {
-                window.electron.updateRemoteControlStatus({
+                remoteControl.updateRemoteControlStatus({
                     portal: 'xtream',
                     isLiveView: false,
                     supportsVolume: false,
@@ -290,7 +291,7 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
                     Number(item.xtream_id) === Number(selectedItem.xtream_id)
             );
 
-            window.electron.updateRemoteControlStatus({
+            remoteControl.updateRemoteControlStatus({
                 portal: 'xtream',
                 isLiveView: true,
                 channelName: selectedItem.title ?? selectedItem.name,
@@ -304,8 +305,9 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        if (window.electron?.onChannelChange) {
-            const unsubscribe = window.electron.onChannelChange(
+        const remoteControl = this.remoteControlBridge;
+        if (remoteControl?.onChannelChange) {
+            const unsubscribe = remoteControl.onChannelChange(
                 (data: { direction: 'up' | 'down' }) => {
                     this.handleRemoteChannelChange(data.direction);
                 }
@@ -314,8 +316,8 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
                 this.unsubscribeRemoteChannelChange = unsubscribe;
             }
         }
-        if (window.electron?.onRemoteControlCommand) {
-            const unsubscribe = window.electron.onRemoteControlCommand(
+        if (remoteControl?.onRemoteControlCommand) {
+            const unsubscribe = remoteControl.onRemoteControlCommand(
                 (command) => {
                     this.handleRemoteControlCommand(command);
                 }
@@ -554,6 +556,10 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
             start: program.start,
             stop: program.stop ?? program.end,
         };
+    }
+
+    private get remoteControlBridge(): Window['electron'] | undefined {
+        return this.runtime.supportsRemoteControl ? window.electron : undefined;
     }
 
     private getProgramTimestampSeconds(


### PR DESCRIPTION
## Summary
- Gate M3U, Xtream, and Stalker live remote-control bridge access through RuntimeCapabilitiesService.supportsRemoteControl
- Add regression coverage so partial Electron bridges do not publish remote-control status
- Document the renderer remote-control capability boundary

## Tests
- pnpm nx test portal-xtream-feature --runTestsByPath libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.spec.ts
- pnpm nx test portal-stalker-feature --runTestsByPath libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.spec.ts
- pnpm nx test playlist-m3u-feature-player --runTestsByPath libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.spec.ts
- pnpm nx lint portal-xtream-feature
- pnpm nx lint portal-stalker-feature
- pnpm nx lint playlist-m3u-feature-player
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache
- pnpm nx build web --configuration=pwa --skip-nx-cache

## Notes
- Stacked on #991 / agent/xtream-data-source-runtime-capability.
- Wiki export skipped because IPTVNATOR_WIKI_VAULT is not configured.