### PR TITLE
refactor(runtime): gate downloads navigation by capability

### DIFF
--- a/libs/portal/shared/ui/src/lib/navigation/navigation.component.spec.ts
+++ b/libs/portal/shared/ui/src/lib/navigation/navigation.component.spec.ts
@@ -11,7 +11,7 @@ import { NavigationComponent } from './navigation.component';
 describe('NavigationComponent', () => {
     let playlist: ReturnType<typeof signal<Partial<Playlist> | undefined>>;
     let runtime: {
-        isElectron: boolean;
+        supportsDownloads: boolean;
     };
 
     beforeEach(async () => {
@@ -19,7 +19,7 @@ describe('NavigationComponent', () => {
             _id: 'xtream-1',
         });
         runtime = {
-            isElectron: true,
+            supportsDownloads: true,
         };
 
         await TestBed.configureTestingModule({
@@ -61,8 +61,8 @@ describe('NavigationComponent', () => {
         return TestBed.createComponent(NavigationComponent).componentInstance;
     }
 
-    it('includes downloads in portal rail links when Electron is available', () => {
-        runtime.isElectron = true;
+    it('includes downloads in portal rail links when downloads are supported', () => {
+        runtime.supportsDownloads = true;
 
         const component = createComponent();
 
@@ -73,8 +73,8 @@ describe('NavigationComponent', () => {
         ]);
     });
 
-    it('hides downloads in portal rail links when Electron is unavailable', () => {
-        runtime.isElectron = false;
+    it('hides downloads in portal rail links when downloads are unsupported', () => {
+        runtime.supportsDownloads = false;
 
         const component = createComponent();
 

--- a/libs/portal/shared/ui/src/lib/navigation/navigation.component.ts
+++ b/libs/portal/shared/ui/src/lib/navigation/navigation.component.ts
@@ -50,7 +50,7 @@ export class NavigationComponent {
         () => !!(this.currentPlaylist() as Playlist | undefined)?.macAddress
     );
 
-    readonly isElectron = this.runtime.isElectron;
+    readonly supportsDownloads = this.runtime.supportsDownloads;
 
     readonly railLinks = computed(() => {
         const playlistId =
@@ -63,7 +63,7 @@ export class NavigationComponent {
         return buildPortalRailLinks({
             provider: this.isStalkerPlaylist() ? 'stalker' : 'xtreams',
             playlistId,
-            isElectron: this.isElectron,
+            supportsDownloads: this.supportsDownloads,
             workspace: false,
         });
     });

--- a/libs/portal/shared/util/src/lib/navigation/portal-rail-links.spec.ts
+++ b/libs/portal/shared/util/src/lib/navigation/portal-rail-links.spec.ts
@@ -1,11 +1,11 @@
 import { buildPortalRailLinks } from './portal-rail-links';
 
 describe('buildPortalRailLinks', () => {
-    it('builds Xtream links with scoped tooltip labels on Electron', () => {
+    it('builds Xtream links with scoped tooltip labels when downloads are supported', () => {
         const links = buildPortalRailLinks({
             provider: 'xtreams',
             playlistId: 'xtream-1',
-            isElectron: true,
+            supportsDownloads: true,
             workspace: false,
         });
 
@@ -28,7 +28,7 @@ describe('buildPortalRailLinks', () => {
         const links = buildPortalRailLinks({
             provider: 'xtreams',
             playlistId: 'xtream-web',
-            isElectron: false,
+            supportsDownloads: false,
             workspace: true,
         });
 
@@ -50,7 +50,7 @@ describe('buildPortalRailLinks', () => {
         const links = buildPortalRailLinks({
             provider: 'stalker',
             playlistId: 'portal-1',
-            isElectron: false,
+            supportsDownloads: false,
             workspace: true,
         });
 
@@ -74,7 +74,7 @@ describe('buildPortalRailLinks', () => {
         const links = buildPortalRailLinks({
             provider: 'playlists',
             playlistId: 'm3u-1',
-            isElectron: true,
+            supportsDownloads: true,
             workspace: true,
         });
 

--- a/libs/portal/shared/util/src/lib/navigation/portal-rail-links.ts
+++ b/libs/portal/shared/util/src/lib/navigation/portal-rail-links.ts
@@ -25,7 +25,7 @@ export interface PortalRailLink {
 interface BuildPortalRailLinksOptions {
     provider: PortalProvider;
     playlistId: string;
-    isElectron: boolean;
+    supportsDownloads: boolean;
     workspace: boolean;
 }
 
@@ -37,7 +37,7 @@ interface PortalRailLinkGroups {
 export function buildPortalRailLinks(
     options: BuildPortalRailLinksOptions
 ): PortalRailLinkGroups {
-    const { provider, playlistId, isElectron, workspace } = options;
+    const { provider, playlistId, supportsDownloads, workspace } = options;
     const root = workspace
         ? ['/workspace', provider, playlistId]
         : [`/${provider}`, playlistId];
@@ -82,7 +82,7 @@ export function buildPortalRailLinks(
             }
         );
 
-        if (isElectron) {
+        if (supportsDownloads) {
             secondary.push({
                 icon: 'download',
                 tooltip: 'Downloads (this playlist)',
@@ -131,7 +131,7 @@ export function buildPortalRailLinks(
             },
         ];
 
-        if (isElectron) {
+        if (supportsDownloads) {
             secondary.push({
                 icon: 'download',
                 tooltip: 'Downloads (this playlist)',

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/helpers/workspace-shell-command-builders.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/helpers/workspace-shell-command-builders.ts
@@ -29,7 +29,7 @@ export interface CommandBuilderContext {
     hasActivePlaylist: boolean;
     hasXtreamPlaylists: boolean;
     canRefreshPlaylist: boolean;
-    isElectron: boolean;
+    supportsDownloads: boolean;
     showDashboard: boolean;
     translate: TranslateFn;
     router: Router;
@@ -139,8 +139,13 @@ export function getPlaylistCommandDefinitions(
 export function getGlobalCommandDefinitions(
     ctx: CommandBuilderContext
 ): WorkspaceCommandContribution[] {
-    const { route, hasXtreamPlaylists, isElectron, showDashboard, actions } =
-        ctx;
+    const {
+        route,
+        hasXtreamPlaylists,
+        supportsDownloads,
+        showDashboard,
+        actions,
+    } = ctx;
 
     return [
         {
@@ -185,7 +190,7 @@ export function getGlobalCommandDefinitions(
             descriptionKey:
                 'WORKSPACE.SHELL.COMMANDS.OPEN_DOWNLOADS_DESCRIPTION',
             priority: 40,
-            visible: isElectron && route.kind !== 'downloads',
+            visible: supportsDownloads && route.kind !== 'downloads',
             run: () => actions.openDownloadsShortcut(),
         },
         {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
@@ -18,6 +18,7 @@ import {
 import { StalkerStore } from '@iptvnator/portal/stalker/data-access';
 import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
 import {
+    DownloadsService,
     PlaylistsService,
     RuntimeCapabilitiesService,
     SettingsStore,
@@ -129,6 +130,7 @@ describe('WorkspaceShellFacade', () => {
         typeof signal<PlaylistSignalMeta | null>
     >;
     let playlistsSignal: ReturnType<typeof signal<PlaylistSignalMeta[]>>;
+    let downloadsActiveCountSignal: ReturnType<typeof signal<number>>;
     let refreshPreparationSignal: ReturnType<
         typeof signal<XtreamRefreshPreparationState | null>
     >;
@@ -142,6 +144,7 @@ describe('WorkspaceShellFacade', () => {
     let runtime: {
         isElectron: boolean;
         isMacOS: boolean;
+        supportsDownloads: boolean;
     };
 
     beforeEach(() => {
@@ -149,6 +152,7 @@ describe('WorkspaceShellFacade', () => {
         runtime = {
             isElectron: true,
             isMacOS: true,
+            supportsDownloads: true,
         };
 
         activePlaylistSignal = signal({
@@ -161,6 +165,7 @@ describe('WorkspaceShellFacade', () => {
             { _id: 'pl-1', serverUrl: 'http://example.com' },
             { _id: 'pl-2', macAddress: '00:11:22:33' },
         ]);
+        downloadsActiveCountSignal = signal(0);
         refreshPreparationSignal = signal<XtreamRefreshPreparationState | null>(
             null
         );
@@ -272,6 +277,12 @@ describe('WorkspaceShellFacade', () => {
                 {
                     provide: PlaylistsService,
                     useValue: playlistsService,
+                },
+                {
+                    provide: DownloadsService,
+                    useValue: {
+                        activeCount: downloadsActiveCountSignal,
+                    },
                 },
                 {
                     provide: MatDialog,
@@ -677,6 +688,20 @@ describe('WorkspaceShellFacade', () => {
             true
         );
         expect(commands.every((command) => command.enabled)).toBe(true);
+    });
+
+    it('hides the downloads command when downloads are unsupported', () => {
+        (facade as unknown as { supportsDownloads: boolean }).supportsDownloads =
+            false;
+        activePlaylistSignal.set(null);
+        playlistsSignal.set([]);
+        facade.currentUrl.set('/workspace/dashboard');
+
+        const commands = facade.commandPaletteCommands();
+
+        expect(commands.map((command) => command.id)).not.toContain(
+            'open-downloads'
+        );
     });
 
     it('includes M3U navigation, playlist actions, and Multi-EPG on playlist routes', () => {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
@@ -99,8 +99,9 @@ export class WorkspaceShellFacade {
     );
     private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly downloadsService = inject(DownloadsService);
+    readonly supportsDownloads = this.runtime.supportsDownloads;
     readonly hasActiveDownloads = computed(
-        () => this.isElectron && this.downloadsService.activeCount() > 0
+        () => this.supportsDownloads && this.downloadsService.activeCount() > 0
     );
     private readonly languageTick = toSignal(
         this.translate.onLangChange.pipe(startWith(null)),
@@ -432,7 +433,7 @@ export class WorkspaceShellFacade {
             buildPortalRailLinks({
                 provider: context.provider,
                 playlistId: context.playlistId,
-                isElectron: this.isElectron,
+                supportsDownloads: this.supportsDownloads,
                 workspace: true,
             }).primary,
             context.provider,
@@ -451,7 +452,7 @@ export class WorkspaceShellFacade {
             buildPortalRailLinks({
                 provider: context.provider,
                 playlistId: context.playlistId,
-                isElectron: this.isElectron,
+                supportsDownloads: this.supportsDownloads,
                 workspace: true,
             }).secondary.filter((link) => link.section !== 'downloads'),
             context.provider,
@@ -796,7 +797,7 @@ export class WorkspaceShellFacade {
                 (playlist) => !!playlist.serverUrl
             ),
             canRefreshPlaylist: this.canRefreshPlaylist(),
-            isElectron: this.isElectron,
+            supportsDownloads: this.supportsDownloads,
             showDashboard: this.showDashboard(),
             translate: (key, params) => this.translateText(key, params),
             router: this.router,


### PR DESCRIPTION
## Summary
- pass `supportsDownloads` through portal rail link building instead of broad Electron detection
- hide portal Downloads rail entries and workspace Downloads commands when the full downloads bridge is unavailable
- mock `DownloadsService` in workspace facade tests so capability tests do not instantiate the native downloads service

Stacked on #996.

## Validation
- `pnpm nx test portal-shared-util --runTestsByPath libs/portal/shared/util/src/lib/navigation/portal-rail-links.spec.ts` (Nx expanded to all portal-shared-util specs: 11 suites, 66 tests)
- `pnpm nx test portal-shared-ui --runTestsByPath libs/portal/shared/ui/src/lib/navigation/navigation.component.spec.ts` (Nx expanded to portal-shared-ui specs: 5 suites, 40 tests; existing videojs/artplayer console noise)
- `pnpm nx test workspace-shell-feature --runTestsByPath libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts` (Nx expanded to workspace-shell-feature specs: 12 suites, 95 tests)
- `pnpm nx lint portal-shared-util`
- `pnpm nx lint portal-shared-ui`
- `pnpm nx lint workspace-shell-feature`
- `pnpm run typecheck:web`
- `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- `pnpm nx build web --configuration=pwa --skip-nx-cache` (passes with existing SCSS budget/CommonJS warnings)
- `pnpm nx run web-e2e:e2e-ci--src/self-hosted.e2e.ts` (12 passed; mock server shutdown warnings after successful run)
- `git diff --check`

Docs not changed: the existing PWA runtime boundary doc already describes downloads as capability-gated. Wiki export skipped because `IPTVNATOR_WIKI_VAULT` is not configured.