### PR TITLE
refactor(runtime): gate settings backup file save by capability

### DIFF
--- a/.plans/2026-05-22-pwa-electron-runtime-followups.md
+++ b/.plans/2026-05-22-pwa-electron-runtime-followups.md
@@ -1,0 +1,45 @@
+# PWA/Electron Runtime Follow-Up Plan
+
+## Stop Point
+
+Stop implementation after PR #1002:
+
+- #964 through #1002 now form a long stacked runtime-boundary series.
+- The latest pushed branch is `agent/settings-backup-file-save-runtime-capability`.
+- Do not add more runtime-capability refactor PRs until the current stack is reviewed, merged, and rebased as needed.
+
+## Review And Merge Plan
+
+1. Review and merge bottom-up, starting at #964 and ending at #1002.
+2. Prefer a merge strategy that preserves stacked ancestry. If GitHub squash-merges a PR, rebase the next branch onto updated `master` before reviewing or merging it.
+3. For each PR:
+   - Verify the PR base/head are still correct.
+   - Check that the diff is only the intended logical slice.
+   - Wait for CI to pass.
+   - Merge the PR.
+   - Rebase or retarget the next branch before continuing.
+4. After the stack lands, run a combined validation pass on `master`:
+   - `pnpm nx test services`
+   - `pnpm nx test web --runTestsByPath apps/web/src/app/settings/settings.component.spec.ts apps/web/src/app/settings/settings-options.spec.ts`
+   - `pnpm nx test ui-epg`
+   - `pnpm run typecheck:web`
+   - `pnpm nx build web --configuration=electron-e2e --skip-nx-cache`
+   - `pnpm nx build web --configuration=pwa --skip-nx-cache`
+   - `pnpm nx run web-e2e:e2e-ci--src/self-hosted.e2e.ts`
+   - `pnpm nx run web-e2e:e2e-ci--src/settings.e2e.ts`
+
+## Later Continuation
+
+1. Re-audit direct `window.electron` usage after the stack is merged. Focus on places that still make feature decisions outside `RuntimeCapabilitiesService`.
+2. Decide whether `supportsEpg` should remain one complete capability or be split into narrower capabilities such as EPG fetch, source freshness, and schedule search.
+3. Continue settings cleanup:
+   - gate `updateSettings` by an explicit desktop-settings capability if partial Electron bridges remain a supported case,
+   - review embedded MPV recording-folder selection against an embedded-MPV capability,
+   - keep backup import/export behavior shared and PWA-safe.
+4. Review `libs/epg/data-access` and `libs/ui/epg` for direct Electron bridge calls that could be routed through small typed bridge/facade services.
+5. Review playback/embedded MPV bridge code separately; it has a wider blast radius and should not be mixed with PWA settings/runtime cleanups.
+6. After code cleanup, do a final PWA/Docker documentation pass:
+   - confirm unsupported PWA features are documented,
+   - confirm troubleshooting tells users to copy stream URLs into external players instead of implying managed MPV/VLC support in PWA,
+   - rerun self-hosted e2e and a manual Docker/PWA smoke test.
+

--- a/apps/web/src/app/settings/settings.component.spec.ts
+++ b/apps/web/src/app/settings/settings.component.spec.ts
@@ -911,6 +911,65 @@ describe('SettingsComponent', () => {
         expect(component.isExportingData()).toBe(false);
     });
 
+    it('falls back to browser backup download when desktop file-save preload is incomplete', async () => {
+        fixture.destroy();
+        const saveFileDialog = jest.fn().mockResolvedValue('/tmp/backup.json');
+        window.electron = {
+            platform: 'linux',
+            saveFileDialog,
+        } as unknown as typeof window.electron;
+
+        const createObjectURL = jest.fn().mockReturnValue('blob:backup');
+        const revokeObjectURL = jest.fn();
+        const originalCreateObjectURL = window.URL.createObjectURL;
+        const originalRevokeObjectURL = window.URL.revokeObjectURL;
+        Object.defineProperty(window.URL, 'createObjectURL', {
+            configurable: true,
+            value: createObjectURL,
+        });
+        Object.defineProperty(window.URL, 'revokeObjectURL', {
+            configurable: true,
+            value: revokeObjectURL,
+        });
+        const clickSpy = jest
+            .spyOn(HTMLAnchorElement.prototype, 'click')
+            .mockImplementation();
+
+        try {
+            const partialFileSaveFixture =
+                TestBed.createComponent(SettingsComponent);
+            const partialFileSaveComponent =
+                partialFileSaveFixture.componentInstance;
+            partialFileSaveComponent.checkAppVersion = jest.fn();
+            partialFileSaveComponent.fetchLocalIpAddresses = jest
+                .fn()
+                .mockResolvedValue(undefined);
+            partialFileSaveFixture.detectChanges();
+
+            expect(partialFileSaveComponent.isDesktop).toBe(true);
+            expect(partialFileSaveComponent.supportsDesktopFileSave).toBe(
+                false
+            );
+
+            await partialFileSaveComponent.exportData();
+
+            expect(saveFileDialog).not.toHaveBeenCalled();
+            expect(createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+            expect(clickSpy).toHaveBeenCalled();
+            expect(revokeObjectURL).toHaveBeenCalledWith('blob:backup');
+        } finally {
+            clickSpy.mockRestore();
+            Object.defineProperty(window.URL, 'createObjectURL', {
+                configurable: true,
+                value: originalCreateObjectURL,
+            });
+            Object.defineProperty(window.URL, 'revokeObjectURL', {
+                configurable: true,
+                value: originalRevokeObjectURL,
+            });
+        }
+    });
+
     it('shows a failure snackbar and skips refresh when clearing EPG data rejects', async () => {
         (window.electron.clearEpgData as jest.Mock).mockRejectedValueOnce(
             new Error('boom')

--- a/apps/web/src/app/settings/settings.component.ts
+++ b/apps/web/src/app/settings/settings.component.ts
@@ -135,6 +135,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
     /** Flag that indicates whether the app runs in electron environment */
     readonly isDesktop = this.runtime.isElectron;
+    readonly supportsDesktopFileSave = this.runtime.supportsDesktopFileSave;
     readonly supportsEpg = this.runtime.supportsEpg;
     readonly supportsManagedExternalPlayers =
         this.runtime.supportsManagedExternalPlayers;
@@ -660,7 +661,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
         try {
             const backup = await this.playlistBackupService.exportBackup();
 
-            if (this.isDesktop && window.electron?.saveFileDialog) {
+            if (this.supportsDesktopFileSave && window.electron) {
                 const savePath = await window.electron.saveFileDialog(
                     backup.defaultFileName,
                     [

--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -79,7 +79,8 @@ panels (`fetchEpg`, `getChannelPrograms`, `checkEpgFreshness`,
 `searchEpgPrograms`), `supportsPlaylistRefresh` requires the native playlist
 refresh/cancel/progress bridge, `supportsXtreamSectionNavigation` is available
 in PWA and in Electron when either the SQLite Xtream data source or the Xtream
-API transport is available, and
+API transport is available, `supportsDesktopFileSave` requires both
+`saveFileDialog` and `writeFile`, and
 `supportsManagedExternalPlayers` requires the MPV and VLC preload launch and
 path-setting methods (`openInMpv`, `openInVlc`, `setMpvPlayerPath`, and
 `setVlcPlayerPath`); a partial Electron bridge must not expose desktop-only

--- a/libs/services/src/lib/runtime-capabilities.service.spec.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.spec.ts
@@ -253,6 +253,24 @@ describe('RuntimeCapabilitiesService', () => {
         expect(service.supportsDownloads).toBe(true);
     });
 
+    it('requires both desktop file-save preload methods', () => {
+        testWindow.electron = {
+            saveFileDialog: jest.fn(),
+        };
+
+        const service = new RuntimeCapabilitiesService();
+
+        expect(service.isElectron).toBe(true);
+        expect(service.supportsDesktopFileSave).toBe(false);
+
+        testWindow.electron = {
+            saveFileDialog: jest.fn(),
+            writeFile: jest.fn(),
+        };
+
+        expect(service.supportsDesktopFileSave).toBe(true);
+    });
+
     it('requires the complete playlist refresh preload surface', () => {
         testWindow.electron = {
             refreshPlaylist: jest.fn(),


### PR DESCRIPTION
Stacked on #1001.

## Summary
- use supportsDesktopFileSave before invoking Electron saveFileDialog/writeFile for settings backup export
- fall back to browser download when an Electron bridge exposes only part of the desktop file-save surface
- document the desktop file-save runtime capability contract

## Validation
- pnpm nx test services --runTestsByPath libs/services/src/lib/runtime-capabilities.service.spec.ts
- pnpm nx test web --runTestsByPath apps/web/src/app/settings/settings.component.spec.ts
- pnpm nx lint services (passes with existing warnings)
- pnpm nx lint web
- pnpm run typecheck:web
- pnpm nx build web --configuration=electron-e2e --skip-nx-cache
- pnpm nx build web --configuration=pwa --skip-nx-cache (passes with existing SCSS budget/CommonJS warnings)
- pnpm nx run web-e2e:e2e-ci--src/settings.e2e.ts
- git diff --check

Docs updated: docs/architecture/pwa-self-hosted.md. Wiki export skipped because IPTVNATOR_WIKI_VAULT is not set.