### PR TITLE
test(electron): allow local EPG mocks in E2E

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -13,6 +13,7 @@ jobs:
         name: Electron E2E on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}
         env:
+            IPTVNATOR_ALLOW_PRIVATE_NETWORK_URLS: '1'
             NX_SKIP_NX_CACHE: true
         strategy:
             fail-fast: false

--- a/apps/electron-backend-e2e/src/electron-test-fixtures.ts
+++ b/apps/electron-backend-e2e/src/electron-test-fixtures.ts
@@ -141,6 +141,9 @@ export async function launchElectronApp(
         args,
         env: {
             ...process.env,
+            // Electron E2E uses local mock HTTP servers for playlists, portals, and EPG sources.
+            IPTVNATOR_ALLOW_PRIVATE_NETWORK_URLS:
+                process.env['IPTVNATOR_ALLOW_PRIVATE_NETWORK_URLS'] ?? '1',
             ...options.env,
             ELECTRON_IS_DEV: '0',
             IPTVNATOR_E2E_DATA_DIR: dataDir,


### PR DESCRIPTION
## Summary\n- allow private-network URLs only in Electron E2E runs because the tests use localhost/127.0.0.1 mock playlist, portal, and EPG servers\n- set the same default in the Electron E2E launch helper for local runs\n\n## Validation\n- pnpm nx lint electron-backend-e2e\n- pnpm nx run electron-backend-e2e:e2e-ci--src/epg.e2e.ts --skip-nx-cache