### PR TITLE
[codex] fix Electron hardening follow-ups

### DIFF
--- a/apps/electron-backend/src/app/events/xtream.events.ts
+++ b/apps/electron-backend/src/app/events/xtream.events.ts
@@ -275,9 +275,9 @@ ipcMain.handle(
             method?: 'GET' | 'HEAD';
         }
     ) => {
-        // Guard against SSRF: a malicious portal/playlist could ask the main
-        // process to probe loopback/private/metadata addresses. Only allow
-        // public http(s) targets.
+        // Probe URLs must be http(s), but may target private/LAN Xtream hosts
+        // for self-hosted setups. Redirects stay disabled below so a validated
+        // URL cannot bounce to a different private target.
         try {
             // Private/LAN targets are allowed (users probe self-hosted Xtream
             // servers); maxRedirects:0 below blocks redirect-based SSRF.

--- a/apps/electron-backend/src/app/events/xtream.events.ts
+++ b/apps/electron-backend/src/app/events/xtream.events.ts
@@ -279,8 +279,6 @@ ipcMain.handle(
         // for self-hosted setups. Redirects stay disabled below so a validated
         // URL cannot bounce to a different private target.
         try {
-            // Private/LAN targets are allowed (users probe self-hosted Xtream
-            // servers); maxRedirects:0 below blocks redirect-based SSRF.
             await assertRemoteUrlAllowed(payload.url, {
                 allowPrivateNetworks: true,
             });

--- a/apps/electron-backend/src/app/workers/epg-database.spec.ts
+++ b/apps/electron-backend/src/app/workers/epg-database.spec.ts
@@ -5,6 +5,7 @@ function createDatabaseMock(exec: jest.Mock) {
     const database = {
         close: jest.fn(),
         exec,
+        pragma: jest.fn(),
     };
     const Database = jest.fn(() => database) as unknown as typeof BetterSqlite3;
 
@@ -14,10 +15,11 @@ function createDatabaseMock(exec: jest.Mock) {
 describe('EpgDatabaseClearOperation', () => {
     it('clears programs and channels in one transaction', () => {
         const exec = jest.fn();
-        const { Database } = createDatabaseMock(exec);
+        const { Database, database } = createDatabaseMock(exec);
 
         new EpgDatabaseClearOperation(Database).run();
 
+        expect(database.pragma).toHaveBeenCalledWith('busy_timeout = 5000');
         expect(exec.mock.calls.map(([statement]) => statement)).toEqual([
             'BEGIN',
             'DELETE FROM epg_programs',

--- a/apps/electron-backend/src/app/workers/epg-database.ts
+++ b/apps/electron-backend/src/app/workers/epg-database.ts
@@ -126,6 +126,7 @@ export class EpgDatabaseClearOperation {
 
     constructor(Database: typeof BetterSqlite3) {
         this.db = new Database(getIptvnatorDatabasePath());
+        this.db.pragma('busy_timeout = 5000');
     }
 
     run(): void {

--- a/libs/services/src/lib/downloads.service.spec.ts
+++ b/libs/services/src/lib/downloads.service.spec.ts
@@ -12,7 +12,6 @@ import {
     DownloadsService,
 } from './downloads.service';
 import { RuntimeCapabilitiesService } from './runtime-capabilities.service';
-import { SettingsStore } from './settings-store.service';
 
 type TestDownloadsService = {
     downloads: WritableSignal<DownloadItem[]>;
@@ -22,16 +21,15 @@ type TestDownloadsService = {
     hasLoadedDownloads: Signal<boolean>;
     loadDownloads: DownloadsService['loadDownloads'];
     loadDownloadFolder: DownloadsService['loadDownloadFolder'];
+    selectFolder: DownloadsService['selectFolder'];
     _isLoadingDownloads: WritableSignal<boolean>;
     _hasLoadedDownloads: WritableSignal<boolean>;
     loadDownloadsRequestId: number;
-    settingsStore: {
-        getDownloadFolder: () => string;
-    };
 };
 
 type DownloadsElectronStub = {
     downloadsGetDefaultFolder?: jest.Mock<Promise<string>, []>;
+    downloadsSelectFolder?: jest.Mock<Promise<string | null>, []>;
     downloadsGetList: jest.Mock<Promise<DownloadItem[]>, [string?]>;
 };
 
@@ -87,9 +85,6 @@ describe('DownloadsService', () => {
             _hasLoadedDownloads: hasLoadedDownloads,
             hasLoadedDownloads: hasLoadedDownloads.asReadonly(),
             loadDownloadsRequestId: 0,
-            settingsStore: {
-                getDownloadFolder: () => '/renderer-controlled',
-            },
         });
 
         return service;
@@ -99,7 +94,6 @@ describe('DownloadsService', () => {
         const injector = createEnvironmentInjector(
             [
                 DownloadsService,
-                { provide: SettingsStore, useValue: {} },
                 {
                     provide: RuntimeCapabilitiesService,
                     useValue: { supportsDownloads: false },
@@ -154,6 +148,19 @@ describe('DownloadsService', () => {
         await expect(service.loadDownloadFolder()).resolves.toBe('/authorized');
         expect(service.downloadFolder()).toBe('/authorized');
         expect(electron.downloadsGetDefaultFolder).toHaveBeenCalledTimes(1);
+    });
+
+    it('stores a selected download folder returned by the main process', async () => {
+        const electron = {
+            downloadsSelectFolder: jest.fn(async () => '/selected'),
+            downloadsGetList: jest.fn(async () => []),
+        };
+        testWindow.electron = electron;
+        const service = createService();
+
+        await expect(service.selectFolder()).resolves.toBe('/selected');
+        expect(service.downloadFolder()).toBe('/selected');
+        expect(electron.downloadsSelectFolder).toHaveBeenCalledTimes(1);
     });
 
     it('marks downloads as loaded after a failed request while preserving existing data', async () => {

--- a/libs/services/src/lib/downloads.service.ts
+++ b/libs/services/src/lib/downloads.service.ts
@@ -1,6 +1,5 @@
 import { computed, inject, Injectable, OnDestroy, signal } from '@angular/core';
 import { RuntimeCapabilitiesService } from './runtime-capabilities.service';
-import { SettingsStore } from './settings-store.service';
 
 export type DownloadStatus =
     | 'queued'
@@ -33,7 +32,6 @@ export interface DownloadItem {
 @Injectable({ providedIn: 'root' })
 export class DownloadsService implements OnDestroy {
     private readonly runtime = inject(RuntimeCapabilitiesService);
-    private readonly settingsStore = inject(SettingsStore);
     private unsubscribe?: () => void;
     private loadDownloadsRequestId = 0;
 
@@ -330,8 +328,6 @@ export class DownloadsService implements OnDestroy {
             const folder = await window.electron.downloadsSelectFolder();
             if (folder) {
                 this.downloadFolder.set(folder);
-                // Save to settings
-                await this.settingsStore.updateSettings({ downloadFolder: folder });
             }
             return folder;
         } catch (error) {


### PR DESCRIPTION
## Summary

- remove the stale `SettingsStore` dependency from `DownloadsService` and keep folder selection owned by the Electron main process
- clarify the Xtream probe comment so it matches the intended private/LAN-host boundary with redirects disabled
- apply `busy_timeout = 5000` to `EpgDatabaseClearOperation` and cover it in the worker unit test

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm nx show projects`
- `pnpm nx test services`
- `pnpm nx test electron-backend`
- `pnpm nx lint services`
- `pnpm nx lint electron-backend`

Docs impact: no canonical docs update needed; this is a narrow cleanup/robustness follow-up with no user-visible workflow or architecture change.