### PR TITLE
fix(xtream): open correct channel and category from Ctrl+F live search

### DIFF
--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.ts
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.ts
@@ -2,6 +2,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
+    DestroyRef,
     HostListener,
     computed,
     effect,
@@ -10,6 +11,8 @@ import {
     OnInit,
     signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { filter } from 'rxjs';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
@@ -62,12 +65,13 @@ import {
     ResolvedPortalPlayback,
 } from '@iptvnator/shared/interfaces';
 import { PortalChannelsListComponent } from '../portal-channels-list/portal-channels-list.component';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 
 const LIVE_CHANNEL_SORT_STORAGE_KEY = 'xtream-live-channel-sort-mode';
 
 interface XtreamLiveChannelItem {
+    readonly category_id?: string | number;
     readonly name?: string;
     readonly poster_url?: string;
     readonly stream_icon?: string;
@@ -100,7 +104,9 @@ interface XtreamLiveChannelItem {
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
+    private readonly destroyRef = inject(DestroyRef);
     private readonly route = inject(ActivatedRoute);
+    private readonly router = inject(Router);
     private readonly favoritesService = inject(FavoritesService);
     private readonly xtreamStore = inject(XtreamStore);
     private readonly xtreamUrlService = inject(XtreamUrlService);
@@ -233,14 +239,16 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
             onCleanup(() => clearInterval(intervalId));
         });
 
-        const requestedItemId = Number(
-            (window.history.state as Record<string, unknown> | null)?.[
-                'openXtreamLiveItemId'
-            ]
-        );
-        if (Number.isFinite(requestedItemId) && requestedItemId > 0) {
-            this.pendingAutoOpenLiveItemId.set(requestedItemId);
-        }
+        // Read pending auto-open from navigation state on first load
+        this.checkPendingAutoOpenFromState();
+
+        // Re-read on subsequent navigations to the same route (component is reused)
+        this.router.events
+            .pipe(
+                filter((e) => e instanceof NavigationEnd),
+                takeUntilDestroyed(this.destroyRef)
+            )
+            .subscribe(() => this.checkPendingAutoOpenFromState());
 
         effect(() => {
             const pendingId = this.pendingAutoOpenLiveItemId();
@@ -248,12 +256,21 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
                 return;
             }
 
-            const channels = this.getVisibleChannels();
-            if (!Array.isArray(channels) || channels.length === 0) {
+            // Guard: only process once the live content view is active; otherwise
+            // the effect may fire while selectedContentType is still 'vod' and
+            // incorrectly conclude the channel isn't found.
+            if (this.xtreamStore.selectedContentType() !== 'live') {
                 return;
             }
 
-            const item = channels.find(
+            // Search across all live streams, not just the category-filtered view,
+            // so a channel from a different category can still be auto-opened.
+            const allChannels = this.getAllLiveStreams();
+            if (!Array.isArray(allChannels) || allChannels.length === 0) {
+                return;
+            }
+
+            const item = allChannels.find(
                 (channel) => Number(channel?.xtream_id) === pendingId
             );
             if (!item) {
@@ -262,6 +279,11 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
             }
 
             this.playLive(item);
+            // Navigate to the channel's category so the sidebar shows it highlighted
+            const categoryId = Number(item.category_id);
+            if (Number.isFinite(categoryId) && categoryId > 0) {
+                this.xtreamStore.setSelectedCategory(categoryId);
+            }
             this.pendingAutoOpenLiveItemId.set(null);
             this.clearAutoOpenHistoryState();
         });
@@ -468,6 +490,21 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
             request.playback,
             request.player
         );
+    }
+
+    private checkPendingAutoOpenFromState(): void {
+        const requestedItemId = Number(
+            (window.history.state as Record<string, unknown> | null)?.[
+                'openXtreamLiveItemId'
+            ]
+        );
+        if (Number.isFinite(requestedItemId) && requestedItemId > 0) {
+            this.pendingAutoOpenLiveItemId.set(requestedItemId);
+        }
+    }
+
+    private getAllLiveStreams(): XtreamLiveChannelItem[] {
+        return this.xtreamStore.liveStreams() as unknown as XtreamLiveChannelItem[];
     }
 
     private getVisibleChannels(): XtreamLiveChannelItem[] {


### PR DESCRIPTION
## Summary

- **Component reuse bug**: when already on the `/live` route, Angular reused `LiveStreamLayoutComponent` without re-running the constructor, so `openXtreamLiveItemId` was never read from history state on re-navigation. Fixed by subscribing to `NavigationEnd` and re-checking the state on every navigation.
- **Wrong content type guard**: the auto-open effect could fire before `syncRouteState` set `selectedContentType` to `'live'`, causing the channel to be looked up in VOD streams, not found, and the pending ID immediately cleared. Fixed by guarding on `selectedContentType() === 'live'` before processing.
- **Category filter blocking lookup**: `getVisibleChannels()` only returned channels in the currently selected category, so a channel from a different category was never found. Switched to `getAllLiveStreams()` (raw `liveStreams` signal) for the auto-open lookup.
- **Sidebar not updating**: after opening the channel, `selectedCategoryId` is now set to the channel's category so the sidebar shows the correct category and highlights the playing channel.

## Test plan

- [ ] Open an Xtream playlist and navigate to the Live TV tab with a category selected
- [ ] Press Ctrl+F, search for a live channel in a **different** category, click it → channel plays and sidebar updates to its category
- [ ] Press Ctrl+F while already on the Live TV tab, click a live channel → channel plays (component reuse case)
- [ ] Press Ctrl+F while on the VOD tab, click a live channel → navigates to Live TV and plays the channel

🤖 Generated with [Claude Code](https://claude.ai/claude-code)