### PR TITLE
fix(settings): show current release notes

### DIFF
--- a/apps/electron-backend/src/app/services/app-update.service.spec.ts
+++ b/apps/electron-backend/src/app/services/app-update.service.spec.ts
@@ -139,6 +139,26 @@ describe('AppUpdateService', () => {
         expect(updaterFactory).not.toHaveBeenCalled();
     });
 
+    it('uses the build app version instead of the Electron runtime version', () => {
+        const service = new AppUpdateService({
+            app: {
+                getVersion: () => '41.7.2',
+                isPackaged: false,
+            },
+            appVersion: '0.22.0',
+            getMainWindow: () => createWindow(),
+            updater: jest.fn(() => new FakeUpdater()),
+        });
+
+        expect(service.getStatus()).toEqual({
+            currentVersion: '0.22.0',
+            manualDownloadUrl:
+                'https://github.com/4gray/iptvnator/releases/latest',
+            status: ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Unsupported,
+            supportedSelfUpdate: false,
+        });
+    });
+
     it('checks GitHub releases without resolving the updater on unsupported packaged Linux builds', async () => {
         const fetcher = createReleaseFetcher();
         const updaterFactory = jest.fn(() => new FakeUpdater());
@@ -330,6 +350,22 @@ describe('AppUpdateService', () => {
             tagName: 'v0.22.0',
         });
         expect(newer.tagName).toBe('v0.23.0');
+    });
+
+    it('falls back to latest stable release notes when a local dev version is unpublished', async () => {
+        const fetcher = createReleaseFetcher();
+        const { service } = createService({ fetcher, isPackaged: false });
+
+        await expect(
+            service.getReleaseNotes({
+                fallbackToLatest: true,
+                version: '0.25.0',
+            })
+        ).resolves.toMatchObject({
+            bodyMarkdown: '## New\n\nFresh build',
+            tagName: 'v0.24.0',
+            version: '0.24.0',
+        });
     });
 
     it('stores available release details from updater events', () => {

--- a/apps/electron-backend/src/app/services/app-update.service.ts
+++ b/apps/electron-backend/src/app/services/app-update.service.ts
@@ -104,6 +104,7 @@ type ReleaseFetcher = (
 
 export interface AppUpdateServiceOptions {
     app: AppUpdateAppAdapter;
+    appVersion?: string;
     updater: AppUpdaterAdapterProvider;
     getMainWindow: () => AppUpdateWindow | null | undefined;
     platform?: NodeJS.Platform;
@@ -182,6 +183,13 @@ function isVersionGreaterThan(candidate: string, current: string): boolean {
     return false;
 }
 
+function resolveCurrentVersion(
+    app: AppUpdateAppAdapter,
+    appVersion: string | undefined
+): string {
+    return normalizeVersion(appVersion) || normalizeVersion(app.getVersion());
+}
+
 function toReleaseInfo(
     release: CachedGitHubRelease
 ): ElectronBridgeAppUpdateRelease {
@@ -234,7 +242,10 @@ export class AppUpdateService {
     private status: ElectronBridgeAppUpdateStatus;
 
     constructor(private readonly options: AppUpdateServiceOptions) {
-        this.currentVersion = options.app.getVersion();
+        this.currentVersion = resolveCurrentVersion(
+            options.app,
+            options.appVersion
+        );
         this.isPackaged = options.app.isPackaged;
         this.supportedSelfUpdate = isSelfUpdateSupported(
             options.app.isPackaged,
@@ -312,11 +323,18 @@ export class AppUpdateService {
     async getReleaseNotes(
         request: ElectronBridgeAppUpdateReleaseNotesRequest = {}
     ): Promise<ElectronBridgeAppUpdateReleaseNotes> {
-        await this.ensureReleasePageLoaded(1);
+        const canFallbackToLatest =
+            !request.direction && (!request.version || request.fallbackToLatest);
+
+        if (canFallbackToLatest) {
+            await this.ensureFirstStableReleaseLoaded();
+        } else {
+            await this.ensureReleasePageLoaded(1);
+        }
 
         let index = await this.findReleaseIndex(request.version);
 
-        if (index === -1 && !request.version) {
+        if (index === -1 && canFallbackToLatest) {
             index = 0;
         }
 

--- a/apps/electron-backend/src/main.ts
+++ b/apps/electron-backend/src/main.ts
@@ -29,6 +29,7 @@ import { AppUpdateService } from './app/services/app-update.service';
 import { databaseWorkerClient } from './app/services/database-worker-client';
 import WindowEvents from './app/events/window.events';
 import XtreamEvents from './app/events/xtream.events';
+import { environment } from './environments/environment';
 
 app.setName('iptvnator');
 
@@ -88,6 +89,7 @@ export default class Main {
 
         const appUpdateService = new AppUpdateService({
             app,
+            appVersion: environment.version,
             getMainWindow: () => App.mainWindow,
             updater: () => autoUpdater,
         });

--- a/apps/web/src/app/settings/app-update-release-notes-dialog.component.spec.ts
+++ b/apps/web/src/app/settings/app-update-release-notes-dialog.component.spec.ts
@@ -70,6 +70,27 @@ describe('AppUpdateReleaseNotesDialogComponent', () => {
         ).toContain('desktop updater');
     });
 
+    it('constrains rendered markdown images to the dialog width', async () => {
+        (
+            window.electron.getAppUpdateReleaseNotes as jest.Mock
+        ).mockResolvedValueOnce({
+            ...releaseNotes,
+            bodyMarkdown:
+                '![Application screenshot](https://example.com/screenshot.png)',
+        });
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const image = fixture.nativeElement.querySelector(
+            '[data-test-id="release-notes-body"] img'
+        ) as HTMLImageElement;
+
+        expect(image).toBeTruthy();
+        expect(image.classList).toContain('release-notes-dialog__image');
+    });
+
     it('loads previous notes lazily without closing the dialog', async () => {
         fixture.detectChanges();
         await fixture.whenStable();

--- a/apps/web/src/app/settings/app-update-release-notes-dialog.component.spec.ts
+++ b/apps/web/src/app/settings/app-update-release-notes-dialog.component.spec.ts
@@ -31,7 +31,10 @@ describe('AppUpdateReleaseNotesDialogComponent', () => {
             providers: [
                 {
                     provide: MAT_DIALOG_DATA,
-                    useValue: { initialVersion: '0.23.0' },
+                    useValue: {
+                        fallbackToLatest: true,
+                        initialVersion: '0.23.0',
+                    },
                 },
                 {
                     provide: MatDialogRef,
@@ -53,6 +56,7 @@ describe('AppUpdateReleaseNotesDialogComponent', () => {
         fixture.detectChanges();
 
         expect(window.electron.getAppUpdateReleaseNotes).toHaveBeenCalledWith({
+            fallbackToLatest: true,
             version: '0.23.0',
         });
         expect(

--- a/apps/web/src/app/settings/app-update-release-notes-dialog.component.ts
+++ b/apps/web/src/app/settings/app-update-release-notes-dialog.component.ts
@@ -5,6 +5,7 @@ import {
     OnInit,
     SecurityContext,
     signal,
+    ViewEncapsulation,
 } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
@@ -24,9 +25,26 @@ import {
     ElectronBridgeAppUpdateReleaseNotesRequest,
 } from '@iptvnator/shared/interfaces';
 
+const RELEASE_NOTES_IMAGE_CLASS = 'release-notes-dialog__image';
+
 export interface AppUpdateReleaseNotesDialogData {
     initialVersion?: string;
     fallbackToLatest?: boolean;
+}
+
+function decorateReleaseNotesHtml(html: string): string {
+    if (typeof document === 'undefined') {
+        return html;
+    }
+
+    const template = document.createElement('template');
+    template.innerHTML = html;
+
+    template.content.querySelectorAll('img').forEach((image) => {
+        image.classList.add(RELEASE_NOTES_IMAGE_CLASS);
+    });
+
+    return template.innerHTML;
 }
 
 @Component({
@@ -39,6 +57,7 @@ export interface AppUpdateReleaseNotesDialogData {
         DatePipe,
         TranslatePipe,
     ],
+    encapsulation: ViewEncapsulation.None,
     template: `
         <h2 mat-dialog-title>
             {{ 'SETTINGS.APP_UPDATE_RELEASE_NOTES' | translate }}
@@ -177,6 +196,16 @@ export interface AppUpdateReleaseNotesDialogData {
                 padding: 1px 4px;
                 background: var(--app-hover-overlay);
             }
+
+            .release-notes-dialog__body img,
+            .release-notes-dialog__image {
+                display: block;
+                box-sizing: border-box;
+                max-width: 100%;
+                height: auto;
+                margin: 16px auto;
+                object-fit: contain;
+            }
         `,
     ],
 })
@@ -195,8 +224,10 @@ export class AppUpdateReleaseNotesDialogComponent implements OnInit {
     readonly renderedMarkdown = computed(() => {
         const markdown = this.notes()?.bodyMarkdown ?? '';
         const html = marked.parse(markdown, { async: false }) as string;
+        const sanitizedHtml =
+            this.sanitizer.sanitize(SecurityContext.HTML, html) ?? '';
 
-        return this.sanitizer.sanitize(SecurityContext.HTML, html) ?? '';
+        return decorateReleaseNotesHtml(sanitizedHtml);
     });
 
     ngOnInit(): void {

--- a/apps/web/src/app/settings/app-update-release-notes-dialog.component.ts
+++ b/apps/web/src/app/settings/app-update-release-notes-dialog.component.ts
@@ -21,10 +21,12 @@ import { marked } from 'marked';
 import {
     ElectronBridgeAppUpdateReleaseNotes,
     ElectronBridgeAppUpdateReleaseNotesDirection,
+    ElectronBridgeAppUpdateReleaseNotesRequest,
 } from '@iptvnator/shared/interfaces';
 
 export interface AppUpdateReleaseNotesDialogData {
     initialVersion?: string;
+    fallbackToLatest?: boolean;
 }
 
 @Component({
@@ -212,16 +214,30 @@ export class AppUpdateReleaseNotesDialogComponent implements OnInit {
         const version = direction
             ? this.notes()?.tagName
             : this.data.initialVersion;
+        const fallbackToLatest = direction
+            ? undefined
+            : this.data.fallbackToLatest;
 
         this.loading.set(true);
         this.error.set(null);
 
         try {
+            const request: ElectronBridgeAppUpdateReleaseNotesRequest = {};
+
+            if (direction) {
+                request.direction = direction;
+            }
+
+            if (version) {
+                request.version = version;
+            }
+
+            if (fallbackToLatest) {
+                request.fallbackToLatest = true;
+            }
+
             this.notes.set(
-                await window.electron.getAppUpdateReleaseNotes({
-                    direction,
-                    version,
-                })
+                await window.electron.getAppUpdateReleaseNotes(request)
             );
         } catch (error) {
             this.error.set(error instanceof Error ? error.message : String(error));

--- a/apps/web/src/app/settings/settings-about-section.component.spec.ts
+++ b/apps/web/src/app/settings/settings-about-section.component.spec.ts
@@ -81,6 +81,24 @@ describe('SettingsAboutSectionComponent app updates', () => {
         expect(install).toHaveBeenCalledTimes(1);
     });
 
+    it('shows release notes for the current version when no update is available', () => {
+        const openNotes = jest.fn();
+        fixture.componentInstance.openAppUpdateReleaseNotes.subscribe(openNotes);
+        configureComponent(fixture, {
+            currentVersion: '0.22.0',
+            latestVersion: '0.22.0',
+            manualDownloadUrl:
+                'https://github.com/4gray/iptvnator/releases/latest',
+            status: ELECTRON_BRIDGE_APP_UPDATE_STATUSES.NotAvailable,
+            supportedSelfUpdate: true,
+        });
+
+        getButton(fixture, 'app-update-release-notes')?.click();
+
+        expect(getButton(fixture, 'app-update-release-notes')).toBeTruthy();
+        expect(openNotes).toHaveBeenCalledTimes(1);
+    });
+
     it('emits a manual release request for unsupported Linux packages', () => {
         const openManual = jest.fn();
         fixture.componentInstance.openManualAppUpdate.subscribe(openManual);

--- a/apps/web/src/app/settings/settings-about-section.component.ts
+++ b/apps/web/src/app/settings/settings-about-section.component.ts
@@ -64,13 +64,8 @@ export class SettingsAboutSectionComponent {
         const status = this.appUpdateStatus();
 
         return Boolean(
-            status?.latestVersion &&
-                status.status !== ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Idle &&
-                status.status !==
-                    ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Checking &&
-                status.status !==
-                    ELECTRON_BRIDGE_APP_UPDATE_STATUSES.NotAvailable &&
-                status.status !== ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Error
+            status?.currentVersion &&
+                status.status !== ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Checking
         );
     });
 

--- a/apps/web/src/app/settings/settings.component.spec.ts
+++ b/apps/web/src/app/settings/settings.component.spec.ts
@@ -500,6 +500,29 @@ describe('SettingsComponent', () => {
         );
     });
 
+    it('opens release notes dialog for the current version when no update is available', () => {
+        const openSpy = jest
+            .spyOn(privateApi(component).matDialog, 'open')
+            .mockReturnValue(createDialogRef(false));
+        component.appUpdateStatus.set({
+            ...DEFAULT_APP_UPDATE_STATUS,
+            latestVersion: undefined,
+            release: undefined,
+            status: ELECTRON_BRIDGE_APP_UPDATE_STATUSES.NotAvailable,
+        });
+
+        component.openAppUpdateReleaseNotes();
+
+        expect(openSpy).toHaveBeenCalledWith(
+            AppUpdateReleaseNotesDialogComponent,
+            expect.objectContaining({
+                data: {
+                    initialVersion: DEFAULT_APP_UPDATE_STATUS.currentVersion,
+                },
+            })
+        );
+    });
+
     it('should render a compact page header outside dialog mode', () => {
         const nativeElement = fixture.nativeElement as HTMLElement;
 

--- a/apps/web/src/app/settings/settings.component.spec.ts
+++ b/apps/web/src/app/settings/settings.component.spec.ts
@@ -506,8 +506,10 @@ describe('SettingsComponent', () => {
             .mockReturnValue(createDialogRef(false));
         component.appUpdateStatus.set({
             ...DEFAULT_APP_UPDATE_STATUS,
-            latestVersion: undefined,
-            release: undefined,
+            latestVersion: '0.21.0',
+            release: {
+                version: '0.21.0',
+            },
             status: ELECTRON_BRIDGE_APP_UPDATE_STATUSES.NotAvailable,
         });
 

--- a/apps/web/src/app/settings/settings.component.spec.ts
+++ b/apps/web/src/app/settings/settings.component.spec.ts
@@ -518,6 +518,7 @@ describe('SettingsComponent', () => {
             expect.objectContaining({
                 data: {
                     initialVersion: DEFAULT_APP_UPDATE_STATUS.currentVersion,
+                    fallbackToLatest: true,
                 },
             })
         );

--- a/apps/web/src/app/settings/settings.component.ts
+++ b/apps/web/src/app/settings/settings.component.ts
@@ -37,6 +37,7 @@ import { DataService, RuntimeCapabilitiesService } from '@iptvnator/services';
 import {
     EmbeddedMpvSupport,
     CoverSize,
+    ELECTRON_BRIDGE_APP_UPDATE_STATUSES,
     ElectronBridgeAppUpdateStatus,
     Language,
     StreamFormat,
@@ -398,13 +399,21 @@ export class SettingsComponent implements OnInit, OnDestroy {
     }
 
     openAppUpdateReleaseNotes(): void {
+        const status = this.appUpdateStatus();
+        const isUpdateRelease =
+            status?.status === ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Available ||
+            status?.status ===
+                ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Downloading ||
+            status?.status === ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Downloaded;
+
         this.matDialog.open(AppUpdateReleaseNotesDialogComponent, {
             autoFocus: false,
             data: {
+                ...(!isUpdateRelease ? { fallbackToLatest: true } : {}),
                 initialVersion:
-                    this.appUpdateStatus()?.latestVersion ??
-                    this.appUpdateStatus()?.release?.version ??
-                    this.appUpdateStatus()?.currentVersion,
+                    status?.latestVersion ??
+                    status?.release?.version ??
+                    status?.currentVersion,
             },
             maxWidth: 'calc(100vw - 32px)',
             restoreFocus: true,

--- a/apps/web/src/app/settings/settings.component.ts
+++ b/apps/web/src/app/settings/settings.component.ts
@@ -403,7 +403,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
             data: {
                 initialVersion:
                     this.appUpdateStatus()?.latestVersion ??
-                    this.appUpdateStatus()?.release?.version,
+                    this.appUpdateStatus()?.release?.version ??
+                    this.appUpdateStatus()?.currentVersion,
             },
             maxWidth: 'calc(100vw - 32px)',
             restoreFocus: true,

--- a/apps/web/src/app/settings/settings.component.ts
+++ b/apps/web/src/app/settings/settings.component.ts
@@ -405,15 +405,17 @@ export class SettingsComponent implements OnInit, OnDestroy {
             status?.status ===
                 ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Downloading ||
             status?.status === ELECTRON_BRIDGE_APP_UPDATE_STATUSES.Downloaded;
+        const initialReleaseNotesVersion = isUpdateRelease
+            ? (status?.latestVersion ??
+              status?.release?.version ??
+              status?.currentVersion)
+            : status?.currentVersion;
 
         this.matDialog.open(AppUpdateReleaseNotesDialogComponent, {
             autoFocus: false,
             data: {
                 ...(!isUpdateRelease ? { fallbackToLatest: true } : {}),
-                initialVersion:
-                    status?.latestVersion ??
-                    status?.release?.version ??
-                    status?.currentVersion,
+                initialVersion: initialReleaseNotesVersion,
             },
             maxWidth: 'calc(100vw - 32px)',
             restoreFocus: true,

--- a/apps/web/src/assets/i18n/ar.json
+++ b/apps/web/src/assets/i18n/ar.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "داكن",

--- a/apps/web/src/assets/i18n/ary.json
+++ b/apps/web/src/assets/i18n/ary.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "داكن",

--- a/apps/web/src/assets/i18n/by.json
+++ b/apps/web/src/assets/i18n/by.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Цёмная",

--- a/apps/web/src/assets/i18n/de.json
+++ b/apps/web/src/assets/i18n/de.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Dunkel",

--- a/apps/web/src/assets/i18n/el.json
+++ b/apps/web/src/assets/i18n/el.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Σκούρο",

--- a/apps/web/src/assets/i18n/en.json
+++ b/apps/web/src/assets/i18n/en.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Dark",

--- a/apps/web/src/assets/i18n/es.json
+++ b/apps/web/src/assets/i18n/es.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Oscuro",

--- a/apps/web/src/assets/i18n/fr.json
+++ b/apps/web/src/assets/i18n/fr.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Sombre",

--- a/apps/web/src/assets/i18n/it.json
+++ b/apps/web/src/assets/i18n/it.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Scuro",

--- a/apps/web/src/assets/i18n/ja.json
+++ b/apps/web/src/assets/i18n/ja.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "ダーク",

--- a/apps/web/src/assets/i18n/ko.json
+++ b/apps/web/src/assets/i18n/ko.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "어둡게",

--- a/apps/web/src/assets/i18n/nl.json
+++ b/apps/web/src/assets/i18n/nl.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Donker",

--- a/apps/web/src/assets/i18n/pl.json
+++ b/apps/web/src/assets/i18n/pl.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Ciemny",

--- a/apps/web/src/assets/i18n/pt.json
+++ b/apps/web/src/assets/i18n/pt.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Escuro",

--- a/apps/web/src/assets/i18n/ru.json
+++ b/apps/web/src/assets/i18n/ru.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Обновить",
         "APP_UPDATE_INSTALL": "Перезагрузить приложение",
         "APP_UPDATE_OPEN_RELEASE": "Открыть GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "Что нового"
     },
     "THEMES": {
         "DARK_THEME": "Тёмная",

--- a/apps/web/src/assets/i18n/tr.json
+++ b/apps/web/src/assets/i18n/tr.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "Koyu",

--- a/apps/web/src/assets/i18n/zh.json
+++ b/apps/web/src/assets/i18n/zh.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "深色",

--- a/apps/web/src/assets/i18n/zhtw.json
+++ b/apps/web/src/assets/i18n/zhtw.json
@@ -410,7 +410,7 @@
         "APP_UPDATE_DOWNLOAD": "Update",
         "APP_UPDATE_INSTALL": "Restart application",
         "APP_UPDATE_OPEN_RELEASE": "Open GitHub release",
-        "APP_UPDATE_RELEASE_NOTES": "Release notes"
+        "APP_UPDATE_RELEASE_NOTES": "What's new"
     },
     "THEMES": {
         "DARK_THEME": "深色",

--- a/libs/shared/interfaces/src/lib/electron-api.interface.ts
+++ b/libs/shared/interfaces/src/lib/electron-api.interface.ts
@@ -198,6 +198,7 @@ export type ElectronBridgeAppUpdateReleaseNotesDirection = 'previous' | 'next';
 export interface ElectronBridgeAppUpdateReleaseNotesRequest {
     version?: string;
     direction?: ElectronBridgeAppUpdateReleaseNotesDirection;
+    fallbackToLatest?: boolean;
 }
 
 export interface ElectronBridgeAppUpdateReleaseNotes {


### PR DESCRIPTION
## Summary
- Show the updater "What's new" action even when no update is available.
- Open release notes for the latest update when available, otherwise for the current app version.
- Use the app build version for updater state in local Electron runs instead of Electron's runtime version.
- Fall back to the latest public GitHub release notes when a local dev version is not published as a stable release yet.
- Render release-note screenshots responsively inside the dialog instead of letting markdown images overflow.
- Rename the action from "Release notes" to "What's new" / "Что нового".

## Testing
- [x] `corepack pnpm nx test electron-backend -- --runTestsByPath apps/electron-backend/src/app/services/app-update.service.spec.ts --runInBand`
- [x] `corepack pnpm nx test web -- --runTestsByPath apps/web/src/app/settings/app-update-release-notes-dialog.component.spec.ts apps/web/src/app/settings/settings.component.spec.ts apps/web/src/app/settings/settings-about-section.component.spec.ts --runInBand`
- [x] `corepack pnpm i18n:check`
- [x] `corepack pnpm run typecheck:ci`
- [x] `corepack pnpm run typecheck:web`
- [x] `git diff --check`
- [x] Manual Electron dev smoke via `corepack pnpm nx serve electron-backend`: Settings/About shows `0.22.0`, "What's new" renders GitHub release notes without the `41.7.2` error, and release-note screenshots scale to the dialog width (`bodyScrollWidth=660`, image width `656px`).