### PR TITLE
refactor(runtime): gate settings sections by capability

### DIFF
--- a/apps/web/src/app/settings/settings-options.spec.ts
+++ b/apps/web/src/app/settings/settings-options.spec.ts
@@ -44,24 +44,34 @@ describe('buildSettingsSectionNavItems', () => {
         return ids;
     }
 
-    it('exposes desktop-only items only when isDesktop is true', () => {
-        const desktopItems = buildSettingsSectionNavItems(true);
-        const pwaItems = buildSettingsSectionNavItems(false);
+    it('exposes feature-specific items only when their runtime capabilities are supported', () => {
+        const supportedItems = buildSettingsSectionNavItems({
+            supportsEpg: true,
+            supportsRemoteControl: true,
+        });
+        const unsupportedItems = buildSettingsSectionNavItems({
+            supportsEpg: false,
+            supportsRemoteControl: false,
+        });
 
-        expect(desktopItems.map((item) => item.id)).toEqual(
+        expect(supportedItems.map((item) => item.id)).toEqual(
             expect.arrayContaining(['epg', 'remote-control'])
         );
-        expect(pwaItems.find((item) => item.id === 'epg')?.visible).toBe(
-            false
-        );
         expect(
-            pwaItems.find((item) => item.id === 'remote-control')?.visible
+            unsupportedItems.find((item) => item.id === 'epg')?.visible
+        ).toBe(false);
+        expect(
+            unsupportedItems.find((item) => item.id === 'remote-control')
+                ?.visible
         ).toBe(false);
     });
 
     it('every nav id matches an existing section template id (regression: remote-control nav no longer maps to the Nx lib name)', () => {
         const navIds = new Set(
-            buildSettingsSectionNavItems(true).map((item) => item.id)
+            buildSettingsSectionNavItems({
+                supportsEpg: true,
+                supportsRemoteControl: true,
+            }).map((item) => item.id)
         );
         const templateIds = collectSectionTemplateIds();
 

--- a/apps/web/src/app/settings/settings-options.ts
+++ b/apps/web/src/app/settings/settings-options.ts
@@ -85,9 +85,15 @@ export const SETTINGS_EMBEDDED_PLAYER_OPTIONS: SettingsPlayerOption[] = [
     },
 ];
 
-export function buildSettingsSectionNavItems(
-    isDesktop: boolean
-): SettingsSection[] {
+export interface SettingsSectionVisibility {
+    supportsEpg: boolean;
+    supportsRemoteControl: boolean;
+}
+
+export function buildSettingsSectionNavItems({
+    supportsEpg,
+    supportsRemoteControl,
+}: SettingsSectionVisibility): SettingsSection[] {
     return [
         {
             id: 'general',
@@ -105,7 +111,7 @@ export function buildSettingsSectionNavItems(
             id: 'epg',
             label: 'SETTINGS.NAV_EPG',
             icon: 'calendar_month',
-            visible: isDesktop,
+            visible: supportsEpg,
         },
         {
             // Must match the section's HTML id (`remote-control`) so the
@@ -116,7 +122,7 @@ export function buildSettingsSectionNavItems(
             id: 'remote-control',
             label: 'SETTINGS.NAV_REMOTE',
             icon: 'smartphone',
-            visible: isDesktop,
+            visible: supportsRemoteControl,
         },
         {
             id: 'backup',

--- a/apps/web/src/app/settings/settings.component.html
+++ b/apps/web/src/app/settings/settings.component.html
@@ -52,7 +52,7 @@
                 (selectRecordingFolder)="selectRecordingFolder()"
             />
 
-            @if (isDesktop) {
+            @if (supportsEpg) {
                 <app-settings-epg-section
                     [form]="settingsForm"
                     [activeSection]="activeSection()"
@@ -64,7 +64,9 @@
                     (refreshAllEpg)="refreshAllEpg()"
                     (clearEpgData)="clearEpgData()"
                 />
+            }
 
+            @if (supportsRemoteControl) {
                 <app-settings-remote-control-section
                     [form]="settingsForm"
                     [activeSection]="activeSection()"

--- a/apps/web/src/app/settings/settings.component.spec.ts
+++ b/apps/web/src/app/settings/settings.component.spec.ts
@@ -250,12 +250,16 @@ describe('SettingsComponent', () => {
                 staleUrls: [],
             }),
             clearEpgData: jest.fn().mockResolvedValue({ success: true }),
+            fetchEpg: jest.fn().mockResolvedValue({ success: true }),
             forceFetchEpg: jest.fn().mockResolvedValue({ success: true }),
             getAppVersion: jest.fn().mockResolvedValue('1.0.0'),
+            getChannelPrograms: jest.fn().mockResolvedValue([]),
+            getEpgChannelsByRange: jest.fn().mockResolvedValue([]),
             getLocalIpAddresses: jest.fn().mockResolvedValue([]),
             openInMpv: jest.fn(),
             openInVlc: jest.fn(),
             platform: 'linux',
+            searchEpgPrograms: jest.fn().mockResolvedValue([]),
             saveFileDialog: jest.fn().mockResolvedValue('/tmp/backup.json'),
             setMpvPlayerPath: jest.fn().mockResolvedValue(undefined),
             setVlcPlayerPath: jest.fn().mockResolvedValue(undefined),
@@ -496,6 +500,21 @@ describe('SettingsComponent', () => {
             expect(partialBridgeComponent.supportsManagedExternalPlayers).toBe(
                 false
             );
+            expect(partialBridgeComponent.supportsEpg).toBe(false);
+            expect(partialBridgeComponent.supportsRemoteControl).toBe(false);
+            expect(
+                partialBridgeComponent.settingsForm.get('epgUrl')
+            ).toBeNull();
+            expect(
+                partialBridgeComponent.sectionNav.find(
+                    (section) => section.id === 'epg'
+                )
+            ).toBeUndefined();
+            expect(
+                partialBridgeComponent.sectionNav.find(
+                    (section) => section.id === 'remote-control'
+                )
+            ).toBeUndefined();
             expect(
                 partialBridgeComponent
                     .players()
@@ -748,6 +767,8 @@ describe('SettingsComponent', () => {
 
         expect(browserComponent.isDesktop).toBe(false);
         expect(browserComponent.isPwa).toBe(true);
+        expect(browserComponent.supportsEpg).toBe(false);
+        expect(browserComponent.supportsRemoteControl).toBe(false);
         expect(browserComponent.settingsForm.get('epgUrl')).toBeNull();
 
         mockStore.overrideSelector(selectAllPlaylistsMeta, [

--- a/apps/web/src/app/settings/settings.component.ts
+++ b/apps/web/src/app/settings/settings.component.ts
@@ -135,8 +135,10 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
     /** Flag that indicates whether the app runs in electron environment */
     readonly isDesktop = this.runtime.isElectron;
+    readonly supportsEpg = this.runtime.supportsEpg;
     readonly supportsManagedExternalPlayers =
         this.runtime.supportsManagedExternalPlayers;
+    readonly supportsRemoteControl = this.runtime.supportsRemoteControl;
     readonly embeddedMpvSupport = signal<EmbeddedMpvSupport | null>(null);
     readonly supportsEmbeddedMpv = computed(
         () => this.isDesktop && !!this.embeddedMpvSupport()?.supported
@@ -184,7 +186,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     /** Settings form object */
     settingsForm = this.formBuilder.group({
         player: [VideoPlayer.VideoJs],
-        ...(this.isDesktop ? { epgUrl: new FormArray([]) } : {}),
+        ...(this.supportsEpg ? { epgUrl: new FormArray([]) } : {}),
         streamFormat: StreamFormat.M3u8StreamFormat,
         openStreamOnDoubleClick: false,
         language: Language.ENGLISH,
@@ -211,7 +213,9 @@ export class SettingsComponent implements OnInit, OnDestroy {
         ],
         recordingFolder: '',
         coverSize: 'medium' as CoverSize,
-        ...(this.isDesktop ? { preferUploadedEpgOverXtream: false } : {}),
+        ...(this.supportsEpg
+            ? { preferUploadedEpgOverXtream: false }
+            : {}),
     });
 
     /** Form array with epg sources */
@@ -229,7 +233,10 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
     private settingsStore = inject(SettingsStore);
     readonly sectionNavItems: SettingsSection[] = buildSettingsSectionNavItems(
-        this.isDesktop
+        {
+            supportsEpg: this.supportsEpg,
+            supportsRemoteControl: this.supportsRemoteControl,
+        }
     );
 
     readonly playlistDeleteSummary = computed<SettingsPlaylistDeleteSummary>(
@@ -337,7 +344,10 @@ export class SettingsComponent implements OnInit, OnDestroy {
      * Fetches local IP addresses for remote control URL display
      */
     async fetchLocalIpAddresses(): Promise<void> {
-        if (window.electron?.getLocalIpAddresses) {
+        if (
+            this.supportsRemoteControl &&
+            window.electron?.getLocalIpAddresses
+        ) {
             const addresses = await window.electron.getLocalIpAddresses();
             this.localIpAddresses.set(addresses);
         }
@@ -361,7 +371,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
         const currentSettings = this.settingsStore.getSettings();
         this.settingsForm.patchValue(currentSettings);
 
-        if (this.isDesktop && currentSettings.epgUrl) {
+        if (this.supportsEpg && currentSettings.epgUrl) {
             this.epgUrl.clear();
             this.setEpgUrls(currentSettings.epgUrl);
         }
@@ -518,7 +528,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
      */
     applyChangedSettings(): void {
         this.settingsForm.markAsPristine();
-        if (this.isDesktop) {
+        if (this.supportsEpg) {
             let epgUrls = this.settingsForm.value.epgUrl;
             if (epgUrls) {
                 if (!Array.isArray(epgUrls)) {
@@ -558,7 +568,9 @@ export class SettingsComponent implements OnInit, OnDestroy {
      * intends when clicking "Refresh".
      */
     refreshEpg(url: string): void {
-        if (!url || !window.electron?.forceFetchEpg) return;
+        if (!this.supportsEpg || !url || !window.electron?.forceFetchEpg) {
+            return;
+        }
         void window.electron.forceFetchEpg(url);
     }
 
@@ -568,7 +580,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
      * gets visible per-URL feedback.
      */
     refreshAllEpg(): void {
-        if (!window.electron?.forceFetchEpg) return;
+        if (!this.supportsEpg || !window.electron?.forceFetchEpg) return;
         const urls = (this.epgUrl.value as string[])
             .map((url) => url?.trim())
             .filter((url): url is string => Boolean(url));
@@ -605,6 +617,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
             ),
             onConfirm: async (): Promise<void> => {
                 if (
+                    !this.supportsEpg ||
                     !window.electron?.clearEpgData ||
                     this.isClearingEpgData()
                 ) {

--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -73,10 +73,13 @@ feature decisions expressed as capabilities such as `supportsEpg`,
 from one shared boundary. `supportsSqlite` requires the complete playlist
 storage preload API surface used by `PlaylistsService`, `supportsDownloads`
 requires the complete downloads preload API surface used by `DownloadsService`,
-`supportsPlaylistRefresh` requires the native playlist refresh/cancel/progress
-bridge, `supportsXtreamSectionNavigation` is available in PWA and in Electron
-when either the SQLite Xtream data source or the Xtream API transport is
-available, and
+`supportsEpg` requires the Electron EPG preload methods used by the shared EPG
+panels (`fetchEpg`, `getChannelPrograms`, `checkEpgFreshness`,
+`forceFetchEpg`, `clearEpgData`, `getEpgChannelsByRange`, and
+`searchEpgPrograms`), `supportsPlaylistRefresh` requires the native playlist
+refresh/cancel/progress bridge, `supportsXtreamSectionNavigation` is available
+in PWA and in Electron when either the SQLite Xtream data source or the Xtream
+API transport is available, and
 `supportsManagedExternalPlayers` requires the MPV and VLC preload launch and
 path-setting methods (`openInMpv`, `openInVlc`, `setMpvPlayerPath`, and
 `setVlcPlayerPath`); a partial Electron bridge must not expose desktop-only

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -106,6 +106,13 @@ describe('RuntimeCapabilitiesService', () => {
             onChannelChange: jest.fn(),
             onRemoteControlCommand: jest.fn(),
             xtreamRequest: jest.fn(),
+            fetchEpg: jest.fn(),
+            getChannelPrograms: jest.fn(),
+            checkEpgFreshness: jest.fn(),
+            forceFetchEpg: jest.fn(),
+            clearEpgData: jest.fn(),
+            getEpgChannelsByRange: jest.fn(),
+            searchEpgPrograms: jest.fn(),
         };
 
         const service = new RuntimeCapabilitiesService();
@@ -138,7 +145,7 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.environment).toBe('electron');
         expect(service.platform).toBeUndefined();
         expect(service.isMacOS).toBe(false);
-        expect(service.supportsEpg).toBe(true);
+        expect(service.supportsEpg).toBe(false);
         expect(service.supportsSqlite).toBe(false);
         expect(service.supportsXtreamSqliteDataSource).toBe(false);
         expect(service.supportsDownloads).toBe(false);
@@ -191,6 +198,31 @@ describe('RuntimeCapabilitiesService', () => {
         };
 
         expect(service.supportsManagedExternalPlayers).toBe(true);
+    });
+
+    it('requires the complete EPG preload surface', () => {
+        testWindow.electron = {
+            fetchEpg: jest.fn(),
+            getChannelPrograms: jest.fn(),
+            checkEpgFreshness: jest.fn(),
+        };
+
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.isElectron).toBe(true);
+        expect(service.supportsEpg).toBe(false);
+
+        testWindow.electron = {
+            fetchEpg: jest.fn(),
+            getChannelPrograms: jest.fn(),
+            checkEpgFreshness: jest.fn(),
+            forceFetchEpg: jest.fn(),
+            clearEpgData: jest.fn(),
+            getEpgChannelsByRange: jest.fn(),
+            searchEpgPrograms: jest.fn(),
+        };
+
+        expect(service.supportsEpg).toBe(true);
     });
 
     it('requires the complete downloads preload surface', () => {

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -32,7 +32,15 @@ export class RuntimeCapabilitiesService {
     }
 
     get supportsEpg(): boolean {
-        return this.isElectron;
+        return [
+            'fetchEpg',
+            'getChannelPrograms',
+            'checkEpgFreshness',
+            'forceFetchEpg',
+            'clearEpgData',
+            'getEpgChannelsByRange',
+            'searchEpgPrograms',
+        ].every((methodName) => this.hasElectronMethod(methodName));
     }
 
     get supportsSqlite(): boolean {


### PR DESCRIPTION
Stacked on #1000.

## Summary
- make supportsEpg require the concrete Electron EPG preload surface instead of any Electron bridge
- gate Settings EPG and Remote Control sections/nav entries by runtime capabilities rather than isDesktop
- add partial-Electron regression coverage and document the stricter EPG capability contract

## Validation
- pnpm nx test services --runTestsByPath libs/services/src/lib/runtime-capabilities.service.spec.ts
- pnpm nx test web --runTestsByPath apps/web/src/app/settings/settings.component.spec.ts apps/web/src/app/settings/settings-options.spec.ts
- pnpm nx test ui-epg --runTestsByPath libs/ui/epg/src/lib/epg-source-status/epg-source-status.component.spec.ts libs/ui/epg/src/lib/multi-epg/multi-epg-container.component.spec.ts
- pnpm nx lint services (passes with existing warnings)
- pnpm nx lint web
- pnpm nx lint ui-epg
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache
- pnpm nx build web --configuration=pwa --skip-nx-cache (passes with existing SCSS budget/CommonJS warnings)
- pnpm nx run web-e2e:e2e-ci--src/settings.e2e.ts
- git diff --check

Docs updated: docs/architecture/pwa-self-hosted.md. Wiki export skipped because IPTVNATOR_WIKI_VAULT is not set.