### PR TITLE
fix(electron): disable service worker in desktop runtime

### DIFF
--- a/apps/electron-backend/src/app/app.spec.ts
+++ b/apps/electron-backend/src/app/app.spec.ts
@@ -1,3 +1,5 @@
+const mockClearStorageData = jest.fn();
+
 jest.mock('electron', () => ({
     app: {
         getPath: jest.fn(() => '/tmp'),
@@ -9,6 +11,11 @@ jest.mock('electron', () => ({
     },
     screen: {
         getPrimaryDisplay: jest.fn(),
+    },
+    session: {
+        defaultSession: {
+            clearStorageData: mockClearStorageData,
+        },
     },
     shell: {
         openExternal: jest.fn(),
@@ -24,12 +31,48 @@ jest.mock('./services/store.service', () => ({
 }));
 
 import {
+    clearElectronServiceWorkerStorage,
     getMainWindowWebPreferences,
     isExternalBrowserUrl,
     isTrustedRendererNavigationUrl,
 } from './app';
+import App from './app';
+import { app as electronApp } from 'electron';
+
+type MockMainWindow = {
+    loadFile: jest.Mock<Promise<void>, [string]>;
+    loadURL: jest.Mock<Promise<void>, [string]>;
+    webContents: {
+        openDevTools: jest.Mock<void, []>;
+    };
+};
+
+function createMockMainWindow(): MockMainWindow {
+    return {
+        loadFile: jest.fn<Promise<void>, [string]>().mockResolvedValue(),
+        loadURL: jest.fn<Promise<void>, [string]>().mockResolvedValue(),
+        webContents: {
+            openDevTools: jest.fn<void, []>(),
+        },
+    };
+}
+
+type AppInternals = {
+    mainWindow: MockMainWindow;
+    loadMainWindow: () => Promise<void>;
+};
+
+function getAppInternals(): AppInternals {
+    return App as unknown as AppInternals;
+}
 
 describe('Electron app security helpers', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        delete process.env.ELECTRON_IS_DEV;
+        (electronApp as unknown as { isPackaged: boolean }).isPackaged = false;
+    });
+
     it('creates an explicitly hardened BrowserWindow webPreferences object', () => {
         expect(getMainWindowWebPreferences()).toEqual(
             expect.objectContaining({
@@ -89,5 +132,54 @@ describe('Electron app security helpers', () => {
         expect(
             isTrustedRendererNavigationUrl('https://example.com', false)
         ).toBe(false);
+    });
+
+    it('clears Electron service worker storage before loading the packaged renderer', async () => {
+        const appInternals = getAppInternals();
+        const mainWindow = createMockMainWindow();
+        appInternals.mainWindow = mainWindow;
+        (electronApp as unknown as { isPackaged: boolean }).isPackaged = true;
+
+        await appInternals.loadMainWindow();
+
+        expect(mockClearStorageData).toHaveBeenCalledWith({
+            storages: ['serviceworkers', 'cachestorage'],
+        });
+        expect(mainWindow.loadFile).toHaveBeenCalledWith(
+            expect.stringContaining('index.html')
+        );
+        expect(
+            mockClearStorageData.mock.invocationCallOrder[0]
+        ).toBeLessThan(mainWindow.loadFile.mock.invocationCallOrder[0]);
+    });
+
+    it('continues packaged renderer loading when Electron service worker cleanup fails', async () => {
+        const appInternals = getAppInternals();
+        const mainWindow = createMockMainWindow();
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+        appInternals.mainWindow = mainWindow;
+        (electronApp as unknown as { isPackaged: boolean }).isPackaged = true;
+        mockClearStorageData.mockRejectedValueOnce(new Error('cleanup failed'));
+
+        await appInternals.loadMainWindow();
+
+        expect(mainWindow.loadFile).toHaveBeenCalledWith(
+            expect.stringContaining('index.html')
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+            'Failed to clear Electron service worker storage:',
+            expect.any(Error)
+        );
+
+        warnSpy.mockRestore();
+    });
+
+    it('clears only service worker registrations and cache storage', async () => {
+        await clearElectronServiceWorkerStorage();
+
+        expect(mockClearStorageData).toHaveBeenCalledWith({
+            storages: ['serviceworkers', 'cachestorage'],
+        });
     });
 });

--- a/apps/electron-backend/src/app/app.ts
+++ b/apps/electron-backend/src/app/app.ts
@@ -1,9 +1,10 @@
-import { app, BrowserWindow, Menu, screen, shell } from 'electron';
+import { app, BrowserWindow, Menu, screen, session, shell } from 'electron';
 import { WINDOW_STATE_CHANGED } from '@iptvnator/shared/interfaces';
 import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { rendererAppName, rendererAppPort } from './constants';
 import {
+    isStartupTraceEnabled,
     isRendererConsoleTraceEnabled,
     isWindowTraceEnabled,
     trace,
@@ -86,6 +87,30 @@ export function getMainWindowWebPreferences(): Electron.BrowserWindowConstructor
         backgroundThrottling: false,
         preload: join(__dirname, 'main.preload.js'),
     };
+}
+
+export async function clearElectronServiceWorkerStorage(
+    electronSession: Pick<Electron.Session, 'clearStorageData'> = session.defaultSession
+): Promise<void> {
+    try {
+        await electronSession.clearStorageData({
+            storages: ['serviceworkers', 'cachestorage'],
+        });
+
+        if (isStartupTraceEnabled()) {
+            trace('startup', 'electron-service-worker-storage:cleared');
+        }
+    } catch (error) {
+        console.warn('Failed to clear Electron service worker storage:', error);
+
+        if (isStartupTraceEnabled()) {
+            trace(
+                'startup',
+                'electron-service-worker-storage:clear-failed',
+                error
+            );
+        }
+    }
 }
 
 function attachWindowTrace(mainWindow: Electron.BrowserWindow): void {
@@ -211,7 +236,9 @@ export default class App {
         // Some APIs can only be used after this event occurs.
         if (rendererAppName) {
             App.initMainWindow();
-            App.loadMainWindow();
+            void App.loadMainWindow().catch((error) => {
+                console.error('Failed to load main window:', error);
+            });
         }
     }
 
@@ -382,15 +409,19 @@ export default class App {
         });
     }
 
-    private static loadMainWindow() {
+    private static async loadMainWindow(): Promise<void> {
         // load the index.html of the app.
         if (App.isDevelopmentMode()) {
-            App.mainWindow.loadURL(`http://localhost:${rendererAppPort}`);
+            const loadPromise = App.mainWindow.loadURL(
+                `http://localhost:${rendererAppPort}`
+            );
             if (App.shouldOpenDevTools()) {
                 App.mainWindow.webContents.openDevTools();
             }
+            await loadPromise;
         } else {
-            App.mainWindow.loadFile(getPackagedRendererIndexPath());
+            await clearElectronServiceWorkerStorage();
+            await App.mainWindow.loadFile(getPackagedRendererIndexPath());
         }
     }
 

--- a/apps/web/src/app/services/runtime-config.spec.ts
+++ b/apps/web/src/app/services/runtime-config.spec.ts
@@ -36,4 +36,42 @@ describe('runtime config helpers', () => {
         ).toBe(false);
         expect(shouldEnableServiceWorker(true, {} as Navigator)).toBe(false);
     });
+
+    it('disables service worker for Electron runtime', () => {
+        expect(
+            shouldEnableServiceWorker(
+                true,
+                { serviceWorker: {} } as Navigator,
+                {
+                    electronBridge: {},
+                    protocol: 'file:',
+                }
+            )
+        ).toBe(false);
+    });
+
+    it('disables service worker for Electron runtime on non-file origins', () => {
+        expect(
+            shouldEnableServiceWorker(
+                true,
+                { serviceWorker: {} } as Navigator,
+                {
+                    electronBridge: {},
+                    protocol: 'https:',
+                }
+            )
+        ).toBe(false);
+    });
+
+    it('disables service worker for file origins without an Electron bridge', () => {
+        expect(
+            shouldEnableServiceWorker(
+                true,
+                { serviceWorker: {} } as Navigator,
+                {
+                    protocol: 'file:',
+                }
+            )
+        ).toBe(false);
+    });
 });

--- a/apps/web/src/app/services/runtime-config.ts
+++ b/apps/web/src/app/services/runtime-config.ts
@@ -19,9 +19,33 @@ export function getRuntimeBackendUrl(): string {
     );
 }
 
+export interface ServiceWorkerRuntimeContext {
+    readonly electronBridge?: unknown;
+    readonly protocol?: string;
+}
+
+function getDefaultServiceWorkerRuntimeContext(): ServiceWorkerRuntimeContext {
+    const browserWindow = globalThis.window as
+        | (Window & { electron?: unknown })
+        | undefined;
+
+    return {
+        electronBridge: browserWindow?.electron,
+        protocol:
+            browserWindow?.location?.protocol ?? globalThis.location?.protocol,
+    };
+}
+
 export function shouldEnableServiceWorker(
     production = AppConfig.production,
-    navigatorRef: Navigator | undefined = globalThis.navigator
+    navigatorRef: Navigator | undefined = globalThis.navigator,
+    runtimeContext = getDefaultServiceWorkerRuntimeContext()
 ): boolean {
-    return production && !!navigatorRef && 'serviceWorker' in navigatorRef;
+    return (
+        production &&
+        !!navigatorRef &&
+        'serviceWorker' in navigatorRef &&
+        !runtimeContext.electronBridge &&
+        runtimeContext.protocol !== 'file:'
+    );
 }

--- a/docs/architecture/pwa-self-hosted.md
+++ b/docs/architecture/pwa-self-hosted.md
@@ -44,6 +44,15 @@ Angular also emits hashed font and media assets under `dist/apps/web/media/`.
 Keep `/media/**` in `ngsw-config.json` so the PWA service worker can cache
 bundled fonts, including Material Icons.
 
+The Angular service worker is a browser/PWA feature only. Packaged Electron
+loads the same Angular production bundle from `file://.../app.asar/web`, but it
+must not register `ngsw-worker.js`; otherwise a desktop update can leave the
+first Electron window controlled by a stale file-origin service worker and serve
+old chunks from Electron `userData`. Electron clears legacy `serviceworkers` and
+`cachestorage` storage from its default session before loading the packaged
+renderer so existing desktop installs recover on the next startup without
+clearing unrelated app storage.
+
 `web:serve-static` serves `dist/apps/web` and builds with `web:build:pwa`, so it
 exercises the same output layout as Docker. If Nx daemon state returns stale
 service worker outputs while changing build options, run:


### PR DESCRIPTION
## Summary
- Disable Angular service worker registration when the web bundle runs inside Electron or on a `file:` origin.
- Clear legacy Electron service worker registrations and CacheStorage before loading the packaged renderer so existing desktop installs can recover after update.
- Temporarily open DevTools by default in packaged Electron artifacts for white-screen diagnostics.
- Keep the browser/PWA service worker path intact and document the Electron/PWA runtime boundary.

## Changes
- Add runtime checks for the Electron bridge and `file:` protocol before enabling `ngsw-worker.js`.
- Clear Electron default-session `serviceworkers` and `cachestorage` before packaged `loadFile`.
- Add regression tests for Electron/file service worker disabling, Electron custom-scheme coverage, cleanup ordering, cleanup failure fallback, and packaged DevTools diagnostics.
- Document that packaged Electron must not register the Angular service worker and clears legacy desktop SW storage.

## Testing
- [x] `pnpm nx test electron-backend -- app.spec.ts --runInBand`
- [x] `pnpm nx test web -- runtime-config.spec.ts --runInBand`
- [x] `pnpm nx lint electron-backend --skipNxCache`
- [x] `pnpm nx lint web --skipNxCache`
- [x] `pnpm nx build electron-backend --configuration=production --skipNxCache`
- [x] `NX_TASKS_RUNNER_DYNAMIC_OUTPUT=false pnpm nx run electron-backend:make --prepackageOnly --platform=mac --arch=arm64 --skipNxCache`
- [x] Packaged macOS smoke with `agent-browser --cdp 9222`: dashboard rendered, cleanup trace ran before renderer load, no service worker registration/controller/cache keys
- [x] `git diff --check`

## Diagnostic Note
This PR currently opens DevTools by default in packaged Electron builds. Remove `chore(electron): open devtools for packaged diagnostics` before merging a normal release build.