### PR TITLE
feat(workspace): expandable navigation rail

### DIFF
--- a/apps/electron-backend-e2e/src/electron-test-fixtures.ts
+++ b/apps/electron-backend-e2e/src/electron-test-fixtures.ts
@@ -565,7 +565,7 @@ export async function saveSettings(page: Page): Promise<void> {
 
 export async function goToDashboard(page: Page): Promise<void> {
     const dashboardLink = page
-        .locator('a.brand[href$="/workspace/dashboard"]')
+        .getByRole('link', { name: 'Dashboard', exact: true })
         .first();
 
     await expect(dashboardLink).toBeVisible();

--- a/apps/electron-backend-e2e/src/settings.e2e.ts
+++ b/apps/electron-backend-e2e/src/settings.e2e.ts
@@ -247,10 +247,15 @@ test.describe('Electron Settings', () => {
                     exact: true,
                 })
             ).toHaveCount(0);
-            await expect(secondLaunch.mainWindow.locator('a.brand')).toHaveAttribute(
-                'href',
-                /\/workspace\/sources$/
-            );
+            await expect(
+                secondLaunch.mainWindow.getByRole('link', {
+                    name: 'Sources',
+                    exact: true,
+                })
+            ).toHaveClass(/is-active/);
+            await expect(
+                secondLaunch.mainWindow.locator('button.brand')
+            ).toBeVisible();
         } finally {
             await closeElectronApp(secondLaunch);
         }

--- a/apps/web/src/assets/i18n/ar.json
+++ b/apps/web/src/assets/i18n/ar.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "توسيع التنقل",
+            "COLLAPSE_NAVIGATION": "طي التنقل",
             "RAIL_DASHBOARD": "لوحة التحكم",
             "OPEN_DASHBOARD": "فتح لوحة التحكم",
             "RAIL_SOURCES": "المصادر",

--- a/apps/web/src/assets/i18n/ar.json
+++ b/apps/web/src/assets/i18n/ar.json
@@ -913,8 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
-            "EXPAND_NAVIGATION": "توسيع التنقل",
-            "COLLAPSE_NAVIGATION": "طي التنقل",
+            "EXPAND_NAVIGATION": "إظهار القائمة",
+            "COLLAPSE_NAVIGATION": "إخفاء القائمة",
             "RAIL_DASHBOARD": "لوحة التحكم",
             "OPEN_DASHBOARD": "فتح لوحة التحكم",
             "RAIL_SOURCES": "المصادر",

--- a/apps/web/src/assets/i18n/ary.json
+++ b/apps/web/src/assets/i18n/ary.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "وسّع التنقل",
+            "COLLAPSE_NAVIGATION": "طوي التنقل",
             "RAIL_DASHBOARD": "لوحة التحكم",
             "OPEN_DASHBOARD": "حل لوحة التحكم",
             "RAIL_SOURCES": "المصادر",

--- a/apps/web/src/assets/i18n/by.json
+++ b/apps/web/src/assets/i18n/by.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Разгарнуць навігацыю",
+            "COLLAPSE_NAVIGATION": "Згарнуць навігацыю",
             "RAIL_DASHBOARD": "Панэль",
             "OPEN_DASHBOARD": "Адкрыць панэль",
             "RAIL_SOURCES": "Крыніцы",

--- a/apps/web/src/assets/i18n/de.json
+++ b/apps/web/src/assets/i18n/de.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Navigation ausklappen",
+            "COLLAPSE_NAVIGATION": "Navigation einklappen",
             "RAIL_DASHBOARD": "Dashboard",
             "OPEN_DASHBOARD": "Dashboard öffnen",
             "RAIL_SOURCES": "Quellen",

--- a/apps/web/src/assets/i18n/el.json
+++ b/apps/web/src/assets/i18n/el.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Ανάπτυξη πλοήγησης",
+            "COLLAPSE_NAVIGATION": "Σύμπτυξη πλοήγησης",
             "RAIL_DASHBOARD": "Πίνακας ελέγχου",
             "OPEN_DASHBOARD": "Άνοιγμα πίνακα ελέγχου",
             "RAIL_SOURCES": "Πηγές",

--- a/apps/web/src/assets/i18n/en.json
+++ b/apps/web/src/assets/i18n/en.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Expand navigation",
+            "COLLAPSE_NAVIGATION": "Collapse navigation",
             "RAIL_DASHBOARD": "Dashboard",
             "OPEN_DASHBOARD": "Open dashboard",
             "RAIL_SOURCES": "Sources",

--- a/apps/web/src/assets/i18n/es.json
+++ b/apps/web/src/assets/i18n/es.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Ampliar navegación",
+            "COLLAPSE_NAVIGATION": "Contraer navegación",
             "RAIL_DASHBOARD": "Panel",
             "OPEN_DASHBOARD": "Abrir panel",
             "RAIL_SOURCES": "Fuentes",

--- a/apps/web/src/assets/i18n/fr.json
+++ b/apps/web/src/assets/i18n/fr.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Développer la navigation",
+            "COLLAPSE_NAVIGATION": "Réduire la navigation",
             "RAIL_DASHBOARD": "Tableau de bord",
             "OPEN_DASHBOARD": "Ouvrir le tableau de bord",
             "RAIL_SOURCES": "Sources",

--- a/apps/web/src/assets/i18n/it.json
+++ b/apps/web/src/assets/i18n/it.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Espandi navigazione",
+            "COLLAPSE_NAVIGATION": "Comprimi navigazione",
             "RAIL_DASHBOARD": "Dashboard",
             "OPEN_DASHBOARD": "Apri dashboard",
             "RAIL_SOURCES": "Sorgenti",

--- a/apps/web/src/assets/i18n/ja.json
+++ b/apps/web/src/assets/i18n/ja.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "ナビゲーションを展開",
+            "COLLAPSE_NAVIGATION": "ナビゲーションを折りたたむ",
             "RAIL_DASHBOARD": "ダッシュボード",
             "OPEN_DASHBOARD": "ダッシュボードを開く",
             "RAIL_SOURCES": "ソース",

--- a/apps/web/src/assets/i18n/ko.json
+++ b/apps/web/src/assets/i18n/ko.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "탐색 펼치기",
+            "COLLAPSE_NAVIGATION": "탐색 접기",
             "RAIL_DASHBOARD": "대시보드",
             "OPEN_DASHBOARD": "대시보드 열기",
             "RAIL_SOURCES": "소스",

--- a/apps/web/src/assets/i18n/nl.json
+++ b/apps/web/src/assets/i18n/nl.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Navigatie uitklappen",
+            "COLLAPSE_NAVIGATION": "Navigatie inklappen",
             "RAIL_DASHBOARD": "Dashboard",
             "OPEN_DASHBOARD": "Open dashboard",
             "RAIL_SOURCES": "Bronnen",

--- a/apps/web/src/assets/i18n/pl.json
+++ b/apps/web/src/assets/i18n/pl.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Rozwiń nawigację",
+            "COLLAPSE_NAVIGATION": "Zwiń nawigację",
             "RAIL_DASHBOARD": "Pulpit",
             "OPEN_DASHBOARD": "Otwórz pulpit",
             "RAIL_SOURCES": "Źródła",

--- a/apps/web/src/assets/i18n/pt.json
+++ b/apps/web/src/assets/i18n/pt.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Expandir navegação",
+            "COLLAPSE_NAVIGATION": "Recolher navegação",
             "RAIL_DASHBOARD": "Dashboard",
             "OPEN_DASHBOARD": "Abrir dashboard",
             "RAIL_SOURCES": "Fontes",

--- a/apps/web/src/assets/i18n/ru.json
+++ b/apps/web/src/assets/i18n/ru.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Развернуть навигацию",
+            "COLLAPSE_NAVIGATION": "Свернуть навигацию",
             "RAIL_DASHBOARD": "Панель",
             "OPEN_DASHBOARD": "Открыть панель",
             "RAIL_SOURCES": "Источники",

--- a/apps/web/src/assets/i18n/tr.json
+++ b/apps/web/src/assets/i18n/tr.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "Gezinmeyi genişlet",
+            "COLLAPSE_NAVIGATION": "Gezinmeyi daralt",
             "RAIL_DASHBOARD": "Pano",
             "OPEN_DASHBOARD": "Panoyu aç",
             "RAIL_SOURCES": "Kaynaklar",

--- a/apps/web/src/assets/i18n/zh.json
+++ b/apps/web/src/assets/i18n/zh.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "展开导航",
+            "COLLAPSE_NAVIGATION": "收起导航",
             "RAIL_DASHBOARD": "仪表盘",
             "OPEN_DASHBOARD": "打开仪表盘",
             "RAIL_SOURCES": "源",

--- a/apps/web/src/assets/i18n/zhtw.json
+++ b/apps/web/src/assets/i18n/zhtw.json
@@ -913,6 +913,8 @@
         },
         "SHELL": {
             "BRAND_ALT": "IPTVnator",
+            "EXPAND_NAVIGATION": "展開導覽",
+            "COLLAPSE_NAVIGATION": "收合導覽",
             "RAIL_DASHBOARD": "儀表板",
             "OPEN_DASHBOARD": "開啟儀表板",
             "RAIL_SOURCES": "來源",

--- a/docs/architecture/workspace-shell.md
+++ b/docs/architecture/workspace-shell.md
@@ -153,6 +153,17 @@ Rail navigation is also shell-owned:
 3. On dashboard, sources, settings, and global favorites, the shell falls back
    to the currently selected playlist so provider navigation remains available
    even outside a provider route.
+4. The IPTVnator brand button toggles the primary rail between its default
+   60px icon-only layout and an expanded, label-bearing layout. The expanded
+   width is content-driven by the longest visible label with equal horizontal
+   spacing around icons and text, capped to preserve the content area. Mobile
+   navigation remains compact and does not enter the expanded state.
+5. Active-link markers must stay inset within the rail so selection styling is
+   not clipped by the rail's overflow boundary.
+6. The navigation links own the rail's scroll area while the settings shortcut
+   remains visible in the fixed footer.
+7. Expanded labels use automatic text direction and logical start alignment so
+   left-to-right and right-to-left translations align naturally.
 
 Command palette behavior is shell-owned but view-extensible:
 

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.html
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.html
@@ -1,4 +1,4 @@
-<nav class="rail-links">
+<nav class="rail-links" [class.is-expanded]="expanded()">
     @for (link of links(); track link.path.join('/')) {
         <a
             class="portal-rail-link nav-item"
@@ -6,15 +6,19 @@
             [routerLinkActive]="activeClass()"
             [routerLinkActiveOptions]="{ exact: link.exact ?? false }"
             [matTooltip]="link.tooltip"
+            [matTooltipDisabled]="expanded()"
             [matTooltipPosition]="'right'"
             [attr.aria-label]="link.tooltip"
             [attr.aria-current]="isActive(link) ? 'page' : null"
             [class.active]="activeClass() === 'active' && isActive(link)"
-            [class.is-active]="
-                activeClass() === 'is-active' && isActive(link)
-            "
+            [class.is-active]="activeClass() === 'is-active' && isActive(link)"
         >
             <mat-icon>{{ resolveIcon(link) }}</mat-icon>
+            @if (expanded()) {
+                <span class="portal-rail-link-label" dir="auto">
+                    {{ link.tooltip }}
+                </span>
+            }
         </a>
     }
 </nav>

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.scss
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.scss
@@ -12,9 +12,21 @@
     width: 100%;
 }
 
+.rail-links.is-expanded {
+    align-items: stretch;
+
+    .portal-rail-link {
+        width: 100%;
+        justify-content: flex-start;
+        gap: 12px;
+        padding: 0 12px;
+    }
+}
+
 .portal-rail-link {
     width: 44px;
     height: 44px;
+    box-sizing: border-box;
     padding: 0;
     gap: 0;
     border-radius: 14px;
@@ -34,10 +46,7 @@
 
     &:hover {
         color: var(--rail-link-hover-color, var(--mat-sys-on-surface));
-        background: var(
-            --rail-link-hover-bg,
-            var(--mat-sys-surface-container)
-        );
+        background: var(--rail-link-hover-bg, var(--mat-sys-surface-container));
     }
 
     mat-icon {
@@ -45,6 +54,17 @@
         width: 20px;
         height: 20px;
     }
+}
+
+.portal-rail-link-label {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: start;
+    white-space: nowrap;
+    font-size: 14px;
+    font-weight: 500;
 }
 
 @for $i from 1 through 8 {
@@ -88,7 +108,7 @@
 .portal-rail-link.active::after {
     content: '';
     position: absolute;
-    right: -4px;
+    right: 3px;
     top: 50%;
     transform: translateY(-50%);
     width: 4px;
@@ -96,4 +116,26 @@
     border-radius: 999px;
     background: var(--rail-link-active-icon, var(--app-selection-color));
     box-shadow: 0 0 10px var(--rail-link-active-glow, var(--app-selection-glow));
+}
+
+@media (max-width: 640px) {
+    :host {
+        flex: 0 0 auto;
+        width: auto;
+    }
+
+    .rail-links {
+        flex-direction: row;
+    }
+
+    .rail-links.is-expanded .portal-rail-link {
+        width: 44px;
+        justify-content: center;
+        gap: 0;
+        padding: 0;
+    }
+
+    .portal-rail-link-label {
+        display: none;
+    }
 }

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.spec.ts
@@ -46,6 +46,11 @@ describe('WorkspaceShellRailLinksComponent', () => {
         expect(labels).toEqual(['Dashboard', 'Movies']);
         expect(
             fixture.nativeElement
+                .querySelector('.portal-rail-link-label')
+                ?.getAttribute('dir')
+        ).toBe('auto');
+        expect(
+            fixture.nativeElement
                 .querySelector('.rail-links')
                 ?.classList.contains('is-expanded')
         ).toBe(true);

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { WorkspaceShellRailLinksComponent } from './workspace-shell-rail-links.component';
+
+describe('WorkspaceShellRailLinksComponent', () => {
+    let fixture: ComponentFixture<WorkspaceShellRailLinksComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [WorkspaceShellRailLinksComponent],
+            providers: [provideRouter([])],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(WorkspaceShellRailLinksComponent);
+        fixture.componentRef.setInput('links', [
+            {
+                icon: 'dashboard',
+                tooltip: 'Dashboard',
+                path: ['/workspace/dashboard'],
+                exact: true,
+            },
+            {
+                icon: 'movie',
+                tooltip: 'Movies',
+                path: ['/workspace/movies'],
+            },
+        ]);
+    });
+
+    it('keeps labels hidden in the compact rail', () => {
+        fixture.detectChanges();
+
+        expect(
+            fixture.nativeElement.querySelectorAll('.portal-rail-link-label')
+        ).toHaveLength(0);
+    });
+
+    it('renders every navigation label in the expanded rail', () => {
+        fixture.componentRef.setInput('expanded', true);
+        fixture.detectChanges();
+
+        const labels = Array.from(
+            fixture.nativeElement.querySelectorAll('.portal-rail-link-label')
+        ).map((element: Element) => element.textContent?.trim());
+
+        expect(labels).toEqual(['Dashboard', 'Movies']);
+        expect(
+            fixture.nativeElement
+                .querySelector('.rail-links')
+                ?.classList.contains('is-expanded')
+        ).toBe(true);
+    });
+});

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail-links/workspace-shell-rail-links.component.ts
@@ -1,4 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    inject,
+    input,
+} from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 import {
@@ -27,9 +32,12 @@ export class WorkspaceShellRailLinksComponent {
         PortalRailSection | string | null | undefined
     >(null);
     readonly activeClass = input<'active' | 'is-active'>('is-active');
+    readonly expanded = input(false);
 
     resolveIcon(link: PortalRailLink): string {
-        const normalizedPath = link.path.map((segment) => String(segment)).join('/');
+        const normalizedPath = link.path
+            .map((segment) => String(segment))
+            .join('/');
         if (normalizedPath.includes('/workspace/sources')) {
             return 'playlist_play';
         }

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.html
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.html
@@ -1,40 +1,69 @@
-<aside class="app-rail" [class.is-macos]="isMacOS()">
-    <a
+<aside
+    id="workspace-primary-navigation"
+    class="app-rail"
+    [class.is-macos]="isMacOS()"
+    [class.is-expanded]="expanded()"
+>
+    <button
+        type="button"
         class="brand"
-        [routerLink]="brandLink()"
-        [matTooltip]="brandTooltipKey() | translate"
+        (click)="toggleExpanded()"
+        [disabled]="isCompact()"
+        [matTooltip]="
+            (expanded()
+                ? 'WORKSPACE.SHELL.COLLAPSE_NAVIGATION'
+                : 'WORKSPACE.SHELL.EXPAND_NAVIGATION'
+            ) | translate
+        "
+        [matTooltipDisabled]="expanded() || isCompact()"
         [matTooltipPosition]="'right'"
-        [attr.aria-label]="brandAriaLabelKey() | translate"
+        [attr.aria-controls]="'workspace-primary-navigation'"
+        [attr.aria-expanded]="isCompact() ? null : expanded()"
+        [attr.aria-label]="
+            isCompact()
+                ? null
+                : ((expanded()
+                      ? 'WORKSPACE.SHELL.COLLAPSE_NAVIGATION'
+                      : 'WORKSPACE.SHELL.EXPAND_NAVIGATION'
+                  ) | translate)
+        "
     >
         <img
             src="./assets/icons/icon-tv-256.png"
             [attr.alt]="'WORKSPACE.SHELL.BRAND_ALT' | translate"
         />
-    </a>
+        @if (expanded()) {
+            <span class="brand-label" dir="auto">IPTVnator</span>
+        }
+    </button>
 
-    <app-workspace-shell-rail-links [links]="workspaceLinks()" />
+    <div class="rail-navigation">
+        <app-workspace-shell-rail-links
+            [expanded]="expanded()"
+            [links]="workspaceLinks()"
+        />
 
-    @if (primaryContextLinks().length > 0) {
-        <div
-            class="rail-context-region"
-            [class]="railProviderClass()"
-        >
-            <app-workspace-shell-rail-links
-                activeClass="is-active"
-                [selectedSection]="selectedSection()"
-                [links]="primaryContextLinks()"
-            />
-
-            @if (secondaryContextLinks().length > 0) {
-                <div class="rail-divider"></div>
+        @if (primaryContextLinks().length > 0) {
+            <div class="rail-context-region" [class]="railProviderClass()">
                 <app-workspace-shell-rail-links
                     activeClass="is-active"
+                    [expanded]="expanded()"
                     [selectedSection]="selectedSection()"
-                    [links]="secondaryContextLinks()"
+                    [links]="primaryContextLinks()"
                 />
-            }
-        </div>
-    }
+
+                @if (secondaryContextLinks().length > 0) {
+                    <div class="rail-divider"></div>
+                    <app-workspace-shell-rail-links
+                        activeClass="is-active"
+                        [expanded]="expanded()"
+                        [selectedSection]="selectedSection()"
+                        [links]="secondaryContextLinks()"
+                    />
+                }
+            </div>
+        }
+    </div>
 
     <div class="rail-footer">
         <a
@@ -42,10 +71,16 @@
             routerLink="/workspace/settings"
             [class.is-active]="isSettingsRoute()"
             [matTooltip]="'WORKSPACE.SHELL.RAIL_SETTINGS' | translate"
+            [matTooltipDisabled]="expanded()"
             [matTooltipPosition]="'right'"
             [attr.aria-label]="'WORKSPACE.SHELL.OPEN_SETTINGS' | translate"
         >
             <mat-icon>settings</mat-icon>
+            @if (expanded()) {
+                <span class="rail-shortcut-label" dir="auto">
+                    {{ 'WORKSPACE.SHELL.RAIL_SETTINGS' | translate }}
+                </span>
+            }
         </a>
     </div>
 </aside>

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.scss
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.scss
@@ -1,7 +1,14 @@
 :host {
     display: block;
+    width: 60px;
     min-width: 0;
     min-height: 0;
+    --workspace-rail-expanded-max-width: min(320px, 40vw);
+}
+
+:host.rail-expanded {
+    width: max-content;
+    max-width: var(--workspace-rail-expanded-max-width);
 }
 
 .app-rail {
@@ -16,10 +23,14 @@
         var(--app-rail-border, var(--mat-sys-outline-variant));
     background: var(--app-rail-bg, var(--mat-sys-surface-container-low));
     app-region: drag;
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow: hidden;
     scrollbar-width: none;
-    --rail-link-color: color-mix(in srgb, var(--app-on-surface) 65%, transparent);
+    width: 60px;
+    --rail-link-color: color-mix(
+        in srgb,
+        var(--app-on-surface) 65%,
+        transparent
+    );
     --rail-link-hover-color: var(--app-on-surface);
     --rail-link-hover-bg: var(--app-hover-overlay);
     --rail-link-active-bg: var(--app-selection-surface);
@@ -33,14 +44,44 @@
         padding-top: 36px;
     }
 
+    &.is-expanded {
+        width: max-content;
+        max-width: var(--workspace-rail-expanded-max-width);
+        align-items: stretch;
+
+        .rail-context-region {
+            align-items: stretch;
+            max-width: none;
+        }
+    }
+
     &::-webkit-scrollbar {
         display: none;
     }
 }
 
-.app-rail a {
+.rail-navigation {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+}
+
+.app-rail a,
+.app-rail button {
     width: 44px;
     height: 44px;
+    box-sizing: border-box;
     border-radius: 14px;
     position: relative;
     display: inline-flex;
@@ -54,6 +95,7 @@
         box-shadow 0.2s ease,
         transform 0.2s ease;
     app-region: no-drag;
+    font: inherit;
 
     mat-icon {
         font-size: 20px;
@@ -62,7 +104,8 @@
     }
 }
 
-.app-rail a:hover {
+.app-rail a:hover,
+.app-rail button:hover {
     color: var(--rail-link-hover-color);
     background: var(--rail-link-hover-bg);
 }
@@ -87,7 +130,7 @@
     &::after {
         content: '';
         position: absolute;
-        right: -4px;
+        right: 3px;
         top: 50%;
         transform: translateY(-50%);
         width: 3px;
@@ -100,6 +143,8 @@
 
 .brand {
     margin-bottom: 10px;
+    padding: 0;
+    border: 0;
     background: var(--mat-sys-primary-container);
     color: var(--mat-sys-on-primary-container);
     width: 40px;
@@ -108,12 +153,37 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    cursor: pointer;
+
+    &:disabled {
+        opacity: 1;
+        cursor: default;
+    }
+}
+
+.app-rail.is-expanded .brand {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 12px;
+    padding: 0 12px;
 }
 
 .brand img {
     width: 24px;
     height: 24px;
     object-fit: contain;
+}
+
+.brand-label,
+.rail-shortcut-label {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: start;
+    white-space: nowrap;
+    font-size: 14px;
+    font-weight: 600;
 }
 
 .rail-context-region {
@@ -183,7 +253,7 @@
 }
 
 .rail-footer {
-    margin-top: auto;
+    flex: 0 0 auto;
 
     .rail-shortcut {
         width: 44px;
@@ -212,7 +282,7 @@
         &.is-active::after {
             content: '';
             position: absolute;
-            right: -4px;
+            right: 3px;
             top: 50%;
             transform: translateY(-50%);
             width: 4px;
@@ -224,8 +294,21 @@
     }
 }
 
+.app-rail.is-expanded .rail-footer .rail-shortcut {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 12px;
+    padding: 0 12px;
+}
+
 @media (max-width: 640px) {
+    :host {
+        width: 100%;
+    }
+
     .app-rail {
+        width: 100%;
+        min-width: 0;
         flex-direction: row;
         justify-content: space-between;
         padding: 6px 10px;
@@ -235,6 +318,30 @@
         .brand {
             margin-bottom: 0;
         }
+
+        &.is-expanded {
+            align-items: center;
+
+            .brand,
+            .rail-footer .rail-shortcut {
+                width: 44px;
+                justify-content: center;
+                padding: 0;
+            }
+
+            .brand-label,
+            .rail-shortcut-label {
+                display: none;
+            }
+        }
+    }
+
+    .rail-navigation {
+        flex-direction: row;
+        align-items: center;
+        width: auto;
+        overflow-x: auto;
+        overflow-y: hidden;
     }
 
     .rail-divider {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.spec.ts
@@ -1,5 +1,6 @@
 import { Component, input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 import { provideRouter } from '@angular/router';
@@ -18,6 +19,7 @@ class MockWorkspaceShellRailLinksComponent {
     readonly links = input<unknown[]>([]);
     readonly selectedSection = input<string | null>(null);
     readonly activeClass = input('active');
+    readonly expanded = input(false);
 }
 
 describe('WorkspaceShellRailComponent', () => {
@@ -60,11 +62,6 @@ describe('WorkspaceShellRailComponent', () => {
     });
 
     it('renders provider context region and active settings shortcut state', () => {
-        fixture.componentRef.setInput('brandLink', '/workspace/sources');
-        fixture.componentRef.setInput(
-            'brandAriaLabelKey',
-            'WORKSPACE.SHELL.OPEN_SOURCES'
-        );
         fixture.componentRef.setInput('primaryContextLinks', [
             {
                 icon: 'movie',
@@ -86,15 +83,40 @@ describe('WorkspaceShellRailComponent', () => {
         expect(
             fixture.nativeElement.querySelector('.rail-shortcut.is-active')
         ).not.toBeNull();
+    });
+
+    it('uses the brand control to toggle the rail instead of navigating', () => {
+        fixture.detectChanges();
+
+        const brand = fixture.debugElement.query(By.css('.brand'));
+
+        expect(brand.nativeElement.tagName).toBe('BUTTON');
+        expect(brand.nativeElement.getAttribute('href')).toBeNull();
+        expect(brand.nativeElement.getAttribute('aria-expanded')).toBe('false');
+
+        brand.triggerEventHandler('click');
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.expanded()).toBe(true);
+        expect(brand.nativeElement.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('shows the application and navigation labels while expanded', () => {
+        fixture.componentRef.setInput('expanded', true);
+        fixture.detectChanges();
+
+        expect(
+            fixture.nativeElement.querySelector('.brand-label')?.textContent
+        ).toContain('IPTVnator');
         expect(
             fixture.nativeElement
-                .querySelector('.brand')
-                ?.getAttribute('href')
-        ).toContain('/workspace/sources');
+                .querySelector('.rail-shortcut-label')
+                ?.textContent.trim()
+        ).toBe('WORKSPACE.SHELL.RAIL_SETTINGS');
         expect(
             fixture.nativeElement
-                .querySelector('.brand')
-                ?.getAttribute('aria-label')
-        ).toBe('WORKSPACE.SHELL.OPEN_SOURCES');
+                .querySelector('.app-rail')
+                ?.classList.contains('is-expanded')
+        ).toBe(true);
     });
 });

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.spec.ts
@@ -83,6 +83,9 @@ describe('WorkspaceShellRailComponent', () => {
         expect(
             fixture.nativeElement.querySelector('.rail-shortcut.is-active')
         ).not.toBeNull();
+        expect(
+            fixture.nativeElement.querySelector('.rail-navigation')
+        ).not.toBeNull();
     });
 
     it('uses the brand control to toggle the rail instead of navigating', () => {
@@ -101,6 +104,92 @@ describe('WorkspaceShellRailComponent', () => {
         expect(brand.nativeElement.getAttribute('aria-expanded')).toBe('true');
     });
 
+    it('keeps the horizontal mobile navigation compact', () => {
+        const originalMatchMedia = Object.getOwnPropertyDescriptor(
+            window,
+            'matchMedia'
+        );
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            value: jest.fn().mockReturnValue({ matches: true }),
+        });
+
+        try {
+            fixture.destroy();
+            fixture = TestBed.createComponent(WorkspaceShellRailComponent);
+            fixture.detectChanges();
+
+            const brand = fixture.debugElement.query(By.css('.brand'));
+            brand.triggerEventHandler('click');
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.expanded()).toBe(false);
+            expect(brand.nativeElement.disabled).toBe(true);
+            expect(
+                brand.nativeElement.getAttribute('aria-expanded')
+            ).toBeNull();
+            expect(brand.nativeElement.getAttribute('aria-label')).toBeNull();
+            expect(brand.injector.get(MatTooltip).disabled).toBe(true);
+        } finally {
+            if (originalMatchMedia) {
+                Object.defineProperty(window, 'matchMedia', originalMatchMedia);
+            } else {
+                Reflect.deleteProperty(window, 'matchMedia');
+            }
+        }
+    });
+
+    it('closes an expanded rail when the viewport becomes compact', () => {
+        let mediaListener: ((event: { matches: boolean }) => void) | undefined;
+        const removeEventListener = jest.fn();
+        const originalMatchMedia = Object.getOwnPropertyDescriptor(
+            window,
+            'matchMedia'
+        );
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            value: jest.fn().mockReturnValue({
+                matches: false,
+                addEventListener: (
+                    _type: string,
+                    listener: (event: { matches: boolean }) => void
+                ) => {
+                    mediaListener = listener;
+                },
+                removeEventListener,
+            }),
+        });
+
+        try {
+            fixture.destroy();
+            fixture = TestBed.createComponent(WorkspaceShellRailComponent);
+            fixture.componentRef.setInput('expanded', true);
+            fixture.detectChanges();
+
+            mediaListener?.({ matches: true });
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.expanded()).toBe(false);
+            expect(
+                fixture.nativeElement
+                    .querySelector('.brand')
+                    ?.getAttribute('aria-expanded')
+            ).toBeNull();
+
+            fixture.destroy();
+            expect(removeEventListener).toHaveBeenCalledWith(
+                'change',
+                mediaListener
+            );
+        } finally {
+            if (originalMatchMedia) {
+                Object.defineProperty(window, 'matchMedia', originalMatchMedia);
+            } else {
+                Reflect.deleteProperty(window, 'matchMedia');
+            }
+        }
+    });
+
     it('shows the application and navigation labels while expanded', () => {
         fixture.componentRef.setInput('expanded', true);
         fixture.detectChanges();
@@ -113,6 +202,11 @@ describe('WorkspaceShellRailComponent', () => {
                 .querySelector('.rail-shortcut-label')
                 ?.textContent.trim()
         ).toBe('WORKSPACE.SHELL.RAIL_SETTINGS');
+        expect(
+            fixture.nativeElement
+                .querySelector('.rail-shortcut-label')
+                ?.getAttribute('dir')
+        ).toBe('auto');
         expect(
             fixture.nativeElement
                 .querySelector('.app-rail')

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/components/workspace-shell-rail/workspace-shell-rail.component.ts
@@ -1,8 +1,13 @@
 import {
     ChangeDetectionStrategy,
     Component,
+    DestroyRef,
+    inject,
     input,
+    model,
+    signal,
 } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
@@ -15,6 +20,9 @@ import { WorkspaceShellRailLinksComponent } from '../workspace-shell-rail-links/
 
 @Component({
     selector: 'app-workspace-shell-rail',
+    host: {
+        '[class.rail-expanded]': 'expanded()',
+    },
     imports: [
         MatIcon,
         MatTooltip,
@@ -27,10 +35,14 @@ import { WorkspaceShellRailLinksComponent } from '../workspace-shell-rail-links/
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WorkspaceShellRailComponent {
+    private readonly document = inject(DOCUMENT);
+    private readonly destroyRef = inject(DestroyRef);
+    private readonly compactMediaQuery =
+        this.document.defaultView?.matchMedia?.('(max-width: 640px)') ?? null;
+
     readonly isMacOS = input(false);
-    readonly brandLink = input('/workspace/dashboard');
-    readonly brandTooltipKey = input('WORKSPACE.SHELL.RAIL_DASHBOARD');
-    readonly brandAriaLabelKey = input('WORKSPACE.SHELL.OPEN_DASHBOARD');
+    readonly expanded = model(false);
+    readonly isCompact = signal(this.compactMediaQuery?.matches ?? false);
     readonly workspaceLinks = input<PortalRailLink[]>([]);
     readonly primaryContextLinks = input<PortalRailLink[]>([]);
     readonly secondaryContextLinks = input<PortalRailLink[]>([]);
@@ -39,4 +51,33 @@ export class WorkspaceShellRailComponent {
     >(null);
     readonly railProviderClass = input('rail-context-region');
     readonly isSettingsRoute = input(false);
+
+    constructor() {
+        const mediaQuery = this.compactMediaQuery;
+        if (!mediaQuery) {
+            return;
+        }
+
+        const updateCompactState = (matches: boolean): void => {
+            this.isCompact.set(matches);
+            if (matches) {
+                this.expanded.set(false);
+            }
+        };
+        const onMediaChange = (event: MediaQueryListEvent): void =>
+            updateCompactState(event.matches);
+
+        mediaQuery.addEventListener?.('change', onMediaChange);
+        this.destroyRef.onDestroy(() =>
+            mediaQuery.removeEventListener?.('change', onMediaChange)
+        );
+    }
+
+    toggleExpanded(): void {
+        if (this.isCompact()) {
+            return;
+        }
+
+        this.expanded.update((expanded) => !expanded);
+    }
 }

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-route-state.service.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-route-state.service.ts
@@ -1,4 +1,10 @@
-import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
+import {
+    computed,
+    DestroyRef,
+    inject,
+    Injectable,
+    signal,
+} from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
@@ -48,21 +54,6 @@ export class WorkspaceShellRouteStateService {
     readonly currentSection = computed(() => this.currentRoute().section);
     readonly showDashboard = computed(() =>
         this.startupPreferences.showDashboard()
-    );
-    readonly brandLink = computed(() =>
-        this.startupPreferences.getFirstAvailableWorkspacePath(
-            this.showDashboard()
-        )
-    );
-    readonly brandTooltipKey = computed(() =>
-        this.showDashboard()
-            ? 'WORKSPACE.SHELL.RAIL_DASHBOARD'
-            : 'WORKSPACE.SHELL.RAIL_SOURCES'
-    );
-    readonly brandAriaLabelKey = computed(() =>
-        this.showDashboard()
-            ? 'WORKSPACE.SHELL.OPEN_DASHBOARD'
-            : 'WORKSPACE.SHELL.OPEN_SOURCES'
     );
     readonly workspaceLinks = computed<PortalRailLink[]>(() => {
         this.languageTick();

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.spec.ts
@@ -666,7 +666,6 @@ describe('WorkspaceShellFacade', () => {
                 exact: true,
             },
         ]);
-        expect(facade.brandLink()).toBe('/workspace/sources');
     });
 
     it('persists the last restorable route from navigation events', () => {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell.facade.ts
@@ -67,9 +67,6 @@ export class WorkspaceShellFacade {
     readonly currentUrl = this.routeState.currentUrl;
     readonly currentRoute = this.routeState.currentRoute;
     readonly showDashboard = this.routeState.showDashboard;
-    readonly brandLink = this.routeState.brandLink;
-    readonly brandTooltipKey = this.routeState.brandTooltipKey;
-    readonly brandAriaLabelKey = this.routeState.brandAriaLabelKey;
     readonly currentContext = this.routeState.currentContext;
     readonly currentSection = this.routeState.currentSection;
     readonly commandPaletteCommands = computed<WorkspaceResolvedCommandItem[]>(

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.html
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.html
@@ -1,5 +1,6 @@
 <div
     class="workspace-shell"
+    [class.rail-expanded]="railExpanded()"
     appPlaylistDropZone
     #dropZone="playlistDropZone"
 >
@@ -10,15 +11,14 @@
 
     <app-workspace-shell-rail
         [isMacOS]="facade.isMacOS"
-        [brandLink]="facade.brandLink()"
-        [brandTooltipKey]="facade.brandTooltipKey()"
-        [brandAriaLabelKey]="facade.brandAriaLabelKey()"
+        [expanded]="railExpanded()"
         [workspaceLinks]="facade.workspaceLinks()"
         [primaryContextLinks]="facade.primaryContextLinks()"
         [secondaryContextLinks]="facade.secondaryContextLinks()"
         [selectedSection]="facade.currentSection()"
         [railProviderClass]="facade.railProviderClass()"
         [isSettingsRoute]="facade.isSettingsRoute()"
+        (expandedChange)="railExpanded.set($event)"
     />
 
     <app-workspace-shell-header
@@ -53,7 +53,10 @@
         (accountInfoRequested)="facade.openAccountInfo()"
     />
 
-    <div class="workspace-body" [class.single-pane]="!facade.showContextPanel()">
+    <div
+        class="workspace-body"
+        [class.single-pane]="!facade.showContextPanel()"
+    >
         @if (facade.showContextPanel()) {
             <app-workspace-shell-context-sidebar
                 [variant]="facade.contextPanel()"

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.scss
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.scss
@@ -17,6 +17,10 @@
     color: var(--mat-sys-on-surface);
 }
 
+.workspace-shell.rail-expanded {
+    grid-template-columns: max-content minmax(0, 1fr);
+}
+
 app-workspace-shell-rail {
     grid-column: 1;
     grid-row: 1 / span 3;
@@ -65,7 +69,6 @@ app-workspace-shell-context-sidebar {
     box-shadow: -4px 8px 20px var(--app-content-shadow, rgba(0, 0, 0, 0.18));
 }
 
-
 @media (max-width: 780px) {
     .workspace-shell {
         grid-template-columns: 56px 1fr;
@@ -77,6 +80,10 @@ app-workspace-shell-context-sidebar {
     .workspace-shell {
         grid-template-columns: 1fr;
         grid-template-rows: 52px 56px minmax(0, 1fr) auto;
+    }
+
+    .workspace-shell.rail-expanded {
+        grid-template-columns: 1fr;
     }
 
     app-workspace-shell-rail {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.spec.ts
@@ -35,6 +35,8 @@ class MockWorkspaceShellRailComponent {
     readonly selectedSection = input<string | null>(null);
     readonly railProviderClass = input('');
     readonly isSettingsRoute = input(false);
+    readonly expanded = input(false);
+    readonly expandedChange = output<boolean>();
 }
 
 @Component({
@@ -250,6 +252,18 @@ describe('WorkspaceShellComponent', () => {
         expect(
             fixture.nativeElement.querySelector('app-external-playback-dock')
         ).not.toBeNull();
+
+        const rail = fixture.debugElement.query(
+            By.directive(MockWorkspaceShellRailComponent)
+        );
+        rail.componentInstance.expandedChange.emit(true);
+        fixture.detectChanges();
+
+        expect(
+            fixture.nativeElement
+                .querySelector('.workspace-shell')
+                ?.classList.contains('rail-expanded')
+        ).toBe(true);
     });
 
     it('renders the xtream import overlay child only when the facade flag is true', async () => {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.spec.ts
@@ -26,9 +26,6 @@ import { WorkspaceKeyboardShortcutsService } from '../workspace-keyboard-shortcu
 })
 class MockWorkspaceShellRailComponent {
     readonly isMacOS = input(false);
-    readonly brandLink = input('/workspace/dashboard');
-    readonly brandTooltipKey = input('WORKSPACE.SHELL.RAIL_DASHBOARD');
-    readonly brandAriaLabelKey = input('WORKSPACE.SHELL.OPEN_DASHBOARD');
     readonly workspaceLinks = input<unknown[]>([]);
     readonly primaryContextLinks = input<unknown[]>([]);
     readonly secondaryContextLinks = input<unknown[]>([]);
@@ -128,9 +125,6 @@ class MockWorkspaceKeyboardShortcutsService {
 }
 
 class MockWorkspaceShellFacade {
-    readonly brandLink = signal('/workspace/dashboard');
-    readonly brandTooltipKey = signal('WORKSPACE.SHELL.RAIL_DASHBOARD');
-    readonly brandAriaLabelKey = signal('WORKSPACE.SHELL.OPEN_DASHBOARD');
     readonly workspaceLinks = signal([]);
     readonly primaryContextLinks = signal([]);
     readonly secondaryContextLinks = signal([]);

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/workspace-shell.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { ExternalPlaybackDockComponent } from '@iptvnator/ui/components';
 import {
@@ -46,4 +46,5 @@ import { WorkspaceKeyboardShortcutsService } from '../workspace-keyboard-shortcu
 export class WorkspaceShellComponent {
     readonly facade = inject(WorkspaceShellFacade);
     readonly keyboardShortcuts = inject(WorkspaceKeyboardShortcutsService);
+    readonly railExpanded = signal(false);
 }


### PR DESCRIPTION
## Summary

Adds an expandable navigation rail to the workspace shell, split out of #1056 (workspace topic only).

- **New rail components** (`workspace-shell-rail`, `workspace-shell-rail-links`): a compact icon rail that expands to show labelled navigation, with workspace + primary/secondary context links.
- **Expand/collapse state**: a `railExpanded` signal on the shell drives a `.rail-expanded` class and the rail's `[expanded]` / `(expandedChange)` two-way binding.
- **Route-state service** (`workspace-shell-route-state.service`) and facade wiring for the rail's selected-section and provider styling.
- **i18n**: navigation labels added across all 18 locales, plus clarified Arabic (`ar`) navigation strings.
- Updates `docs/architecture/workspace-shell.md`.

## Tests

`workspace-shell-rail`, `workspace-shell-rail-links`, facade, and `workspace-shell.component` specs cover the compact↔expanded toggle and rail composition. Verified locally on top of `upstream/master`: affected `build` + `lint` clean; `workspace-shell-feature` tests 102/102 green.

## Context

Part of splitting the oversized #1056 into reviewable, topic-scoped PRs. Companion PRs: **#1069 casting controls** and **xtream IPC hardening**.
