### PR TITLE
fix(player): kill reused MPV/VLC processes on app quit

### DIFF
--- a/apps/electron-backend/src/app/events/mpv-session.service.spec.ts
+++ b/apps/electron-backend/src/app/events/mpv-session.service.spec.ts
@@ -1,0 +1,150 @@
+jest.mock('electron', () => ({
+    ipcMain: {
+        handle: jest.fn(),
+    },
+}));
+
+jest.mock('child_process', () => ({
+    spawn: jest.fn(),
+}));
+
+jest.mock('../app', () => ({
+    __esModule: true,
+    default: {
+        mainWindow: null,
+    },
+}));
+
+jest.mock('../services/store.service', () => ({
+    MPV_PLAYER_ARGUMENTS: 'MPV_PLAYER_ARGUMENTS',
+    MPV_PLAYER_PATH: 'MPV_PLAYER_PATH',
+    MPV_REUSE_INSTANCE: 'MPV_REUSE_INSTANCE',
+    VLC_PLAYER_ARGUMENTS: 'VLC_PLAYER_ARGUMENTS',
+    VLC_PLAYER_PATH: 'VLC_PLAYER_PATH',
+    VLC_REUSE_INSTANCE: 'VLC_REUSE_INSTANCE',
+    store: {
+        get: jest.fn(),
+        set: jest.fn(),
+    },
+}));
+
+import { spawn, type ChildProcess } from 'child_process';
+import { EventEmitter } from 'events';
+import {
+    MPV_PLAYER_PATH,
+    MPV_REUSE_INSTANCE,
+    VLC_PLAYER_PATH,
+    VLC_REUSE_INSTANCE,
+    store,
+} from '../services/store.service';
+import { openMpvPlayer, shutdownMpvSession } from './mpv-session.service';
+import { openVlcPlayer, shutdownVlcSession } from './vlc-session.service';
+
+function createMockChildProcess(): ChildProcess {
+    return Object.assign(new EventEmitter(), {
+        killed: false,
+        kill: jest.fn(() => true),
+        stderr: null,
+        stdout: null,
+        unref: jest.fn(),
+    }) as unknown as ChildProcess;
+}
+
+async function waitForSpawnCallCount(count: number): Promise<void> {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        if ((spawn as unknown as jest.Mock).mock.calls.length >= count) {
+            return;
+        }
+
+        await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+        });
+    }
+
+    throw new Error(`Expected ${count} player spawn calls`);
+}
+
+function mockStoreValues(values: Record<string, unknown>): void {
+    (store.get as unknown as jest.Mock).mockImplementation(
+        (key: string, fallback?: unknown) =>
+            key in values ? values[key] : fallback
+    );
+}
+
+describe('external player shutdown on app quit', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('kills the stored reusable MPV process on shutdown', async () => {
+        const proc = createMockChildProcess();
+        (spawn as unknown as jest.Mock).mockReturnValue(proc);
+        mockStoreValues({
+            [MPV_PLAYER_PATH]: '/usr/bin/mpv',
+            [MPV_REUSE_INSTANCE]: true,
+        });
+
+        await openMpvPlayer({
+            title: 'Reusable MPV stream',
+            url: 'https://example.com/live.m3u8',
+        });
+
+        expect(proc.kill).not.toHaveBeenCalled();
+
+        shutdownMpvSession();
+
+        expect(proc.kill).toHaveBeenCalledTimes(1);
+
+        // The stored process reference is cleared, so a second shutdown
+        // must not attempt another kill.
+        shutdownMpvSession();
+        expect(proc.kill).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not track non-reusable MPV processes for shutdown', async () => {
+        const proc = createMockChildProcess();
+        (spawn as unknown as jest.Mock).mockReturnValue(proc);
+        mockStoreValues({
+            [MPV_PLAYER_PATH]: '/usr/bin/mpv',
+            [MPV_REUSE_INSTANCE]: false,
+        });
+
+        await openMpvPlayer({
+            title: 'Detached MPV stream',
+            url: 'https://example.com/live.m3u8',
+        });
+
+        expect(proc.unref).toHaveBeenCalled();
+
+        shutdownMpvSession();
+
+        expect(proc.kill).not.toHaveBeenCalled();
+    });
+
+    it('kills the stored reusable VLC process on shutdown', async () => {
+        const proc = createMockChildProcess();
+        (spawn as unknown as jest.Mock).mockReturnValue(proc);
+        mockStoreValues({
+            [VLC_PLAYER_PATH]: '/usr/bin/vlc',
+            [VLC_REUSE_INSTANCE]: true,
+        });
+
+        const openPromise = openVlcPlayer({
+            title: 'Reusable VLC stream',
+            url: 'https://example.com/live.m3u8',
+        });
+
+        await waitForSpawnCallCount(1);
+        proc.emit('spawn');
+        await openPromise;
+
+        expect(proc.kill).not.toHaveBeenCalled();
+
+        shutdownVlcSession();
+
+        expect(proc.kill).toHaveBeenCalledTimes(1);
+
+        shutdownVlcSession();
+        expect(proc.kill).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/electron-backend/src/app/events/mpv-session.service.ts
+++ b/apps/electron-backend/src/app/events/mpv-session.service.ts
@@ -181,17 +181,33 @@ function sendMpvCommand(
     });
 }
 
+function killStoredMpvProcess(reason: string): void {
+    if (!mpvProcess || mpvProcess.killed) {
+        return;
+    }
+    traceExternalPlayer(reason);
+    mpvProcess.kill();
+    mpvProcess = null;
+    mpvSocketPath = null;
+    stopPositionPolling();
+}
+
 export function setMpvReuseInstance(reuseInstance: boolean): void {
     traceExternalPlayer('set mpv reuse instance', { reuseInstance });
     store.set(MPV_REUSE_INSTANCE, reuseInstance);
 
-    if (!reuseInstance && mpvProcess && !mpvProcess.killed) {
-        traceExternalPlayer('clean up mpv process after disabling reuse');
-        mpvProcess.kill();
-        mpvProcess = null;
-        mpvSocketPath = null;
-        stopPositionPolling();
+    if (!reuseInstance) {
+        killStoredMpvProcess('clean up mpv process after disabling reuse');
     }
+}
+
+/**
+ * Kill the MPV instance kept alive for reuse. The reused process is spawned
+ * non-detached with piped stdio, so without an explicit kill it outlives the
+ * app and keeps playing after quit.
+ */
+export function shutdownMpvSession(): void {
+    killStoredMpvProcess('kill reused mpv process on app shutdown');
 }
 
 export async function openMpvPlayer({

--- a/apps/electron-backend/src/app/events/vlc-session.service.ts
+++ b/apps/electron-backend/src/app/events/vlc-session.service.ts
@@ -270,17 +270,33 @@ function getFreePort(): Promise<number> {
     });
 }
 
+function killStoredVlcProcess(reason: string): void {
+    if (!vlcProcess || vlcProcess.killed) {
+        return;
+    }
+    traceExternalPlayer(reason);
+    vlcProcess.kill();
+    vlcProcess = null;
+    vlcRcPort = null;
+    stopVlcPositionPolling();
+}
+
 export function setVlcReuseInstance(reuseInstance: boolean): void {
     traceExternalPlayer('set vlc reuse instance', { reuseInstance });
     store.set(VLC_REUSE_INSTANCE, reuseInstance);
 
-    if (!reuseInstance && vlcProcess && !vlcProcess.killed) {
-        traceExternalPlayer('clean up vlc process after disabling reuse');
-        vlcProcess.kill();
-        vlcProcess = null;
-        vlcRcPort = null;
-        stopVlcPositionPolling();
+    if (!reuseInstance) {
+        killStoredVlcProcess('clean up vlc process after disabling reuse');
     }
+}
+
+/**
+ * Kill the VLC instance kept alive for reuse. The reused process is spawned
+ * non-detached, so without an explicit kill it outlives the app and keeps
+ * playing after quit.
+ */
+export function shutdownVlcSession(): void {
+    killStoredVlcProcess('kill reused vlc process on app shutdown');
 }
 
 export async function openVlcPlayer({

--- a/apps/electron-backend/src/main.ts
+++ b/apps/electron-backend/src/main.ts
@@ -13,7 +13,9 @@ import EmbeddedMpvEvents, {
     shutdownEmbeddedMpv,
 } from './app/events/embedded-mpv.events';
 import EpgEvents from './app/events/epg.events';
+import { shutdownMpvSession } from './app/events/mpv-session.service';
 import PlayerEvents from './app/events/player.events';
+import { shutdownVlcSession } from './app/events/vlc-session.service';
 import PlaylistEvents from './app/events/playlist.events';
 import RemoteControlEvents from './app/events/remote-control.events';
 import SettingsEvents from './app/events/settings.events';
@@ -145,5 +147,7 @@ app.whenReady().then(async () => {
 
 app.on('before-quit', () => {
     shutdownEmbeddedMpv();
+    shutdownMpvSession();
+    shutdownVlcSession();
     void databaseWorkerClient.shutdown();
 });


### PR DESCRIPTION
## Problem

With the **reuse instance** setting enabled, the spawned MPV/VLC process is stored globally and kept alive (non-detached, piped stdio) so follow-up streams can be loaded into the same player window. Nothing killed that process on app quit — every app restart left an orphaned player running in the background, accumulating zombie processes over time.

## Fix

- Extract a `killStoredMpvProcess()` / `killStoredVlcProcess()` helper from the existing "disable reuse" cleanup path.
- Export `shutdownMpvSession()` / `shutdownVlcSession()` and call them from the existing `app.on('before-quit')` hook in `main.ts`, mirroring the embedded-MPV shutdown path.
- Non-reusable (detached + unref'ed) processes are intentionally untouched — detaching is the documented behavior there.

## Test impact

- New regression spec `mpv-session.service.spec.ts`: reusable MPV process is killed exactly once on shutdown, non-reusable MPV process is not tracked, reusable VLC process is killed on shutdown.
- `pnpm nx test electron-backend` — 24 suites, 254 tests passed.
- `pnpm nx lint electron-backend` — clean.
- Docs: no updates needed (internal lifecycle fix, no user-visible behavior or architecture change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)