### PR TITLE
ci: skip draft release for fork PRs

### DIFF
--- a/.github/workflows/build-and-make.yaml
+++ b/.github/workflows/build-and-make.yaml
@@ -522,6 +522,7 @@ jobs:
     create-release:
         name: Create Draft Release
         needs: build
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         runs-on: ubuntu-latest
         permissions:
             contents: write


### PR DESCRIPTION
## Summary
- skip the draft release job for pull requests from forks, where the GitHub token is read-only
- keep the job enabled for same-repo PRs, pushes, tags, and manual workflow runs

## Validation
- pnpm exec prettier --check .github/workflows/build-and-make.yaml