### PR TITLE
chore(frontend): clean logging and lint suppressions

### DIFF
--- a/apps/web/src/app/services/electron.service.ts
+++ b/apps/web/src/app/services/electron.service.ts
@@ -6,6 +6,7 @@ import { PlaylistActions } from '@iptvnator/m3u-state';
 import { DataService } from '@iptvnator/services';
 import {
     AUTO_UPDATE_PLAYLISTS,
+    createDevLogger,
     ERROR,
     Playlist,
     PLAYLIST_PARSE_BY_URL,
@@ -46,6 +47,7 @@ export class ElectronService extends DataService {
     private readonly snackBar = inject(MatSnackBar);
     private readonly store = inject(Store);
     private readonly translateService = inject(TranslateService);
+    private readonly debugLog = createDevLogger('ElectronService');
     private readonly silentXtreamActions = new Set<string>([
         XtreamCodeActions.GetAccountInfo,
         XtreamCodeActions.GetLiveCategories,
@@ -58,7 +60,7 @@ export class ElectronService extends DataService {
 
     constructor() {
         super();
-        console.log('Electron service initialized...');
+        this.debugLog('Electron service initialized...');
         this.setupPlayerErrorListener();
         this.setupPortalDebugListener();
     }
@@ -225,7 +227,7 @@ export class ElectronService extends DataService {
             return playlists as T;
         }
 
-        console.log('Unknown type', type);
+        this.debugLog('Unknown IPC event type:', type);
         return undefined as T;
     }
 
@@ -476,7 +478,7 @@ export class ElectronService extends DataService {
 
             // Log error to console
             if (isSilentAction) {
-                console.log(
+                this.debugLog(
                     `Background Xtream action failed (${action ?? 'unknown'}):`,
                     normalizedMessage
                 );

--- a/apps/web/src/app/services/pwa.service.ts
+++ b/apps/web/src/app/services/pwa.service.ts
@@ -15,6 +15,7 @@ import {
 } from 'rxjs';
 import { DataService } from '@iptvnator/services';
 import {
+    createDevLogger,
     ERROR,
     Playlist,
     PLAYLIST_PARSE_BY_URL,
@@ -70,6 +71,7 @@ export class PwaService extends DataService {
     private readonly store = inject(Store);
     private readonly swUpdate = inject(SwUpdate);
     private readonly translateService = inject(TranslateService);
+    private readonly debugLog = createDevLogger('PwaService');
     private readonly providerTargetIds = new Map<string, Promise<string>>();
     private readonly silentXtreamActions = new Set<string>([
         XtreamCodeActions.GetAccountInfo,
@@ -86,7 +88,7 @@ export class PwaService extends DataService {
 
     constructor() {
         super();
-        console.log('PWA service initialized...');
+        this.debugLog('PWA service initialized...');
     }
 
     /** Uses service worker mechanism to check for available application updates */
@@ -355,7 +357,7 @@ export class PwaService extends DataService {
                 );
 
                 if (isSilentAction) {
-                    console.log(
+                    this.debugLog(
                         `Background Xtream action failed (${action ?? 'unknown'}):`,
                         normalizedMessage
                     );
@@ -395,7 +397,7 @@ export class PwaService extends DataService {
 
             // Log error to console
             if (isSilentAction) {
-                console.log(
+                this.debugLog(
                     `Background Xtream action failed (${action ?? 'unknown'}):`,
                     normalizedMessage
                 );

--- a/libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.ts
+++ b/libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.ts
@@ -85,6 +85,7 @@ import {
 } from '@iptvnator/services';
 import {
     Channel,
+    createDevLogger,
     EpgProgram,
     ExternalPlayerSession,
     OPEN_MPV_PLAYER,
@@ -142,6 +143,7 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
     private readonly workspaceHeaderContext = inject(
         WorkspaceHeaderContextService
     );
+    private readonly debugLog = createDevLogger('VideoPlayerComponent');
 
     /** Active selected channel */
     readonly activeChannel = this.store.selectSignal(selectActive);
@@ -442,7 +444,7 @@ export class VideoPlayerComponent implements OnInit, OnDestroy {
      * Handle remote control channel change
      */
     handleRemoteChannelChange(direction: 'up' | 'down'): void {
-        console.log(`Remote control: changing channel ${direction}`);
+        this.debugLog('Remote control channel change:', direction);
 
         // Use combineLatest to get both values and take only the first emission
         combineLatest([this.channels$, this.store.select(selectActive)])

--- a/libs/portal/stalker/data-access/src/lib/stalker-session.service.ts
+++ b/libs/portal/stalker/data-access/src/lib/stalker-session.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, inject } from '@angular/core';
-import { Playlist, STALKER_REQUEST } from '@iptvnator/shared/interfaces';
+import {
+    createDevLogger,
+    Playlist,
+    STALKER_REQUEST,
+} from '@iptvnator/shared/interfaces';
 import { DataService } from '@iptvnator/services';
 import {
     getStalkerPortalIdentityFromPlaylist,
@@ -87,6 +91,7 @@ interface StalkerAuthConfirmationResponse {
 })
 export class StalkerSessionService {
     private dataService = inject(DataService);
+    private readonly debugLog = createDevLogger('StalkerSession');
 
     // In-memory token cache for current session (keyed by playlist ID)
     private tokenCache = new Map<string, string>();
@@ -482,9 +487,7 @@ export class StalkerSessionService {
         // This prevents race conditions when multiple resources request a token simultaneously
         const pendingPromise = this.pendingAuth.get(playlist._id);
         if (pendingPromise) {
-            console.log(
-                '[StalkerSession] Waiting for pending authentication...'
-            );
+            this.debugLog('Waiting for pending authentication...');
             return pendingPromise;
         }
 

--- a/libs/services/src/lib/playlists.service.ts
+++ b/libs/services/src/lib/playlists.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { inject, Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { TranslateService } from '@ngx-translate/core';
@@ -139,6 +138,20 @@ export class PlaylistsService {
         }
 
         return this.indexedDbMigrationPromise;
+    }
+
+    private toPlaylistMeta(playlist: Playlist): Playlist {
+        const playlistMeta = { ...playlist };
+        delete playlistMeta.playlist;
+        delete playlistMeta.items;
+        delete playlistMeta.header;
+        return playlistMeta;
+    }
+
+    private toAutoUpdatePlaylistMeta(playlist: Playlist): Playlist {
+        const playlistMeta = this.toPlaylistMeta(playlist);
+        delete playlistMeta.favorites;
+        return playlistMeta;
     }
 
     private async migrateIndexedDbPlaylistsToSqlite(): Promise<void> {
@@ -366,10 +379,8 @@ export class PlaylistsService {
                 const playlists = electron
                     ? await electron.dbGetAppPlaylists()
                     : [];
-                return (playlists as Playlist[]).map(
-                    ({ playlist, items, header, ...rest }) => ({
-                        ...(rest as Playlist),
-                    })
+                return (playlists as Playlist[]).map((playlist) =>
+                    this.toPlaylistMeta(playlist)
                 );
             });
         }
@@ -377,11 +388,7 @@ export class PlaylistsService {
         return this.runOnIndexedDb(() =>
             firstValueFrom(this.dbService.getAll<Playlist>(DbStores.Playlists))
         ).pipe(
-            map((data) =>
-                data.map(({ playlist, items, header, ...rest }) => ({
-                    ...(rest as Playlist),
-                }))
-            )
+            map((data) => data.map((playlist) => this.toPlaylistMeta(playlist)))
         );
     }
 
@@ -855,15 +862,7 @@ export class PlaylistsService {
             map((playlists: Playlist[]) => {
                 return playlists
                     .filter((item) => item.autoRefresh)
-                    .map(
-                        ({
-                            playlist,
-                            header,
-                            items,
-                            favorites,
-                            ...rest
-                        }: Playlist) => rest
-                    );
+                    .map((playlist) => this.toAutoUpdatePlaylistMeta(playlist));
             })
         );
     }

--- a/libs/services/src/lib/portal-status.service.ts
+++ b/libs/services/src/lib/portal-status.service.ts
@@ -182,7 +182,7 @@ export class PortalStatusService {
             } else {
                 return 'inactive';
             }
-        } catch (error) {
+        } catch {
             return 'unavailable';
         }
     }

--- a/libs/services/src/lib/settings-store.service.ts
+++ b/libs/services/src/lib/settings-store.service.ts
@@ -135,7 +135,9 @@ export const SettingsStore = signalStore(
                 showCaptions: store.showCaptions(),
                 showDashboard: store.showDashboard(),
                 startupBehavior: store.startupBehavior(),
-                showExternalPlaybackBar: store.showExternalPlaybackBar!(),
+                showExternalPlaybackBar:
+                    store.showExternalPlaybackBar?.() ??
+                    DEFAULT_SETTINGS.showExternalPlaybackBar,
                 theme: store.theme(),
                 mpvPlayerPath: store.mpvPlayerPath(),
                 mpvPlayerArguments: store.mpvPlayerArguments(),
@@ -146,20 +148,26 @@ export const SettingsStore = signalStore(
                 remoteControl: store.remoteControl(),
                 remoteControlPort: store.remoteControlPort(),
                 epgUrl: store.epgUrl(),
-                downloadFolder: store.downloadFolder!(),
-                recordingFolder: store.recordingFolder!(),
-                coverSize: store.coverSize!(),
+                downloadFolder:
+                    store.downloadFolder?.() ?? DEFAULT_SETTINGS.downloadFolder,
+                recordingFolder:
+                    store.recordingFolder?.() ??
+                    DEFAULT_SETTINGS.recordingFolder,
+                coverSize: store.coverSize?.() ?? DEFAULT_SETTINGS.coverSize,
                 preferUploadedEpgOverXtream:
-                    store.preferUploadedEpgOverXtream!(),
+                    store.preferUploadedEpgOverXtream?.() ??
+                    DEFAULT_SETTINGS.preferUploadedEpgOverXtream,
             };
         },
 
         getDownloadFolder() {
-            return store.downloadFolder!();
+            return store.downloadFolder?.() ?? DEFAULT_SETTINGS.downloadFolder;
         },
 
         getRecordingFolder() {
-            return store.recordingFolder!();
+            return (
+                store.recordingFolder?.() ?? DEFAULT_SETTINGS.recordingFolder
+            );
         },
 
         getPlayer() {


### PR DESCRIPTION
## Summary
- route frontend/runtime debug-only messages through createDevLogger instead of direct console.log
- remove the broad no-unused-vars disable from PlaylistsService by extracting playlist metadata helpers
- clean remaining services lint warnings from an unused catch binding and optional settings signal fallbacks

## Validation
- pnpm nx run-many -t lint -p web services playlist-m3u-feature-player portal-stalker-data-access --skipNxCache
- pnpm nx test services --runInBand --skipNxCache
- pnpm nx test web --runInBand --skipNxCache
- pnpm nx test playlist-m3u-feature-player --runInBand --skipNxCache
- pnpm nx test portal-stalker-data-access --runInBand --skipNxCache
- pnpm nx run web:build --configuration=development --skipNxCache
- pnpm exec prettier --check apps/web/src/app/services/pwa.service.ts apps/web/src/app/services/electron.service.ts libs/playlist/m3u/feature-player/src/lib/video-player/video-player.component.ts libs/portal/stalker/data-access/src/lib/stalker-session.service.ts libs/services/src/lib/playlists.service.ts libs/services/src/lib/portal-status.service.ts libs/services/src/lib/settings-store.service.ts
- git diff --check