### PR TITLE
ci: harden CI workflow permissions/concurrency + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+    # Keep GitHub Actions up to date. Dependabot can also raise PRs that pin
+    # actions to commit SHAs, addressing the "unpinned third-party action"
+    # supply-chain risk without hand-maintaining digests.
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      labels:
+          - 'dependencies'
+          - 'github-actions'
+
+    # Keep npm dependencies up to date. Dev/tooling updates are grouped to keep
+    # PR noise low; runtime dependencies are raised individually for review.
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      open-pull-requests-limit: 10
+      labels:
+          - 'dependencies'
+      groups:
+          dev-dependencies:
+              dependency-type: 'development'
+
+    # Keep the self-hosted PWA Docker base image patched.
+    - package-ecosystem: 'docker'
+      directory: '/docker'
+      schedule:
+          interval: 'weekly'
+      labels:
+          - 'dependencies'
+          - 'docker'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ on:
             - master
     workflow_dispatch:
 
+# Least-privilege default token: this workflow only reads the repo.
+permissions:
+    contents: read
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     unit-and-typecheck:
         name: Unit Tests and Typechecks

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,16 @@ on:
   schedule:
     - cron: '0 20 * * 3'
 
+# Least-privilege token for CodeQL: read code + Actions, write scan results.
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -8,6 +8,15 @@ on:
         branches:
             - master
 
+# Least-privilege default token: E2E only needs to read the repo.
+permissions:
+    contents: read
+
+# Cancel superseded multi-OS E2E runs on the same ref.
+concurrency:
+    group: e2e-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     electron-e2e-tests:
         name: Electron E2E on ${{ matrix.os }}


### PR DESCRIPTION
CI hardening, rebased onto the latest `master`:
- `ci.yml`: least-privilege `permissions: contents: read` (was the broad default token) + a `concurrency` group that cancels superseded runs on the same ref.
- New `.github/dependabot.yml`: weekly `github-actions` (also enables SHA-pinning), `npm` (dev/tooling grouped), and `docker` updates.

No job logic changed.