### PR TITLE
fix(epg): decode compressed XMLTV responses

### DIFF
--- a/apps/electron-backend/src/app/workers/epg-parser.worker.ts
+++ b/apps/electron-backend/src/app/workers/epg-parser.worker.ts
@@ -6,10 +6,13 @@ import {
 } from '@iptvnator/shared/interfaces';
 import { Readable } from 'stream';
 import { parentPort, workerData } from 'worker_threads';
-import { createGunzip } from 'zlib';
 import { EpgDatabase, EpgDatabaseClearOperation } from './epg-database';
+import { createDecodedEpgStream } from './epg-stream-decoder';
 import { StreamingEpgParser } from './epg-streaming-parser';
-import { shouldGunzipEpgResponse } from './epg-response-utils';
+import {
+    getEpgResponseContentEncoding,
+    shouldGunzipEpgResponse,
+} from './epg-response-utils';
 import {
     isPrivateNetworkUrlAccessAllowed,
     UnsafeUrlError,
@@ -130,6 +133,9 @@ async function fetchAndParseEpgStreaming(
             headers: response.headers,
             url: responseUrl,
         });
+        const contentEncoding = getEpgResponseContentEncoding(
+            response.headers
+        );
 
         if (responseUrl && responseUrl !== url) {
             console.log(
@@ -142,6 +148,12 @@ async function fetchAndParseEpgStreaming(
             loggerLabel,
             `EPG response detected as gzipped: ${isGzipped}`
         );
+        if (contentEncoding) {
+            console.log(
+                loggerLabel,
+                `EPG response content-encoding: ${contentEncoding}`
+            );
+        }
 
         if (response.status < 200 || response.status >= 300) {
             throw new Error(`HTTP error! status: ${response.status}`);
@@ -175,18 +187,11 @@ async function fetchAndParseEpgStreaming(
         );
 
         return new Promise((resolve, reject) => {
-            let dataStream: Readable = response.data;
-
-            if (isGzipped) {
-                const gunzip = createGunzip();
-                dataStream = response.data.pipe(gunzip);
-
-                gunzip.on('error', (err) => {
-                    console.error(loggerLabel, 'Gunzip error:', err);
-                    epgDb.close();
-                    reject(err);
-                });
-            }
+            const dataStream = createDecodedEpgStream(
+                response.data,
+                response.headers,
+                isGzipped
+            );
 
             dataStream.on('data', (chunk: Buffer) => {
                 try {

--- a/apps/electron-backend/src/app/workers/epg-response-utils.spec.ts
+++ b/apps/electron-backend/src/app/workers/epg-response-utils.spec.ts
@@ -1,4 +1,7 @@
-import { shouldGunzipEpgResponse } from './epg-response-utils';
+import {
+    getEpgResponseContentEncoding,
+    shouldGunzipEpgResponse,
+} from './epg-response-utils';
 
 describe('shouldGunzipEpgResponse', () => {
     it('returns true for original .gz URLs', () => {
@@ -69,5 +72,39 @@ describe('shouldGunzipEpgResponse', () => {
                 url: 'https://example.com/guide.xml',
             })
         ).toBe(false);
+    });
+});
+
+describe('getEpgResponseContentEncoding', () => {
+    it('detects Brotli transfer encoding from response headers', () => {
+        expect(
+            getEpgResponseContentEncoding({
+                'content-encoding': 'br',
+            })
+        ).toBe('br');
+    });
+
+    it('detects gzip transfer encoding from response headers', () => {
+        expect(
+            getEpgResponseContentEncoding(
+                new Headers([['content-encoding', 'gzip']])
+            )
+        ).toBe('gzip');
+    });
+
+    it('detects deflate transfer encoding from response headers', () => {
+        expect(
+            getEpgResponseContentEncoding({
+                'Content-Encoding': 'deflate',
+            })
+        ).toBe('deflate');
+    });
+
+    it('ignores unsupported transfer encodings', () => {
+        expect(
+            getEpgResponseContentEncoding({
+                'content-encoding': 'zstd',
+            })
+        ).toBe(null);
     });
 });

--- a/apps/electron-backend/src/app/workers/epg-response-utils.spec.ts
+++ b/apps/electron-backend/src/app/workers/epg-response-utils.spec.ts
@@ -107,4 +107,12 @@ describe('getEpgResponseContentEncoding', () => {
             })
         ).toBe(null);
     });
+
+    it('returns the outermost supported transfer encoding first', () => {
+        expect(
+            getEpgResponseContentEncoding({
+                'content-encoding': 'gzip, br',
+            })
+        ).toBe('br');
+    });
 });

--- a/apps/electron-backend/src/app/workers/epg-response-utils.ts
+++ b/apps/electron-backend/src/app/workers/epg-response-utils.ts
@@ -6,6 +6,12 @@ export type HeaderReader =
 
 export type EpgResponseContentEncoding = 'br' | 'gzip' | 'deflate';
 
+const SUPPORTED_CONTENT_ENCODINGS: readonly EpgResponseContentEncoding[] = [
+    'br',
+    'gzip',
+    'deflate',
+];
+
 function getHeaderValue(headers: HeaderReader, name: string): string | null {
     const value =
         'get' in headers && typeof headers.get === 'function'
@@ -32,15 +38,26 @@ function hasGzipPath(url: string | null | undefined): boolean {
 export function getEpgResponseContentEncoding(
     headers: HeaderReader
 ): EpgResponseContentEncoding | null {
-    const contentEncoding = getHeaderValue(headers, 'content-encoding')
-        ?.toLowerCase()
-        .split(',')
-        .map((encoding) => encoding.trim())
-        .find((encoding): encoding is EpgResponseContentEncoding =>
-            ['br', 'gzip', 'deflate'].includes(encoding)
-        );
+    const contentEncoding = getEpgResponseContentEncodings(headers).at(0);
 
     return contentEncoding ?? null;
+}
+
+export function getEpgResponseContentEncodings(
+    headers: HeaderReader
+): EpgResponseContentEncoding[] {
+    return (
+        getHeaderValue(headers, 'content-encoding')
+            ?.toLowerCase()
+            .split(',')
+            .map((encoding) => encoding.trim())
+            .filter((encoding): encoding is EpgResponseContentEncoding =>
+                SUPPORTED_CONTENT_ENCODINGS.includes(
+                    encoding as EpgResponseContentEncoding
+                )
+            )
+            .reverse() ?? []
+    );
 }
 
 /**

--- a/apps/electron-backend/src/app/workers/epg-response-utils.ts
+++ b/apps/electron-backend/src/app/workers/epg-response-utils.ts
@@ -1,8 +1,10 @@
-type HeaderReader =
+export type HeaderReader =
     | Record<string, unknown>
     | {
           get(name: string): unknown;
       };
+
+export type EpgResponseContentEncoding = 'br' | 'gzip' | 'deflate';
 
 function getHeaderValue(headers: HeaderReader, name: string): string | null {
     const value =
@@ -25,6 +27,20 @@ function hasGzipPath(url: string | null | undefined): boolean {
     } catch {
         return url.toLowerCase().endsWith('.gz');
     }
+}
+
+export function getEpgResponseContentEncoding(
+    headers: HeaderReader
+): EpgResponseContentEncoding | null {
+    const contentEncoding = getHeaderValue(headers, 'content-encoding')
+        ?.toLowerCase()
+        .split(',')
+        .map((encoding) => encoding.trim())
+        .find((encoding): encoding is EpgResponseContentEncoding =>
+            ['br', 'gzip', 'deflate'].includes(encoding)
+        );
+
+    return contentEncoding ?? null;
 }
 
 /**

--- a/apps/electron-backend/src/app/workers/epg-stream-decoder.spec.ts
+++ b/apps/electron-backend/src/app/workers/epg-stream-decoder.spec.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { PassThrough, Readable } from 'stream';
 import { brotliCompressSync, gzipSync } from 'zlib';
 import { createDecodedEpgStream } from './epg-stream-decoder';
 import { StreamingEpgParser } from './epg-streaming-parser';
@@ -69,11 +69,26 @@ describe('createDecodedEpgStream', () => {
     });
 
     it('decodes gzip XML payloads after transfer decoding', async () => {
-        const transferEncodedPayload = gzipSync(gzipSync(xmltvFixture));
+        const transferEncodedPayload = brotliCompressSync(
+            gzipSync(xmltvFixture)
+        );
 
         const decodedText = await collectDecodedText(
             createDecodedEpgStream(
                 Readable.from([transferEncodedPayload]),
+                { 'content-encoding': 'br' },
+                true
+            )
+        );
+
+        expect(decodedText.startsWith('<?xml')).toBe(true);
+        expect(parseChannelCount(decodedText)).toBe(1);
+    });
+
+    it('does not double-gunzip mislabelled gzip XML payloads', async () => {
+        const decodedText = await collectDecodedText(
+            createDecodedEpgStream(
+                Readable.from([gzipSync(xmltvFixture)]),
                 { 'content-encoding': 'gzip' },
                 true
             )
@@ -81,5 +96,35 @@ describe('createDecodedEpgStream', () => {
 
         expect(decodedText.startsWith('<?xml')).toBe(true);
         expect(parseChannelCount(decodedText)).toBe(1);
+    });
+
+    it('decodes multi-value content-encoding in reverse order', async () => {
+        const encodedPayload = brotliCompressSync(gzipSync(xmltvFixture));
+
+        const decodedText = await collectDecodedText(
+            createDecodedEpgStream(
+                Readable.from([encodedPayload]),
+                { 'content-encoding': 'gzip, br' },
+                false
+            )
+        );
+
+        expect(decodedText.startsWith('<?xml')).toBe(true);
+        expect(parseChannelCount(decodedText)).toBe(1);
+    });
+
+    it('destroys the source stream when a decoder fails', async () => {
+        const source = new PassThrough();
+        const decodedStream = createDecodedEpgStream(
+            source,
+            { 'content-encoding': 'gzip' },
+            false
+        );
+
+        const readPromise = collectDecodedText(decodedStream);
+        source.end(Buffer.from('not gzip'));
+
+        await expect(readPromise).rejects.toThrow();
+        expect(source.destroyed).toBe(true);
     });
 });

--- a/apps/electron-backend/src/app/workers/epg-stream-decoder.spec.ts
+++ b/apps/electron-backend/src/app/workers/epg-stream-decoder.spec.ts
@@ -1,0 +1,85 @@
+import { Readable } from 'stream';
+import { brotliCompressSync, gzipSync } from 'zlib';
+import { createDecodedEpgStream } from './epg-stream-decoder';
+import { StreamingEpgParser } from './epg-streaming-parser';
+
+const xmltvFixture =
+    '<?xml version="1.0" encoding="utf-8" ?>' +
+    '<tv><channel id="test"><display-name>Test Channel</display-name></channel></tv>';
+
+async function collectDecodedText(stream: Readable): Promise<string> {
+    const chunks: Buffer[] = [];
+
+    for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+
+    return Buffer.concat(chunks).toString('utf-8');
+}
+
+function parseChannelCount(xml: string): number {
+    const parser = new StreamingEpgParser(
+        () => undefined,
+        () => undefined,
+        () => undefined
+    );
+
+    parser.write(xml);
+    return parser.finish().totalChannels;
+}
+
+describe('createDecodedEpgStream', () => {
+    it('decodes Brotli transfer-encoded XML before SAX parsing', async () => {
+        const decodedText = await collectDecodedText(
+            createDecodedEpgStream(
+                Readable.from([brotliCompressSync(xmltvFixture)]),
+                { 'content-encoding': 'br' },
+                false
+            )
+        );
+
+        expect(decodedText.startsWith('<?xml')).toBe(true);
+        expect(parseChannelCount(decodedText)).toBe(1);
+    });
+
+    it('decodes gzip transfer-encoded XML before SAX parsing', async () => {
+        const decodedText = await collectDecodedText(
+            createDecodedEpgStream(
+                Readable.from([gzipSync(xmltvFixture)]),
+                { 'content-encoding': 'gzip' },
+                false
+            )
+        );
+
+        expect(decodedText.startsWith('<?xml')).toBe(true);
+        expect(parseChannelCount(decodedText)).toBe(1);
+    });
+
+    it('keeps plain XML readable when no transfer encoding is present', async () => {
+        const decodedText = await collectDecodedText(
+            createDecodedEpgStream(
+                Readable.from([Buffer.from(xmltvFixture)]),
+                {},
+                false
+            )
+        );
+
+        expect(decodedText.startsWith('<?xml')).toBe(true);
+        expect(parseChannelCount(decodedText)).toBe(1);
+    });
+
+    it('decodes gzip XML payloads after transfer decoding', async () => {
+        const transferEncodedPayload = gzipSync(gzipSync(xmltvFixture));
+
+        const decodedText = await collectDecodedText(
+            createDecodedEpgStream(
+                Readable.from([transferEncodedPayload]),
+                { 'content-encoding': 'gzip' },
+                true
+            )
+        );
+
+        expect(decodedText.startsWith('<?xml')).toBe(true);
+        expect(parseChannelCount(decodedText)).toBe(1);
+    });
+});

--- a/apps/electron-backend/src/app/workers/epg-stream-decoder.ts
+++ b/apps/electron-backend/src/app/workers/epg-stream-decoder.ts
@@ -1,0 +1,61 @@
+import { Readable, Transform } from 'stream';
+import {
+    createBrotliDecompress,
+    createGunzip,
+    createInflate,
+} from 'zlib';
+import {
+    getEpgResponseContentEncoding,
+    HeaderReader,
+} from './epg-response-utils';
+
+function createContentEncodingDecoder(
+    contentEncoding: ReturnType<typeof getEpgResponseContentEncoding>
+): Transform | null {
+    switch (contentEncoding) {
+        case 'br':
+            return createBrotliDecompress();
+        case 'gzip':
+            return createGunzip();
+        case 'deflate':
+            return createInflate();
+        default:
+            return null;
+    }
+}
+
+export function createDecodedEpgStream(
+    source: Readable,
+    headers: HeaderReader,
+    shouldGunzipPayload: boolean
+): Readable {
+    const transforms: Transform[] = [];
+    const contentEncoding = getEpgResponseContentEncoding(headers);
+    const contentEncodingDecoder =
+        createContentEncodingDecoder(contentEncoding);
+
+    if (contentEncodingDecoder) {
+        transforms.push(contentEncodingDecoder);
+    }
+
+    if (shouldGunzipPayload) {
+        transforms.push(createGunzip());
+    }
+
+    if (transforms.length === 0) {
+        return source;
+    }
+
+    const decodedStream = transforms.reduce<Readable>(
+        (stream, transform) => stream.pipe(transform),
+        source
+    );
+
+    for (const stream of [source, ...transforms]) {
+        if (stream !== decodedStream) {
+            stream.on('error', (error) => decodedStream.destroy(error));
+        }
+    }
+
+    return decodedStream;
+}

--- a/apps/electron-backend/src/app/workers/epg-stream-decoder.ts
+++ b/apps/electron-backend/src/app/workers/epg-stream-decoder.ts
@@ -1,17 +1,18 @@
-import { Readable, Transform } from 'stream';
+import { PassThrough, Readable, Transform, pipeline } from 'stream';
 import {
     createBrotliDecompress,
     createGunzip,
     createInflate,
 } from 'zlib';
 import {
-    getEpgResponseContentEncoding,
+    EpgResponseContentEncoding,
+    getEpgResponseContentEncodings,
     HeaderReader,
 } from './epg-response-utils';
 
 function createContentEncodingDecoder(
-    contentEncoding: ReturnType<typeof getEpgResponseContentEncoding>
-): Transform | null {
+    contentEncoding: EpgResponseContentEncoding
+): Transform {
     switch (contentEncoding) {
         case 'br':
             return createBrotliDecompress();
@@ -19,8 +20,6 @@ function createContentEncodingDecoder(
             return createGunzip();
         case 'deflate':
             return createInflate();
-        default:
-            return null;
     }
 }
 
@@ -29,16 +28,10 @@ export function createDecodedEpgStream(
     headers: HeaderReader,
     shouldGunzipPayload: boolean
 ): Readable {
-    const transforms: Transform[] = [];
-    const contentEncoding = getEpgResponseContentEncoding(headers);
-    const contentEncodingDecoder =
-        createContentEncodingDecoder(contentEncoding);
+    const contentEncodings = getEpgResponseContentEncodings(headers);
+    const transforms = contentEncodings.map(createContentEncodingDecoder);
 
-    if (contentEncodingDecoder) {
-        transforms.push(contentEncodingDecoder);
-    }
-
-    if (shouldGunzipPayload) {
+    if (shouldGunzipPayload && !contentEncodings.includes('gzip')) {
         transforms.push(createGunzip());
     }
 
@@ -46,16 +39,12 @@ export function createDecodedEpgStream(
         return source;
     }
 
-    const decodedStream = transforms.reduce<Readable>(
-        (stream, transform) => stream.pipe(transform),
-        source
-    );
-
-    for (const stream of [source, ...transforms]) {
-        if (stream !== decodedStream) {
-            stream.on('error', (error) => decodedStream.destroy(error));
+    const output = new PassThrough();
+    pipeline([source, ...transforms, output], (error) => {
+        if (error) {
+            output.destroy(error);
         }
-    }
+    });
 
-    return decodedStream;
+    return output;
 }


### PR DESCRIPTION
## Summary
- decode HTTP Content-Encoding for EPG XMLTV streams before SAX parsing
- keep .xml.gz payload decompression as a separate stream layer
- add mock stream coverage for Brotli/gzip transfer encoding and gzip payloads

## Validation
- pnpm nx test electron-backend --testFile=epg-stream-decoder.spec.ts
- pnpm nx test electron-backend
- pnpm nx lint electron-backend
- pnpm nx run electron-backend:build-worker
