### PR TITLE
refactor(runtime): require external player bridge methods

### DIFF
--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -70,7 +70,9 @@ direct `window.electron` or `DataService.getAppEnvironment()` checks. Keep
 feature decisions expressed as capabilities such as `supportsEpg`,
 `supportsSqlite`, `supportsXtreamSqliteDataSource`, `supportsDownloads`, or
 `supportsManagedExternalPlayers` so PWA and Electron behavior stays auditable
-from one shared boundary.
+from one shared boundary. `supportsManagedExternalPlayers` requires the MPV and
+VLC preload launch methods (`openInMpv` and `openInVlc`); a partial Electron
+bridge must not expose managed external-player actions in the PWA/shared UI.
 
 ## Runtime Limitations
 

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -77,6 +77,8 @@ describe('RuntimeCapabilitiesService', () => {
             dbDeleteXtreamContent: jest.fn(),
             dbRestoreXtreamUserData: jest.fn(),
             downloadsGetList: jest.fn(),
+            openInMpv: jest.fn(),
+            openInVlc: jest.fn(),
             prepareEmbeddedMpv: jest.fn(),
             saveFileDialog: jest.fn(),
             writeFile: jest.fn(),
@@ -119,6 +121,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsXtreamSqliteDataSource).toBe(false);
         expect(service.supportsDownloads).toBe(false);
         expect(service.supportsPortalActivityStorage).toBe(false);
+        expect(service.supportsManagedExternalPlayers).toBe(false);
         expect(service.supportsEmbeddedMpv).toBe(false);
         expect(service.supportsDesktopFileSave).toBe(false);
         expect(service.supportsRemoteControl).toBe(false);
@@ -148,5 +151,23 @@ describe('RuntimeCapabilitiesService', () => {
 
         expect(service.supportsSqlite).toBe(true);
         expect(service.supportsXtreamSqliteDataSource).toBe(false);
+    });
+
+    it('requires both managed external player launch methods', () => {
+        testWindow.electron = {
+            openInMpv: jest.fn(),
+        };
+
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.isElectron).toBe(true);
+        expect(service.supportsManagedExternalPlayers).toBe(false);
+
+        testWindow.electron = {
+            openInMpv: jest.fn(),
+            openInVlc: jest.fn(),
+        };
+
+        expect(service.supportsManagedExternalPlayers).toBe(true);
     });
 });

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -106,7 +106,9 @@ export class RuntimeCapabilitiesService {
     }
 
     get supportsManagedExternalPlayers(): boolean {
-        return this.isElectron;
+        return ['openInMpv', 'openInVlc'].every((methodName) =>
+            this.hasElectronMethod(methodName)
+        );
     }
 
     get supportsEmbeddedMpv(): boolean {


### PR DESCRIPTION
## Summary
- Treat managed external players as supported only when the preload bridge exposes both `openInMpv` and `openInVlc`
- Add runtime capability regression coverage for partial Electron bridges
- Document the managed external-player capability boundary in the PWA/self-hosted architecture notes

## Tests
- pnpm nx test services --runTestsByPath libs/services/src/lib/runtime-capabilities.service.spec.ts
- pnpm nx test ui-playback --runTestsByPath libs/ui/playback/src/lib/web-player-view/web-player-view.component.spec.ts
- pnpm nx test workspace-shell-feature --runTestsByPath libs/workspace/shell/feature/src/lib/workspace-player-commands/workspace-player-commands.contributor.spec.ts
- pnpm nx lint services
- pnpm nx lint ui-playback
- pnpm nx lint workspace-shell-feature
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache
- pnpm nx build web --configuration=pwa --skip-nx-cache

## Notes
- Stacked on #992 / agent/remote-control-runtime-capability.
- Wiki export skipped because IPTVNATOR_WIKI_VAULT is not configured.