### PR TITLE
refactor(runtime): enable pwa xtream section navigation

### DIFF
--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -74,7 +74,9 @@ from one shared boundary. `supportsSqlite` requires the complete playlist
 storage preload API surface used by `PlaylistsService`, `supportsDownloads`
 requires the complete downloads preload API surface used by `DownloadsService`,
 `supportsPlaylistRefresh` requires the native playlist refresh/cancel/progress
-bridge, and
+bridge, `supportsXtreamSectionNavigation` is available in PWA and in Electron
+when either the SQLite Xtream data source or the Xtream API transport is
+available, and
 `supportsManagedExternalPlayers` requires the MPV and VLC preload launch methods
 (`openInMpv` and `openInVlc`); a partial Electron bridge must not expose
 desktop-only actions in the PWA/shared UI.

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -30,7 +30,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEmbeddedMpv).toBe(false);
         expect(service.supportsDesktopFileSave).toBe(false);
         expect(service.supportsRemoteControl).toBe(false);
-        expect(service.supportsXtreamSectionNavigation).toBe(false);
+        expect(service.supportsXtreamSectionNavigation).toBe(true);
     });
 
     it('reports Electron capabilities from the available preload bridge methods', () => {
@@ -103,6 +103,7 @@ describe('RuntimeCapabilitiesService', () => {
             updateRemoteControlStatus: jest.fn(),
             onChannelChange: jest.fn(),
             onRemoteControlCommand: jest.fn(),
+            xtreamRequest: jest.fn(),
         };
 
         const service = new RuntimeCapabilitiesService();
@@ -145,6 +146,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsEmbeddedMpv).toBe(false);
         expect(service.supportsDesktopFileSave).toBe(false);
         expect(service.supportsRemoteControl).toBe(false);
+        expect(service.supportsXtreamSectionNavigation).toBe(false);
     });
 
     it('reads the bridge dynamically so tests and late preload setup stay accurate', () => {
@@ -249,6 +251,18 @@ describe('RuntimeCapabilitiesService', () => {
         testWindow.electron = createPlaylistStorageBridge();
 
         expect(service.supportsSqlite).toBe(true);
+    });
+
+    it('supports Xtream section navigation in Electron when Xtream API transport is available', () => {
+        testWindow.electron = {
+            xtreamRequest: jest.fn(),
+        };
+
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.isElectron).toBe(true);
+        expect(service.supportsXtreamSqliteDataSource).toBe(false);
+        expect(service.supportsXtreamSectionNavigation).toBe(true);
     });
 });
 

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -156,7 +156,11 @@ export class RuntimeCapabilitiesService {
     }
 
     get supportsXtreamSectionNavigation(): boolean {
-        return this.isElectron;
+        return (
+            this.isPwa ||
+            this.supportsXtreamSqliteDataSource ||
+            this.hasElectronMethod('xtreamRequest')
+        );
     }
 
     hasElectronMethod(methodName: string): boolean {


### PR DESCRIPTION
## Summary
- make `supportsXtreamSectionNavigation` reflect actual route/data-source support instead of broad Electron detection
- enable Xtream section navigation in PWA, where self-hosted routes already support `/workspace/xtreams/:id/vod/...`
- keep partial Electron bridges from exposing section navigation unless SQLite Xtream data source or `xtreamRequest` transport is available
- document the Xtream section navigation capability boundary in the PWA/self-hosted architecture notes

Stacked on #997.

## Validation
- `pnpm nx test services --runTestsByPath libs/services/src/lib/runtime-capabilities.service.spec.ts` (Nx expanded to all services specs: 7 suites, 35 tests)
- `pnpm nx lint services` (passes with existing warnings in `portal-status.service.ts` and `settings-store.service.ts`)
- `pnpm run typecheck:web`
- `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
- `pnpm nx build web --configuration=pwa --skip-nx-cache` (passes with existing SCSS budget/CommonJS warnings)
- `pnpm nx run web-e2e:e2e-ci--src/self-hosted.e2e.ts` (first sandbox run hit `tsx` IPC EPERM; rerun outside sandbox passed 12/12 with mock server shutdown warnings after success)
- `git diff --check`

Docs updated: `docs/architecture/pwa-self-hosted.md`. Wiki export skipped because `IPTVNATOR_WIKI_VAULT` is not configured.