### PR TITLE
fix(docker): build app on native build platform

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:22-alpine AS build
+# The Nx builds below emit platform-independent JS/static assets. During
+# multi-arch publish builds, keep that heavy build stage on the native builder
+# platform instead of running Node/Nx through QEMU for linux/arm64.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 
 RUN apk add --no-cache python3 make g++ git
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -49,6 +49,12 @@ pnpm nx build web --configuration=pwa
 pnpm nx build web-backend
 ```
 
+Those Nx builds generate platform-independent JS and static assets. In
+multi-architecture CI builds, the Dockerfile runs this build stage on the native
+BuildKit builder platform, then copies the generated output into each target
+runtime image. That avoids running the Angular/Nx build through QEMU when
+publishing `linux/amd64` and `linux/arm64` images.
+
 ## Published Docker Tags
 
 Pull request builds validate the Dockerfile without pushing an image. Docker


### PR DESCRIPTION
## Summary
- run the Docker app build stage on BuildKit's native builder platform during multi-arch builds
- keep the final runtime stage target-platform specific for amd64/arm64 images
- document why the PWA/backend Nx outputs are safe to copy into each target image

## Root Cause
The failing master run published linux/amd64 and linux/arm64 images. The Dockerfile previously ran `pnpm nx build web --configuration=pwa` inside each target build stage, so the arm64 leg executed Node/Nx through QEMU on the GitHub amd64 runner and crashed with `SIGILL`.

## Validation
- `git diff --check`
- `docker buildx build --builder codex-iptvnator-ci --platform linux/amd64,linux/arm64 -f docker/Dockerfile --progress=plain .`

Docs: updated `docker/README.md`. Wiki export skipped because `IPTVNATOR_WIKI_VAULT` is not configured.