### PR TITLE
refactor(runtime): require playlist storage bridge

### DIFF
--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -70,9 +70,11 @@ direct `window.electron` or `DataService.getAppEnvironment()` checks. Keep
 feature decisions expressed as capabilities such as `supportsEpg`,
 `supportsSqlite`, `supportsXtreamSqliteDataSource`, `supportsDownloads`, or
 `supportsManagedExternalPlayers` so PWA and Electron behavior stays auditable
-from one shared boundary. `supportsDownloads` requires the complete downloads
-preload API surface used by `DownloadsService`, `supportsPlaylistRefresh`
-requires the native playlist refresh/cancel/progress bridge, and
+from one shared boundary. `supportsSqlite` requires the complete playlist
+storage preload API surface used by `PlaylistsService`, `supportsDownloads`
+requires the complete downloads preload API surface used by `DownloadsService`,
+`supportsPlaylistRefresh` requires the native playlist refresh/cancel/progress
+bridge, and
 `supportsManagedExternalPlayers` requires the MPV and VLC preload launch methods
 (`openInMpv` and `openInVlc`); a partial Electron bridge must not expose
 desktop-only actions in the PWA/shared UI.

--- a/libs/services/src/lib/playlist-delete-action.service.spec.ts
+++ b/libs/services/src/lib/playlist-delete-action.service.spec.ts
@@ -21,7 +21,7 @@ describe('PlaylistDeleteActionService', () => {
         deletePlaylist: jest.Mock;
     };
     let runtime: {
-        isElectron: boolean;
+        supportsSqlite: boolean;
     };
 
     beforeEach(() => {
@@ -35,7 +35,7 @@ describe('PlaylistDeleteActionService', () => {
             deletePlaylist: jest.fn(() => of({ success: true })),
         };
         runtime = {
-            isElectron: false,
+            supportsSqlite: false,
         };
 
         TestBed.configureTestingModule({
@@ -59,8 +59,8 @@ describe('PlaylistDeleteActionService', () => {
         expect(databaseService.deletePlaylist).not.toHaveBeenCalled();
     });
 
-    it('deletes Electron Xtream playlists through DatabaseService with progress options', async () => {
-        runtime.isElectron = true;
+    it('deletes SQLite-backed Xtream playlists through DatabaseService with progress options', async () => {
+        runtime.supportsSqlite = true;
         const onEvent = jest.fn();
         const service = TestBed.inject(PlaylistDeleteActionService);
 
@@ -81,8 +81,8 @@ describe('PlaylistDeleteActionService', () => {
         expect(playlistsService.deletePlaylist).not.toHaveBeenCalled();
     });
 
-    it('deletes Electron non-Xtream playlists without progress options', async () => {
-        runtime.isElectron = true;
+    it('deletes SQLite-backed non-Xtream playlists without progress options', async () => {
+        runtime.supportsSqlite = true;
         const service = TestBed.inject(PlaylistDeleteActionService);
 
         await expect(
@@ -97,5 +97,17 @@ describe('PlaylistDeleteActionService', () => {
             'playlist-1',
             undefined
         );
+    });
+
+    it('uses browser playlist storage when the Electron bridge lacks SQLite storage support', async () => {
+        runtime.supportsSqlite = false;
+        const service = TestBed.inject(PlaylistDeleteActionService);
+
+        await expect(service.deletePlaylist(playlist)).resolves.toBe(true);
+
+        expect(playlistsService.deletePlaylist).toHaveBeenCalledWith(
+            'playlist-1'
+        );
+        expect(databaseService.deletePlaylist).not.toHaveBeenCalled();
     });
 });

--- a/libs/services/src/lib/playlist-delete-action.service.ts
+++ b/libs/services/src/lib/playlist-delete-action.service.ts
@@ -22,7 +22,7 @@ export class PlaylistDeleteActionService {
         playlist: PlaylistMeta,
         options: PlaylistDeleteActionOptions = {}
     ): Promise<boolean> {
-        if (this.runtime.isElectron) {
+        if (this.runtime.supportsSqlite) {
             return this.deletePlaylistInElectron(playlist, options);
         }
 

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -36,8 +36,12 @@ describe('RuntimeCapabilitiesService', () => {
     it('reports Electron capabilities from the available preload bridge methods', () => {
         testWindow.electron = {
             platform: 'darwin',
+            dbDeleteAllPlaylists: jest.fn(),
+            dbDeletePlaylist: jest.fn(),
+            dbGetAppPlaylist: jest.fn(),
             dbGetAppPlaylists: jest.fn(),
             dbUpsertAppPlaylist: jest.fn(),
+            dbUpsertAppPlaylists: jest.fn(),
             dbGetAppState: jest.fn(),
             dbSetAppState: jest.fn(),
             dbGetRecentlyViewed: jest.fn(),
@@ -57,7 +61,6 @@ describe('RuntimeCapabilitiesService', () => {
             dbGetPlaylist: jest.fn(),
             dbCreatePlaylist: jest.fn(),
             dbUpdatePlaylist: jest.fn(),
-            dbDeletePlaylist: jest.fn(),
             dbHasCategories: jest.fn(),
             dbGetCategories: jest.fn(),
             dbSaveCategories: jest.fn(),
@@ -157,12 +160,7 @@ describe('RuntimeCapabilitiesService', () => {
     });
 
     it('keeps the Xtream SQLite data source disabled when only generic SQLite methods exist', () => {
-        testWindow.electron = {
-            dbGetAppPlaylists: jest.fn(),
-            dbUpsertAppPlaylist: jest.fn(),
-            dbGetAppState: jest.fn(),
-            dbSetAppState: jest.fn(),
-        };
+        testWindow.electron = createPlaylistStorageBridge();
 
         const service = new RuntimeCapabilitiesService();
 
@@ -234,4 +232,35 @@ describe('RuntimeCapabilitiesService', () => {
 
         expect(service.supportsPlaylistRefresh).toBe(true);
     });
+
+    it('requires the complete playlist storage SQLite preload surface', () => {
+        testWindow.electron = {
+            dbGetAppPlaylists: jest.fn(),
+            dbUpsertAppPlaylist: jest.fn(),
+            dbGetAppState: jest.fn(),
+            dbSetAppState: jest.fn(),
+        };
+
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.isElectron).toBe(true);
+        expect(service.supportsSqlite).toBe(false);
+
+        testWindow.electron = createPlaylistStorageBridge();
+
+        expect(service.supportsSqlite).toBe(true);
+    });
 });
+
+function createPlaylistStorageBridge(): Record<string, jest.Mock> {
+    return {
+        dbDeleteAllPlaylists: jest.fn(),
+        dbDeletePlaylist: jest.fn(),
+        dbGetAppPlaylist: jest.fn(),
+        dbGetAppPlaylists: jest.fn(),
+        dbGetAppState: jest.fn(),
+        dbSetAppState: jest.fn(),
+        dbUpsertAppPlaylist: jest.fn(),
+        dbUpsertAppPlaylists: jest.fn(),
+    };
+}

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -36,12 +36,16 @@ export class RuntimeCapabilitiesService {
     }
 
     get supportsSqlite(): boolean {
-        return (
-            this.hasElectronMethod('dbGetAppPlaylists') &&
-            this.hasElectronMethod('dbUpsertAppPlaylist') &&
-            this.hasElectronMethod('dbGetAppState') &&
-            this.hasElectronMethod('dbSetAppState')
-        );
+        return [
+            'dbDeleteAllPlaylists',
+            'dbDeletePlaylist',
+            'dbGetAppPlaylist',
+            'dbGetAppPlaylists',
+            'dbGetAppState',
+            'dbSetAppState',
+            'dbUpsertAppPlaylist',
+            'dbUpsertAppPlaylists',
+        ].every((methodName) => this.hasElectronMethod(methodName));
     }
 
     get supportsXtreamSqliteDataSource(): boolean {


### PR DESCRIPTION
## Summary
- make `supportsSqlite` require the complete playlist storage preload API used by `PlaylistsService`
- route playlist deletion through Electron `DatabaseService` only when that storage capability is available
- keep partial Electron bridges on the browser/PWA playlist storage path instead of broad `isElectron` routing
- document the complete playlist storage capability requirement in the PWA/self-hosted runtime notes

Stacked on #995.

## Validation
- `pnpm nx test services --runTestsByPath libs/services/src/lib/playlist-delete-action.service.spec.ts`
- `pnpm nx test services --runTestsByPath libs/services/src/lib/runtime-capabilities.service.spec.ts` (Nx expanded to all services specs: 7 suites, 34 tests)
- `pnpm nx lint services` (passes with existing warnings in `portal-status.service.ts` and `settings-store.service.ts`)
- `pnpm run typecheck:web`
- `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- `pnpm nx build web --configuration=pwa --skip-nx-cache` (passes with existing SCSS budget/CommonJS warnings)
- `git diff --check`

Docs updated: `docs/architecture/pwa-self-hosted.md`. Wiki export skipped because `IPTVNATOR_WIKI_VAULT` is not configured.