### PR TITLE
refactor(runtime): require downloads bridge surface

### DIFF
--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -70,9 +70,11 @@ direct `window.electron` or `DataService.getAppEnvironment()` checks. Keep
 feature decisions expressed as capabilities such as `supportsEpg`,
 `supportsSqlite`, `supportsXtreamSqliteDataSource`, `supportsDownloads`, or
 `supportsManagedExternalPlayers` so PWA and Electron behavior stays auditable
-from one shared boundary. `supportsManagedExternalPlayers` requires the MPV and
-VLC preload launch methods (`openInMpv` and `openInVlc`); a partial Electron
-bridge must not expose managed external-player actions in the PWA/shared UI.
+from one shared boundary. `supportsDownloads` requires the complete downloads
+preload API surface used by `DownloadsService`, and
+`supportsManagedExternalPlayers` requires the MPV and VLC preload launch methods
+(`openInMpv` and `openInVlc`); a partial Electron bridge must not expose
+desktop-only actions in the PWA/shared UI.
 
 ## Runtime Limitations
 

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -76,7 +76,18 @@ describe('RuntimeCapabilitiesService', () => {
             dbClearPlaybackPosition: jest.fn(),
             dbDeleteXtreamContent: jest.fn(),
             dbRestoreXtreamUserData: jest.fn(),
+            downloadsStart: jest.fn(),
+            downloadsCancel: jest.fn(),
+            downloadsRetry: jest.fn(),
+            downloadsRemove: jest.fn(),
             downloadsGetList: jest.fn(),
+            downloadsGet: jest.fn(),
+            downloadsGetDefaultFolder: jest.fn(),
+            downloadsSelectFolder: jest.fn(),
+            downloadsRevealFile: jest.fn(),
+            downloadsPlayFile: jest.fn(),
+            downloadsClearCompleted: jest.fn(),
+            onDownloadsUpdate: jest.fn(),
             openInMpv: jest.fn(),
             openInVlc: jest.fn(),
             prepareEmbeddedMpv: jest.fn(),
@@ -169,5 +180,33 @@ describe('RuntimeCapabilitiesService', () => {
         };
 
         expect(service.supportsManagedExternalPlayers).toBe(true);
+    });
+
+    it('requires the complete downloads preload surface', () => {
+        testWindow.electron = {
+            downloadsGetList: jest.fn(),
+        };
+
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.isElectron).toBe(true);
+        expect(service.supportsDownloads).toBe(false);
+
+        testWindow.electron = {
+            downloadsStart: jest.fn(),
+            downloadsCancel: jest.fn(),
+            downloadsRetry: jest.fn(),
+            downloadsRemove: jest.fn(),
+            downloadsGetList: jest.fn(),
+            downloadsGet: jest.fn(),
+            downloadsGetDefaultFolder: jest.fn(),
+            downloadsSelectFolder: jest.fn(),
+            downloadsRevealFile: jest.fn(),
+            downloadsPlayFile: jest.fn(),
+            downloadsClearCompleted: jest.fn(),
+            onDownloadsUpdate: jest.fn(),
+        };
+
+        expect(service.supportsDownloads).toBe(true);
     });
 });

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -83,7 +83,20 @@ export class RuntimeCapabilitiesService {
     }
 
     get supportsDownloads(): boolean {
-        return this.hasElectronMethod('downloadsGetList');
+        return [
+            'downloadsStart',
+            'downloadsCancel',
+            'downloadsRetry',
+            'downloadsRemove',
+            'downloadsGetList',
+            'downloadsGet',
+            'downloadsGetDefaultFolder',
+            'downloadsSelectFolder',
+            'downloadsRevealFile',
+            'downloadsPlayFile',
+            'downloadsClearCompleted',
+            'onDownloadsUpdate',
+        ].every((methodName) => this.hasElectronMethod(methodName));
     }
 
     get supportsPortalActivityStorage(): boolean {


### PR DESCRIPTION
## Summary
- Treat downloads as supported only when the preload bridge exposes the full downloads API surface
- Add runtime capability regression coverage for partial downloads bridges
- Document the downloads capability boundary in the PWA/self-hosted architecture notes

## Tests
- pnpm nx test services --runTestsByPath libs/services/src/lib/downloads.service.spec.ts
- pnpm nx test services --runTestsByPath libs/services/src/lib/runtime-capabilities.service.spec.ts
- pnpm nx lint services
- pnpm nx lint portal-downloads-feature
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache
- pnpm nx build web --configuration=pwa --skip-nx-cache

## Notes
- Stacked on #993 / agent/external-player-runtime-capability.
- portal-downloads-feature has no test target; lint plus web typecheck/build covered the feature integration.
- Wiki export skipped because IPTVNATOR_WIKI_VAULT is not configured.