### PR TITLE
Pr/epg fixes

### DIFF
--- a/apps/electron-backend/src/app/api/main.preload.ts
+++ b/apps/electron-backend/src/app/api/main.preload.ts
@@ -517,6 +517,14 @@ const electronApi: ElectronBridgeApi = {
         ipcRenderer.invoke('EPG_CHECK_FRESHNESS', { urls, maxAgeHours }),
     searchEpgPrograms: (searchTerm: string, limit?: number) =>
         ipcRenderer.invoke('EPG_DB_SEARCH_PROGRAMS', searchTerm, limit),
+    getEpgMapping: (channelKey: string) =>
+        ipcRenderer.invoke('EPG_MAPPING_GET', { channelKey }),
+    setEpgMapping: (channelKey: string, epgChannelId: string, playlistId?: string) =>
+        ipcRenderer.invoke('EPG_MAPPING_SET', { channelKey, epgChannelId, playlistId }),
+    deleteEpgMapping: (channelKey: string) =>
+        ipcRenderer.invoke('EPG_MAPPING_DELETE', { channelKey }),
+    searchEpgChannels: (searchTerm: string, limit?: number) =>
+        ipcRenderer.invoke('EPG_CHANNEL_SEARCH', { searchTerm, limit }),
     setMpvPlayerPath: (mpvPlayerPath: string) =>
         ipcRenderer.invoke('SET_MPV_PLAYER_PATH', mpvPlayerPath),
     setVlcPlayerPath: (vlcPlayerPath: string) =>

--- a/apps/electron-backend/src/app/database/operations/epg-mapping.operations.ts
+++ b/apps/electron-backend/src/app/database/operations/epg-mapping.operations.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, like, or, sql } from 'drizzle-orm';
+import { and, eq, inArray, or, sql } from 'drizzle-orm';
 import * as schema from '@iptvnator/shared/database/schema';
 import type { AppDatabase } from '../database.types';
 
@@ -101,7 +101,8 @@ export async function searchEpgChannels(
     limit = 50
 ): Promise<Array<{ id: string; displayName: string; iconUrl: string | null }>> {
     // Escape LIKE wildcards so user input like "HBO%" or "_BC" is literal.
-    const escaped = searchTerm.trim().replace(/[%_]/g, '\\$&');
+    // Drizzle's like() doesn't support ESCAPE, so we use raw SQL.
+    const escaped = searchTerm.trim().replace(/[%_\\]/g, '\\$&');
     const pattern = `%${escaped}%`;
 
     return db
@@ -113,8 +114,8 @@ export async function searchEpgChannels(
         .from(schema.epgChannels)
         .where(
             or(
-                like(schema.epgChannels.displayName, pattern),
-                like(schema.epgChannels.id, pattern)
+                sql`${schema.epgChannels.displayName} LIKE ${pattern} ESCAPE '\\'`,
+                sql`${schema.epgChannels.id} LIKE ${pattern} ESCAPE '\\'`
             )
         )
         .orderBy(schema.epgChannels.displayName)

--- a/apps/electron-backend/src/app/database/operations/epg-mapping.operations.ts
+++ b/apps/electron-backend/src/app/database/operations/epg-mapping.operations.ts
@@ -1,0 +1,120 @@
+import { and, eq, inArray, like, or, sql } from 'drizzle-orm';
+import * as schema from '@iptvnator/shared/database/schema';
+import type { AppDatabase } from '../database.types';
+
+/**
+ * Get a single EPG channel mapping by lookup key.
+ */
+export async function getEpgMapping(
+    db: AppDatabase,
+    channelKey: string
+): Promise<{ id: number; channelKey: string; epgChannelId: string; playlistId: string | null } | null> {
+    const rows = await db
+        .select({
+            id: schema.epgChannelMappings.id,
+            channelKey: schema.epgChannelMappings.channelKey,
+            epgChannelId: schema.epgChannelMappings.epgChannelId,
+            playlistId: schema.epgChannelMappings.playlistId,
+        })
+        .from(schema.epgChannelMappings)
+        .where(eq(schema.epgChannelMappings.channelKey, channelKey))
+        .limit(1);
+
+    return rows[0] ?? null;
+}
+
+/**
+ * Batch lookup of EPG channel mappings for multiple keys.
+ * Returns a Map of channelKey → epgChannelId (only for keys that have mappings).
+ */
+export async function getEpgMappingsBatch(
+    db: AppDatabase,
+    channelKeys: string[]
+): Promise<Map<string, string>> {
+    if (channelKeys.length === 0) {
+        return new Map();
+    }
+
+    const rows = await db
+        .select({
+            channelKey: schema.epgChannelMappings.channelKey,
+            epgChannelId: schema.epgChannelMappings.epgChannelId,
+        })
+        .from(schema.epgChannelMappings)
+        .where(inArray(schema.epgChannelMappings.channelKey, channelKeys));
+
+    const mapping = new Map<string, string>();
+    for (const row of rows) {
+        mapping.set(row.channelKey, row.epgChannelId);
+    }
+    return mapping;
+}
+
+/**
+ * Create or update an EPG channel mapping (upsert).
+ */
+export async function setEpgMapping(
+    db: AppDatabase,
+    channelKey: string,
+    epgChannelId: string,
+    playlistId?: string
+): Promise<{ success: boolean }> {
+    await db
+        .insert(schema.epgChannelMappings)
+        .values({
+            channelKey,
+            epgChannelId,
+            playlistId: playlistId ?? null,
+        })
+        .onConflictDoUpdate({
+            target: schema.epgChannelMappings.channelKey,
+            set: {
+                epgChannelId,
+                playlistId: playlistId ?? null,
+                updatedAt: sql`(datetime('now'))`,
+            },
+        });
+
+    return { success: true };
+}
+
+/**
+ * Remove an EPG channel mapping.
+ */
+export async function deleteEpgMapping(
+    db: AppDatabase,
+    channelKey: string
+): Promise<{ success: boolean }> {
+    await db
+        .delete(schema.epgChannelMappings)
+        .where(eq(schema.epgChannelMappings.channelKey, channelKey));
+
+    return { success: true };
+}
+
+/**
+ * Search EPG channels by display name for the mapping dialog.
+ */
+export async function searchEpgChannels(
+    db: AppDatabase,
+    searchTerm: string,
+    limit = 50
+): Promise<Array<{ id: string; displayName: string; iconUrl: string | null }>> {
+    const pattern = `%${searchTerm.trim()}%`;
+
+    return db
+        .select({
+            id: schema.epgChannels.id,
+            displayName: schema.epgChannels.displayName,
+            iconUrl: schema.epgChannels.iconUrl,
+        })
+        .from(schema.epgChannels)
+        .where(
+            or(
+                like(schema.epgChannels.displayName, pattern),
+                like(schema.epgChannels.id, pattern)
+            )
+        )
+        .orderBy(schema.epgChannels.displayName)
+        .limit(limit);
+}

--- a/apps/electron-backend/src/app/database/operations/epg-mapping.operations.ts
+++ b/apps/electron-backend/src/app/database/operations/epg-mapping.operations.ts
@@ -100,7 +100,9 @@ export async function searchEpgChannels(
     searchTerm: string,
     limit = 50
 ): Promise<Array<{ id: string; displayName: string; iconUrl: string | null }>> {
-    const pattern = `%${searchTerm.trim()}%`;
+    // Escape LIKE wildcards so user input like "HBO%" or "_BC" is literal.
+    const escaped = searchTerm.trim().replace(/[%_]/g, '\\$&');
+    const pattern = `%${escaped}%`;
 
     return db
         .select({

--- a/apps/electron-backend/src/app/database/operations/favorites.operations.ts
+++ b/apps/electron-backend/src/app/database/operations/favorites.operations.ts
@@ -75,6 +75,7 @@ export async function getFavorites(db: AppDatabase, playlistId: string) {
             type: schema.content.type,
             tv_archive: schema.content.tvArchive,
             tv_archive_duration: schema.content.tvArchiveDuration,
+            epg_channel_id: schema.content.epgChannelId,
             added_at: schema.favorites.addedAt,
             position: schema.favorites.position,
         })
@@ -121,6 +122,7 @@ function selectGlobalFavoriteRows(
             type: schema.content.type,
             tv_archive: schema.content.tvArchive,
             tv_archive_duration: schema.content.tvArchiveDuration,
+            epg_channel_id: schema.content.epgChannelId,
             playlist_id: schema.playlists.id,
             playlist_name: schema.playlists.name,
             added_at: schema.favorites.addedAt,

--- a/apps/electron-backend/src/app/database/operations/favorites.operations.ts
+++ b/apps/electron-backend/src/app/database/operations/favorites.operations.ts
@@ -73,6 +73,8 @@ export async function getFavorites(db: AppDatabase, playlistId: string) {
             poster_url: schema.content.posterUrl,
             xtream_id: schema.content.xtreamId,
             type: schema.content.type,
+            tv_archive: schema.content.tvArchive,
+            tv_archive_duration: schema.content.tvArchiveDuration,
             added_at: schema.favorites.addedAt,
             position: schema.favorites.position,
         })
@@ -117,6 +119,8 @@ function selectGlobalFavoriteRows(
                 : {}),
             xtream_id: schema.content.xtreamId,
             type: schema.content.type,
+            tv_archive: schema.content.tvArchive,
+            tv_archive_duration: schema.content.tvArchiveDuration,
             playlist_id: schema.playlists.id,
             playlist_name: schema.playlists.name,
             added_at: schema.favorites.addedAt,

--- a/apps/electron-backend/src/app/database/schema.ts
+++ b/apps/electron-backend/src/app/database/schema.ts
@@ -11,6 +11,7 @@ export {
   recentlyViewed,
   favorites,
   epgChannels,
+  epgChannelMappings,
   epgPrograms,
   playbackPositions,
   downloads,

--- a/apps/electron-backend/src/app/events/epg-query.service.ts
+++ b/apps/electron-backend/src/app/events/epg-query.service.ts
@@ -509,8 +509,7 @@ export class EpgQueryService {
                     sourceUrls
                 )
             )
-            .orderBy(schema.epgPrograms.start)
-            .limit(500);
+            .orderBy(schema.epgPrograms.start);
     }
 
     private async selectLegacyChannelPrograms(
@@ -532,8 +531,7 @@ export class EpgQueryService {
                     { legacyOnly: true }
                 )
             )
-            .orderBy(schema.epgPrograms.start)
-            .limit(500);
+            .orderBy(schema.epgPrograms.start);
     }
 
     private async selectCurrentProgramsForChannelIds(

--- a/apps/electron-backend/src/app/events/epg-query.service.ts
+++ b/apps/electron-backend/src/app/events/epg-query.service.ts
@@ -38,11 +38,19 @@ export class EpgQueryService {
     ): Promise<EpgProgram[]> {
         try {
             const db = await getDatabase();
-            const trimmedChannelId = channelId.trim();
+            let trimmedChannelId = channelId.trim();
             const sourceUrls = this.normalizeSourceUrls(options.sourceUrls);
 
             if (!trimmedChannelId) {
                 return [];
+            }
+
+            // Check for manual EPG mapping — if a user has mapped this
+            // channel key to a different EPG channel ID, use the mapped
+            // ID for all subsequent lookups.
+            const mapped = await this.getMapping(db, trimmedChannelId);
+            if (mapped) {
+                trimmedChannelId = mapped;
             }
 
             let results = await this.selectChannelPrograms(
@@ -820,6 +828,61 @@ export class EpgQueryService {
             !Number.isNaN(new Date(program.start).getTime()) &&
             !Number.isNaN(new Date(program.stop).getTime())
         );
+    }
+
+    private async getMapping(
+        db: EpgDatabase,
+        channelKey: string
+    ): Promise<string | null> {
+        try {
+            // Direct lookup by channel key.
+            const rows = await db
+                .select({
+                    epgChannelId: schema.epgChannelMappings.epgChannelId,
+                })
+                .from(schema.epgChannelMappings)
+                .where(
+                    eq(schema.epgChannelMappings.channelKey, channelKey)
+                )
+                .limit(1);
+            if (rows.length > 0) {
+                return rows[0].epgChannelId;
+            }
+
+            // Fallback: if the key looks like an Xtream epg_channel_id, also
+            // check if a mapping was saved using the xtream_id instead.
+            const contentRows = await db
+                .select({
+                    xtreamId: schema.content.xtreamId,
+                })
+                .from(schema.content)
+                .where(
+                    eq(schema.content.epgChannelId, channelKey)
+                )
+                .limit(1);
+            if (contentRows.length > 0) {
+                const xtreamId = String(contentRows[0].xtreamId);
+                const mapped = await db
+                    .select({
+                        epgChannelId: schema.epgChannelMappings.epgChannelId,
+                    })
+                    .from(schema.epgChannelMappings)
+                    .where(
+                        eq(
+                            schema.epgChannelMappings.channelKey,
+                            xtreamId
+                        )
+                    )
+                    .limit(1);
+                if (mapped.length > 0) {
+                    return mapped[0].epgChannelId;
+                }
+            }
+
+            return null;
+        } catch {
+            return null;
+        }
     }
 }
 

--- a/apps/electron-backend/src/app/events/epg-query.service.ts
+++ b/apps/electron-backend/src/app/events/epg-query.service.ts
@@ -503,17 +503,36 @@ export class EpgQueryService {
         return matchedCandidateIds;
     }
 
+    private readonly EPG_WINDOW_START_DAYS = 14;
+    private readonly EPG_WINDOW_END_DAYS = 2;
+
+    private epgTimeWindow(): { start: string; end: string } {
+        const now = new Date();
+        const start = new Date(
+            now.getTime() - this.EPG_WINDOW_START_DAYS * 24 * 60 * 60 * 1000
+        ).toISOString();
+        const end = new Date(
+            now.getTime() + this.EPG_WINDOW_END_DAYS * 24 * 60 * 60 * 1000
+        ).toISOString();
+        return { start, end };
+    }
+
     private async selectChannelPrograms(
         db: EpgDatabase,
         channelId: string,
         sourceUrls: string[]
     ): Promise<EpgProgramRow[]> {
+        const { start, end } = this.epgTimeWindow();
         return db
             .select()
             .from(schema.epgPrograms)
             .where(
                 this.withProgramSourceScope(
-                    eq(schema.epgPrograms.channelId, channelId),
+                    and(
+                        eq(schema.epgPrograms.channelId, channelId),
+                        gte(schema.epgPrograms.stop, start),
+                        lte(schema.epgPrograms.start, end)
+                    ) as SQL,
                     sourceUrls
                 )
             )
@@ -529,12 +548,17 @@ export class EpgQueryService {
             return [];
         }
 
+        const { start, end } = this.epgTimeWindow();
         return db
             .select()
             .from(schema.epgPrograms)
             .where(
                 this.withProgramSourceScope(
-                    eq(schema.epgPrograms.channelId, channelId),
+                    and(
+                        eq(schema.epgPrograms.channelId, channelId),
+                        gte(schema.epgPrograms.stop, start),
+                        lte(schema.epgPrograms.start, end)
+                    ) as SQL,
                     sourceUrls,
                     { legacyOnly: true }
                 )

--- a/apps/electron-backend/src/app/events/epg.events.spec.ts
+++ b/apps/electron-backend/src/app/events/epg.events.spec.ts
@@ -366,32 +366,15 @@ describe('EpgEvents', () => {
 
     it('falls back to case-insensitive channel id lookup for EPG programs', async () => {
         const select = jest.fn();
-        const programLimitExact = jest.fn().mockResolvedValue([]);
         const channelLimit = jest
             .fn()
             .mockResolvedValue([{ id: 'BBC.ONE.UK', displayName: 'BBC One' }]);
-        const programLimitResolved = jest.fn().mockResolvedValue([
-            {
-                id: 1,
-                channelId: 'BBC.ONE.UK',
-                start: '2026-04-14T10:00:00Z',
-                stop: '2026-04-14T11:00:00Z',
-                title: 'News',
-                description: null,
-                category: null,
-                iconUrl: null,
-                rating: null,
-                episodeNum: null,
-            },
-        ]);
 
         const from = jest
             .fn()
             .mockReturnValueOnce({
                 where: jest.fn().mockReturnValue({
-                    orderBy: jest.fn().mockReturnValue({
-                        limit: programLimitExact,
-                    }),
+                    orderBy: jest.fn().mockResolvedValue([] as any[]),
                 }),
             })
             .mockReturnValueOnce({
@@ -401,9 +384,20 @@ describe('EpgEvents', () => {
             })
             .mockReturnValueOnce({
                 where: jest.fn().mockReturnValue({
-                    orderBy: jest.fn().mockReturnValue({
-                        limit: programLimitResolved,
-                    }),
+                    orderBy: jest.fn().mockResolvedValue([
+                        {
+                            id: 1,
+                            channelId: 'BBC.ONE.UK',
+                            start: '2026-04-14T10:00:00Z',
+                            stop: '2026-04-14T11:00:00Z',
+                            title: 'News',
+                            description: null,
+                            category: null,
+                            iconUrl: null,
+                            rating: null,
+                            episodeNum: null,
+                        },
+                    ]),
                 }),
             });
 
@@ -466,13 +460,11 @@ describe('EpgEvents', () => {
         const from = jest.fn();
         const where = jest.fn();
         const orderBy = jest.fn();
-        const limit = jest.fn();
 
         select.mockImplementation(() => ({ from }));
         from.mockReturnValue({ where });
         where.mockReturnValue({ orderBy });
-        orderBy.mockReturnValue({ limit });
-        limit.mockResolvedValue([
+        orderBy.mockResolvedValue([
             {
                 id: 1,
                 channelId: 'id2e2cd03c90ad',

--- a/apps/electron-backend/src/app/events/epg.events.spec.ts
+++ b/apps/electron-backend/src/app/events/epg.events.spec.ts
@@ -370,36 +370,48 @@ describe('EpgEvents', () => {
             .fn()
             .mockResolvedValue([{ id: 'BBC.ONE.UK', displayName: 'BBC One' }]);
 
+        const resolveMapping = {
+            where: jest.fn().mockReturnValue({
+                limit: jest.fn().mockResolvedValue([] as any[]),
+            }),
+        };
+        const resolvePrograms = (data: any[]) => ({
+            where: jest.fn().mockReturnValue({
+                orderBy: jest.fn().mockResolvedValue(data),
+            }),
+        });
+
         const from = jest
             .fn()
-            .mockReturnValueOnce({
-                where: jest.fn().mockReturnValue({
-                    orderBy: jest.fn().mockResolvedValue([] as any[]),
-                }),
-            })
+            // 1. resolveChannelId in EpgEvents (epg_channel_mappings)
+            .mockReturnValueOnce(resolveMapping)
+            // 2. getMapping in epg-query (epg_channel_mappings)
+            .mockReturnValueOnce(resolveMapping)
+            // 3. getMapping fallback (content table, still no mapping)
+            .mockReturnValueOnce(resolveMapping)
+            // 4. selectChannelPrograms (first attempt, returns [])
+            .mockReturnValueOnce(resolvePrograms([]))
+            // 5. selectChannelById (finds 'BBC.ONE.UK')
             .mockReturnValueOnce({
                 where: jest.fn().mockReturnValue({
                     limit: channelLimit,
                 }),
             })
-            .mockReturnValueOnce({
-                where: jest.fn().mockReturnValue({
-                    orderBy: jest.fn().mockResolvedValue([
-                        {
-                            id: 1,
-                            channelId: 'BBC.ONE.UK',
-                            start: '2026-04-14T10:00:00Z',
-                            stop: '2026-04-14T11:00:00Z',
-                            title: 'News',
-                            description: null,
-                            category: null,
-                            iconUrl: null,
-                            rating: null,
-                            episodeNum: null,
-                        },
-                    ]),
-                }),
-            });
+            // 6. selectChannelPrograms (second attempt, returns data)
+            .mockReturnValueOnce(resolvePrograms([
+                {
+                    id: 1,
+                    channelId: 'BBC.ONE.UK',
+                    start: '2026-04-14T10:00:00Z',
+                    stop: '2026-04-14T11:00:00Z',
+                    title: 'News',
+                    description: null,
+                    category: null,
+                    iconUrl: null,
+                    rating: null,
+                    episodeNum: null,
+                },
+            ]));
 
         select.mockImplementation(() => ({ from }));
 

--- a/apps/electron-backend/src/app/events/epg.events.spec.ts
+++ b/apps/electron-backend/src/app/events/epg.events.spec.ts
@@ -383,21 +383,19 @@ describe('EpgEvents', () => {
 
         const from = jest
             .fn()
-            // 1. resolveChannelId in EpgEvents (epg_channel_mappings)
+            // 1. getMapping in epg-query (epg_channel_mappings)
             .mockReturnValueOnce(resolveMapping)
-            // 2. getMapping in epg-query (epg_channel_mappings)
+            // 2. getMapping fallback (content table, still no mapping)
             .mockReturnValueOnce(resolveMapping)
-            // 3. getMapping fallback (content table, still no mapping)
-            .mockReturnValueOnce(resolveMapping)
-            // 4. selectChannelPrograms (first attempt, returns [])
+            // 3. selectChannelPrograms (first attempt, returns [])
             .mockReturnValueOnce(resolvePrograms([]))
-            // 5. selectChannelById (finds 'BBC.ONE.UK')
+            // 4. selectChannelById (finds 'BBC.ONE.UK')
             .mockReturnValueOnce({
                 where: jest.fn().mockReturnValue({
                     limit: channelLimit,
                 }),
             })
-            // 6. selectChannelPrograms (second attempt, returns data)
+            // 5. selectChannelPrograms (second attempt, returns data)
             .mockReturnValueOnce(resolvePrograms([
                 {
                     id: 1,

--- a/apps/electron-backend/src/app/events/epg.events.ts
+++ b/apps/electron-backend/src/app/events/epg.events.ts
@@ -340,8 +340,9 @@ export default class EpgEvents {
         channelId: string,
         options?: { sourceUrls?: string[] }
     ): Promise<EpgProgram[]> {
-        const resolvedId = await this.resolveChannelId(channelId);
-        return epgQueryService.getChannelPrograms(resolvedId, options);
+        // Mapping resolution is now in epg-query.service.ts getChannelPrograms
+        // via its own getMapping call — no need to resolve here.
+        return epgQueryService.getChannelPrograms(channelId, options);
     }
 
     private static async handleGetCurrentProgramsBatch(

--- a/apps/electron-backend/src/app/events/epg.events.ts
+++ b/apps/electron-backend/src/app/events/epg.events.ts
@@ -9,6 +9,13 @@ import { getDatabase } from '../database/connection';
 import * as schema from '../database/schema';
 import { epgQueryService } from './epg-query.service';
 import { epgWorkerService } from './epg-worker.service';
+import {
+    getEpgMapping,
+    getEpgMappingsBatch,
+    setEpgMapping,
+    deleteEpgMapping,
+    searchEpgChannels,
+} from '../database/operations/epg-mapping.operations';
 
 /**
  * EPG Events Handler
@@ -125,6 +132,52 @@ export default class EpgEvents {
                 return this.checkEpgFreshness(
                     args.urls,
                     args.maxAgeHours ?? 12
+                );
+            }
+        );
+
+        // EPG channel mapping CRUD
+        ipcMain.handle(
+            'EPG_MAPPING_GET',
+            async (_event, args: { channelKey: string }) => {
+                return this.handleGetEpgMapping(args.channelKey);
+            }
+        );
+
+        ipcMain.handle(
+            'EPG_MAPPING_SET',
+            async (
+                _event,
+                args: {
+                    channelKey: string;
+                    epgChannelId: string;
+                    playlistId?: string;
+                }
+            ) => {
+                return this.handleSetEpgMapping(
+                    args.channelKey,
+                    args.epgChannelId,
+                    args.playlistId
+                );
+            }
+        );
+
+        ipcMain.handle(
+            'EPG_MAPPING_DELETE',
+            async (_event, args: { channelKey: string }) => {
+                return this.handleDeleteEpgMapping(args.channelKey);
+            }
+        );
+
+        ipcMain.handle(
+            'EPG_CHANNEL_SEARCH',
+            async (
+                _event,
+                args: { searchTerm: string; limit?: number }
+            ) => {
+                return this.handleSearchEpgChannels(
+                    args.searchTerm,
+                    args.limit
                 );
             }
         );
@@ -287,14 +340,29 @@ export default class EpgEvents {
         channelId: string,
         options?: { sourceUrls?: string[] }
     ): Promise<EpgProgram[]> {
-        return epgQueryService.getChannelPrograms(channelId, options);
+        const resolvedId = await this.resolveChannelId(channelId);
+        return epgQueryService.getChannelPrograms(resolvedId, options);
     }
 
     private static async handleGetCurrentProgramsBatch(
         channelIds: string[],
         options?: { sourceUrls?: string[] }
     ): Promise<Record<string, EpgProgram | null>> {
-        return epgQueryService.getCurrentProgramsBatch(channelIds, options);
+        const resolvedMap = await this.resolveChannelIds(channelIds);
+        const resolvedIds = channelIds.map(
+            (id) => resolvedMap.get(id) ?? id
+        );
+        const results = await epgQueryService.getCurrentProgramsBatch(
+            resolvedIds,
+            options
+        );
+        // Remap results back to the original request keys.
+        const remapped: Record<string, EpgProgram | null> = {};
+        for (const originalId of channelIds) {
+            const resolvedId = resolvedMap.get(originalId) ?? originalId;
+            remapped[originalId] = results[resolvedId] ?? null;
+        }
+        return remapped;
     }
 
     private static async handleGetAllChannels(): Promise<{
@@ -308,7 +376,21 @@ export default class EpgEvents {
         channelIds: string[],
         options?: { sourceUrls?: string[] }
     ): Promise<Record<string, EpgChannelMetadata | null>> {
-        return epgQueryService.getChannelMetadata(channelIds, options);
+        const resolvedMap = await this.resolveChannelIds(channelIds);
+        const resolvedIds = channelIds.map(
+            (id) => resolvedMap.get(id) ?? id
+        );
+        const results = await epgQueryService.getChannelMetadata(
+            resolvedIds,
+            options
+        );
+        // Remap results back to the original request keys.
+        const remapped: Record<string, EpgChannelMetadata | null> = {};
+        for (const originalId of channelIds) {
+            const resolvedId = resolvedMap.get(originalId) ?? originalId;
+            remapped[originalId] = results[resolvedId] ?? null;
+        }
+        return remapped;
     }
 
     private static async handleGetChannelsByRange(
@@ -323,6 +405,97 @@ export default class EpgEvents {
         }>
     > {
         return epgQueryService.getChannelsByRange(skip, limit);
+    }
+
+    // ---------------------------------------------------------------------------
+    // EPG mapping resolution — called at the IPC boundary before queries.
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Resolve a single channel ID through manual mappings.
+     * Returns the mapped EPG channel ID when a mapping exists, or the original.
+     */
+    private static async resolveChannelId(
+        channelId: string
+    ): Promise<string> {
+        try {
+            const db = await getDatabase();
+            const mapping = await getEpgMapping(db, channelId);
+            return mapping?.epgChannelId ?? channelId;
+        } catch {
+            return channelId;
+        }
+    }
+
+    /**
+     * Batch-resolve multiple channel IDs through manual mappings.
+     * Returns a Map of original ID → mapped ID (identity when no mapping).
+     */
+    private static async resolveChannelIds(
+        channelIds: string[]
+    ): Promise<Map<string, string>> {
+        try {
+            const db = await getDatabase();
+            const mappings = await getEpgMappingsBatch(db, channelIds);
+            return mappings;
+        } catch {
+            return new Map();
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // EPG mapping CRUD handlers
+    // ---------------------------------------------------------------------------
+
+    private static async handleGetEpgMapping(
+        channelKey: string
+    ): Promise<{ id: number; channelKey: string; epgChannelId: string; playlistId: string | null } | null> {
+        try {
+            const db = await getDatabase();
+            return getEpgMapping(db, channelKey);
+        } catch {
+            return null;
+        }
+    }
+
+    private static async handleSetEpgMapping(
+        channelKey: string,
+        epgChannelId: string,
+        playlistId?: string
+    ): Promise<{ success: boolean }> {
+        try {
+            const db = await getDatabase();
+            return setEpgMapping(db, channelKey, epgChannelId, playlistId);
+        } catch {
+            return { success: false };
+        }
+    }
+
+    private static async handleDeleteEpgMapping(
+        channelKey: string
+    ): Promise<{ success: boolean }> {
+        try {
+            const db = await getDatabase();
+            return deleteEpgMapping(db, channelKey);
+        } catch {
+            return { success: false };
+        }
+    }
+
+    private static async handleSearchEpgChannels(
+        searchTerm: string,
+        limit?: number
+    ): Promise<Array<{ id: string; displayName: string; iconUrl: string | null }>> {
+        if (!searchTerm?.trim()) {
+            return [];
+        }
+
+        try {
+            const db = await getDatabase();
+            return searchEpgChannels(db, searchTerm, limit);
+        } catch {
+            return [];
+        }
     }
 
     static async clearEpgData(): Promise<void> {

--- a/apps/web/src/assets/i18n/en.json
+++ b/apps/web/src/assets/i18n/en.json
@@ -622,7 +622,7 @@
     },
     "EPG_MAPPING_DIALOG": {
         "TITLE": "Map EPG Channel",
-        "SUBTITLE": "Manually select an EPG channel for \"{channelName}\"",
+        "SUBTITLE": "Manually select an EPG channel for \"{{channelName}}\"",
         "SEARCH_PLACEHOLDER": "Search EPG channels...",
         "CURRENT_MAPPING": "Current mapping",
         "NO_MAPPING": "No EPG mapping set",

--- a/apps/web/src/assets/i18n/en.json
+++ b/apps/web/src/assets/i18n/en.json
@@ -499,6 +499,7 @@
         "REMOVE_FAVORITE": "Remove from favorites",
         "ADD_FAVORITE": "Add to favorites",
         "SHOW_DETAILS": "Show channel details",
+        "MAP_EPG": "Map EPG channel",
         "FAVORITES_UPDATED": "Favorites were updated!",
         "SELECT_CHANNEL_PLAYBACK": "Please select a channel to start playback",
         "SORT_BY": "Sort by",
@@ -618,6 +619,17 @@
         "RETURN_TO_LIVE": "Return to live",
         "COLLAPSE_PANEL": "Collapse EPG panel",
         "EXPAND_PANEL": "Expand EPG panel"
+    },
+    "EPG_MAPPING_DIALOG": {
+        "TITLE": "Map EPG Channel",
+        "SUBTITLE": "Manually select an EPG channel for \"{channelName}\"",
+        "SEARCH_PLACEHOLDER": "Search EPG channels...",
+        "CURRENT_MAPPING": "Current mapping",
+        "NO_MAPPING": "No EPG mapping set",
+        "SAVE": "Save mapping",
+        "REMOVE": "Remove mapping",
+        "CLOSE": "Close",
+        "NO_RESULTS": "No EPG channels found"
     },
     "LANGUAGES": {
         "ARABIC": "العربية",

--- a/libs/epg/data-access/src/lib/epg-runtime-bridge.service.ts
+++ b/libs/epg/data-access/src/lib/epg-runtime-bridge.service.ts
@@ -1,14 +1,16 @@
 import { inject, Injectable } from '@angular/core';
 import {
+    ELECTRON_BRIDGE_EPG_PROGRESS_STATUSES,
     ElectronBridgeApi,
     ElectronBridgeEpgFetchResult,
+    ElectronBridgeEpgMapping,
     ElectronBridgeEpgProgress,
     ElectronBridgeEpgProgressStats,
     ElectronBridgeEpgProgressStatus,
+    ElectronBridgeEpgSearchResult,
     ElectronBridgeEpgChannelWithPrograms,
     ElectronBridgeEpgFreshnessResult,
     ElectronBridgeEpgLookupOptions,
-    ELECTRON_BRIDGE_EPG_PROGRESS_STATUSES,
     ElectronBridgeResult,
     ElectronBridgeTrustOptions,
     EpgChannelMetadata,
@@ -38,6 +40,10 @@ type EpgElectronBridge = Pick<
     | 'getEpgChannelsByRange'
     | 'onEpgProgress'
     | 'searchEpgPrograms'
+    | 'getEpgMapping'
+    | 'setEpgMapping'
+    | 'deleteEpgMapping'
+    | 'searchEpgChannels'
 >;
 
 @Injectable({ providedIn: 'root' })
@@ -78,6 +84,10 @@ export class EpgRuntimeBridgeService {
 
     get supportsProgramSearch(): boolean {
         return this.runtime.supportsEpgProgramSearch;
+    }
+
+    get supportsEpgMapping(): boolean {
+        return this.runtime.supportsEpgMapping;
     }
 
     fetchEpg(
@@ -217,6 +227,53 @@ export class EpgRuntimeBridgeService {
 
         return (
             this.bridge?.searchEpgPrograms?.(searchTerm, limit) ??
+            Promise.resolve(null)
+        );
+    }
+
+    getEpgMapping(
+        channelKey: string
+    ): Promise<ElectronBridgeEpgMapping | null> {
+        if (!this.supportsEpgMapping) {
+            return Promise.resolve(null);
+        }
+
+        return this.bridge?.getEpgMapping?.(channelKey) ?? Promise.resolve(null);
+    }
+
+    setEpgMapping(
+        channelKey: string,
+        epgChannelId: string,
+        playlistId?: string
+    ): Promise<ElectronBridgeResult | null> {
+        if (!this.supportsEpgMapping) {
+            return Promise.resolve(null);
+        }
+
+        return (
+            this.bridge?.setEpgMapping?.(channelKey, epgChannelId, playlistId) ??
+            Promise.resolve(null)
+        );
+    }
+
+    deleteEpgMapping(channelKey: string): Promise<ElectronBridgeResult | null> {
+        if (!this.supportsEpgMapping) {
+            return Promise.resolve(null);
+        }
+
+        return this.bridge?.deleteEpgMapping?.(channelKey) ?? Promise.resolve(null);
+    }
+
+    searchEpgChannels(
+        searchTerm: string,
+        limit?: number
+    ): Promise<ElectronBridgeEpgSearchResult[] | null> {
+        if (!this.supportsEpgMapping) {
+            return Promise.resolve(null);
+        }
+
+        return (
+            this.bridge?.searchEpgChannels?.(searchTerm, limit) ??
             Promise.resolve(null)
         );
     }

--- a/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.spec.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.spec.ts
@@ -31,6 +31,7 @@ describe('StreamResolverService', () => {
             getPlaylistById: jest.fn(),
         };
         xtreamApi = {
+            getFullEpg: jest.fn(),
             getShortEpg: jest.fn(),
         };
         xtreamUrl = {
@@ -228,6 +229,7 @@ describe('StreamResolverService', () => {
         xtreamUrl.constructLiveUrl.mockReturnValue(
             'https://xtream.example.com/live/1'
         );
+        xtreamApi.getFullEpg.mockResolvedValue([]);
         xtreamApi.getShortEpg.mockResolvedValue([
             {
                 id: '1',
@@ -267,7 +269,7 @@ describe('StreamResolverService', () => {
                 password: 'pass',
             },
             1,
-            10,
+            50,
             {
                 suppressErrorLog: true,
             }
@@ -317,6 +319,7 @@ describe('StreamResolverService', () => {
                 password: 'pass',
             } satisfies Partial<Playlist>)
         );
+        xtreamApi.getFullEpg.mockResolvedValue([]);
         xtreamApi.getShortEpg.mockResolvedValue([]);
 
         const items = [
@@ -361,6 +364,7 @@ describe('StreamResolverService', () => {
         xtreamUrl.constructLiveUrl.mockReturnValue(
             'https://xtream.example.com/live/1'
         );
+        xtreamApi.getFullEpg.mockRejectedValue(new Error('EPG failed'));
         xtreamApi.getShortEpg.mockRejectedValue(new Error('EPG failed'));
 
         const item = {
@@ -431,7 +435,7 @@ describe('StreamResolverService', () => {
                 xtreamId: 1,
             } satisfies UnifiedCollectionItem);
 
-            await jest.advanceTimersByTimeAsync(3000);
+            await jest.advanceTimersByTimeAsync(10000);
 
             await expect(detailPromise).resolves.toMatchObject({
                 epgMode: 'portal',

--- a/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.spec.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.spec.ts
@@ -45,6 +45,7 @@ describe('StreamResolverService', () => {
         };
         epgBridge = {
             getChannelPrograms: jest.fn(),
+            getEpgMapping: jest.fn().mockResolvedValue(null),
             supportsProgramLookup: true,
         };
 
@@ -345,7 +346,7 @@ describe('StreamResolverService', () => {
                 password: 'pass',
             },
             1,
-            2,
+            5,
             {
                 suppressErrorLog: true,
             }

--- a/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
@@ -410,6 +410,20 @@ export class StreamResolverService {
                 return [];
             }
 
+            // Check uploaded XMLTV EPG first using the provider's EPG channel
+            // identifier (epg_channel_id from the content table), not the
+            // xtream_id. This respects the user's preferUploadedEpgOverXtream
+            // setting the same way the main live-view loadEpg() does.
+            const epgKey = item.epgChannelId?.trim();
+            if (this.supportsProgramLookup && epgKey) {
+                const uploaded = await this.epgBridge
+                    .getChannelPrograms(epgKey)
+                    .catch(() => null);
+                if (uploaded && uploaded.length > 0) {
+                    return this.mapProgramsToEpgItems(uploaded);
+                }
+            }
+
             // Try the full EPG endpoint first (same as the main live-view
             // loadEpg() in with-epg.feature.ts) — many providers only
             // support get_simple_data_table, not get_short_epg.
@@ -584,19 +598,40 @@ export class StreamResolverService {
                 }
 
                 try {
-                    const items = await this.fetchXtreamEpgItems(
-                        playlistId,
-                        creds,
-                        channel.xtreamId,
-                        2
-                    );
                     const nowSeconds = Math.floor(now / 1000);
-                    const currentItem =
-                        items.find(
-                            (item) =>
-                                Number(item.start_timestamp) <= nowSeconds &&
-                                nowSeconds < Number(item.stop_timestamp)
-                        ) ?? null;
+                    let currentItem: EpgItem | null = null;
+
+                    // Check uploaded XMLTV EPG first.
+                    const epgChannelKey = channel.epgChannelId?.trim();
+                    if (this.supportsProgramLookup && epgChannelKey) {
+                        const uploaded = await this.epgBridge
+                            .getChannelPrograms(epgChannelKey)
+                            .catch(() => null);
+                        if (uploaded && uploaded.length > 0) {
+                            const items = this.mapProgramsToEpgItems(uploaded);
+                            currentItem =
+                                items.find(
+                                    (item) =>
+                                        Number(item.start_timestamp) <= nowSeconds &&
+                                        nowSeconds < Number(item.stop_timestamp)
+                                ) ?? null;
+                        }
+                    }
+
+                    if (!currentItem) {
+                        const items = await this.fetchXtreamEpgItems(
+                            playlistId,
+                            creds,
+                            channel.xtreamId,
+                            2
+                        );
+                        currentItem =
+                            items.find(
+                                (item) =>
+                                    Number(item.start_timestamp) <= nowSeconds &&
+                                    nowSeconds < Number(item.stop_timestamp)
+                            ) ?? null;
+                    }
                     const epgKey =
                         channel.tvgId?.trim() || channel.name?.trim();
 

--- a/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import { DataService, PlaylistsService } from '@iptvnator/services';
+import { DataService, PlaylistsService, SettingsStore } from '@iptvnator/services';
 import { EpgRuntimeBridgeService } from '@iptvnator/epg/data-access';
 import {
     Channel,
@@ -60,6 +60,7 @@ export class StreamResolverService {
     private readonly xtreamApi = inject(XtreamApiService);
     private readonly xtreamUrl = inject(XtreamUrlService);
     private readonly dataService = inject(DataService);
+    private readonly settingsStore = inject(SettingsStore);
     private readonly epgBridge = inject(EpgRuntimeBridgeService);
     private readonly stalkerSession = inject(StalkerSessionService);
     private readonly m3uEpgTimeoutMs = 3000;
@@ -410,9 +411,13 @@ export class StreamResolverService {
                 return [];
             }
 
-            // 1) Check uploaded XMLTV EPG via the provider's epg_channel_id.
+            // 1) Check uploaded XMLTV EPG via the provider's epg_channel_id,
+            //    but only when the user has opted into it — the setting defaults
+            //    to false (prefer Xtream API), matching the live-view loadEpg().
+            const preferXmltv =
+                this.settingsStore.preferUploadedEpgOverXtream?.() ?? false;
             const epgKey = item.epgChannelId?.trim();
-            if (this.supportsProgramLookup && epgKey) {
+            if (preferXmltv && this.supportsProgramLookup && epgKey) {
                 const uploaded = await this.epgBridge
                     .getChannelPrograms(epgKey)
                     .catch(() => null);

--- a/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
@@ -63,7 +63,7 @@ export class StreamResolverService {
     private readonly epgBridge = inject(EpgRuntimeBridgeService);
     private readonly stalkerSession = inject(StalkerSessionService);
     private readonly m3uEpgTimeoutMs = 3000;
-    private readonly portalEpgTimeoutMs = 3000;
+    private readonly portalEpgTimeoutMs = 10000;
     private readonly xtreamEpgCache = new Map<string, XtreamEpgCacheEntry>();
     private readonly xtreamEpgFailureTimestamps = new Map<string, number>();
     private readonly xtreamEpgCacheTtlMs = 60 * 1000;
@@ -410,11 +410,28 @@ export class StreamResolverService {
                 return [];
             }
 
+            // Try the full EPG endpoint first (same as the main live-view
+            // loadEpg() in with-epg.feature.ts) — many providers only
+            // support get_simple_data_table, not get_short_epg.
+            try {
+                const fullEpg = await this.xtreamApi.getFullEpg(
+                    creds,
+                    item.xtreamId,
+                    { suppressErrorLog: true }
+                );
+                if (fullEpg.length > 0) {
+                    return fullEpg;
+                }
+            } catch {
+                // getFullEpg failed — continue to short-EPG fallback below.
+            }
+
+            // Fall back to the short-EPG endpoint with a generous limit.
             return await this.fetchXtreamEpgItems(
                 item.playlistId,
                 creds,
                 item.xtreamId,
-                10
+                50
             );
         } catch {
             return [];

--- a/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
@@ -67,7 +67,7 @@ export class StreamResolverService {
     private readonly xtreamEpgCache = new Map<string, XtreamEpgCacheEntry>();
     private readonly xtreamEpgFailureTimestamps = new Map<string, number>();
     private readonly xtreamEpgCacheTtlMs = 60 * 1000;
-    private readonly xtreamEpgFailureCooldownMs = 60 * 1000;
+    private readonly xtreamEpgFailureCooldownMs = 30 * 1000;
 
     private get supportsProgramLookup(): boolean {
         return this.epgBridge.supportsProgramLookup;
@@ -410,10 +410,7 @@ export class StreamResolverService {
                 return [];
             }
 
-            // Check uploaded XMLTV EPG first using the provider's EPG channel
-            // identifier (epg_channel_id from the content table), not the
-            // xtream_id. This respects the user's preferUploadedEpgOverXtream
-            // setting the same way the main live-view loadEpg() does.
+            // 1) Check uploaded XMLTV EPG via the provider's epg_channel_id.
             const epgKey = item.epgChannelId?.trim();
             if (this.supportsProgramLookup && epgKey) {
                 const uploaded = await this.epgBridge
@@ -424,7 +421,22 @@ export class StreamResolverService {
                 }
             }
 
-            // Try the full EPG endpoint first (same as the main live-view
+            // 2) Fall back to manual mapping table (xtream_id → epgChannelId).
+            if (this.supportsProgramLookup && item.xtreamId) {
+                const mapping = await this.epgBridge
+                    .getEpgMapping(String(item.xtreamId))
+                    .catch(() => null);
+                if (mapping?.epgChannelId) {
+                    const mapped = await this.epgBridge
+                        .getChannelPrograms(mapping.epgChannelId)
+                        .catch(() => null);
+                    if (mapped && mapped.length > 0) {
+                        return this.mapProgramsToEpgItems(mapped);
+                    }
+                }
+            }
+
+            // 3) Try the full EPG endpoint (same as the main live-view
             // loadEpg() in with-epg.feature.ts) — many providers only
             // support get_simple_data_table, not get_short_epg.
             try {
@@ -591,30 +603,50 @@ export class StreamResolverService {
             return;
         }
 
-        await Promise.all(
-            channels.map(async (channel) => {
-                if (!channel.xtreamId) {
-                    return;
-                }
+        // Limit concurrency to avoid overwhelming the provider with
+        // simultaneous EPG requests when loading a large channel list.
+        const concurrency = 3;
+        const pending: Promise<void>[] = [];
+        const iterator = channels.entries();
+
+        const enqueueNext = async (): Promise<void> => {
+            for (;;) {
+                const entry = iterator.next();
+                if (entry.done) return;
+                const [, channel] = entry.value;
+                if (!channel.xtreamId) continue;
 
                 try {
                     const nowSeconds = Math.floor(now / 1000);
                     let currentItem: EpgItem | null = null;
 
-                    // Check uploaded XMLTV EPG first.
+                    // 1) Try uploaded XMLTV EPG via the provider's epg_channel_id.
                     const epgChannelKey = channel.epgChannelId?.trim();
                     if (this.supportsProgramLookup && epgChannelKey) {
-                        const uploaded = await this.epgBridge
-                            .getChannelPrograms(epgChannelKey)
-                            .catch(() => null);
-                        if (uploaded && uploaded.length > 0) {
-                            const items = this.mapProgramsToEpgItems(uploaded);
-                            currentItem =
-                                items.find(
-                                    (item) =>
-                                        Number(item.start_timestamp) <= nowSeconds &&
-                                        nowSeconds < Number(item.stop_timestamp)
-                                ) ?? null;
+                        currentItem = await this.findCurrentInXmltv(
+                            epgChannelKey, nowSeconds
+                        );
+                    }
+
+                    // 2) Fall back to manual mapping (epg_channel_mappings table).
+                    // Try all possible keys the user might have used when saving:
+                    // xtream_id (from favorites dialog), tvgId, name.
+                    if (!currentItem && this.supportsProgramLookup) {
+                        const candidateKeys = [
+                            channel.xtreamId ? String(channel.xtreamId) : null,
+                            channel.tvgId?.trim() || null,
+                            channel.name?.trim() || null,
+                        ].filter(Boolean);
+                        for (const key of candidateKeys) {
+                            const mapping = await this.epgBridge
+                                .getEpgMapping(key!)
+                                .catch(() => null);
+                            if (mapping?.epgChannelId) {
+                                currentItem = await this.findCurrentInXmltv(
+                                    mapping.epgChannelId, nowSeconds
+                                );
+                                if (currentItem) break;
+                            }
                         }
                     }
 
@@ -623,7 +655,7 @@ export class StreamResolverService {
                             playlistId,
                             creds,
                             channel.xtreamId,
-                            2
+                            5
                         );
                         currentItem =
                             items.find(
@@ -663,8 +695,14 @@ export class StreamResolverService {
                         epgMap.set(epgKey, null);
                     }
                 }
-            })
-        );
+            }
+        };
+
+        // Start limited concurrent workers.
+        for (let i = 0; i < concurrency; i++) {
+            pending.push(enqueueNext());
+        }
+        await Promise.all(pending);
     }
 
     private getXtreamEpgCacheKey(
@@ -974,5 +1012,23 @@ export class StreamResolverService {
 
     private isHttpUrl(value: string): boolean {
         return value.startsWith('http://') || value.startsWith('https://');
+    }
+
+    /** Look up the current program for an EPG channel ID from uploaded XMLTV. */
+    private async findCurrentInXmltv(
+        epgChannelId: string,
+        nowSeconds: number
+    ): Promise<EpgItem | null> {
+        if (!this.supportsProgramLookup || !epgChannelId) return null;
+        const programs = await this.epgBridge
+            .getChannelPrograms(epgChannelId)
+            .catch(() => null);
+        if (!programs || programs.length === 0) return null;
+        const items = this.mapProgramsToEpgItems(programs);
+        return items.find(
+            (item) =>
+                Number(item.start_timestamp) <= nowSeconds &&
+                nowSeconds < Number(item.stop_timestamp)
+        ) ?? null;
     }
 }

--- a/libs/portal/shared/data-access/src/lib/collection/unified-favorites-data.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/unified-favorites-data.service.ts
@@ -611,6 +611,7 @@ export class UnifiedFavoritesDataService {
             rating: row.rating ?? undefined,
             tvArchive: row.tv_archive ?? null,
             tvArchiveDuration: row.tv_archive_duration ?? null,
+            epgChannelId: row.epg_channel_id ?? null,
             addedAt:
                 normalizeStalkerDate(row.added_at) || new Date(0).toISOString(),
             position: row.position ?? 0,
@@ -639,6 +640,7 @@ export class UnifiedFavoritesDataService {
             rating: item.rating ?? undefined,
             tvArchive: item.tv_archive ?? null,
             tvArchiveDuration: item.tv_archive_duration ?? null,
+            epgChannelId: item.epg_channel_id ?? null,
             addedAt:
                 normalizeStalkerDate(item.added_at ?? item.added) ||
                 new Date(0).toISOString(),

--- a/libs/portal/shared/data-access/src/lib/collection/unified-favorites-data.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/unified-favorites-data.service.ts
@@ -609,6 +609,8 @@ export class UnifiedFavoritesDataService {
             categoryId: row.category_id,
             tvgId: ct === 'live' ? String(row.xtream_id) : undefined,
             rating: row.rating ?? undefined,
+            tvArchive: row.tv_archive ?? null,
+            tvArchiveDuration: row.tv_archive_duration ?? null,
             addedAt:
                 normalizeStalkerDate(row.added_at) || new Date(0).toISOString(),
             position: row.position ?? 0,
@@ -635,6 +637,8 @@ export class UnifiedFavoritesDataService {
             categoryId: item.category_id,
             tvgId: ct === 'live' ? String(item.xtream_id) : undefined,
             rating: item.rating ?? undefined,
+            tvArchive: item.tv_archive ?? null,
+            tvArchiveDuration: item.tv_archive_duration ?? null,
             addedAt:
                 normalizeStalkerDate(item.added_at ?? item.added) ||
                 new Date(0).toISOString(),

--- a/libs/portal/shared/data-access/src/lib/collection/unified-favorites-data.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/unified-favorites-data.service.ts
@@ -261,6 +261,20 @@ export class UnifiedFavoritesDataService {
         if (
             options?.scope === 'playlist' &&
             options.playlistId &&
+            options.portalType === 'xtream'
+        ) {
+            const electron = this.electronActivityBridge;
+            const updates = this.buildXtreamPositionUpdates(items);
+            if (updates.length > 0 && electron) {
+                await electron.dbReorderGlobalFavorites(updates);
+            }
+            await this.saveOrder(items.map((item) => item.uid));
+            return;
+        }
+
+        if (
+            options?.scope === 'playlist' &&
+            options.playlistId &&
             options.portalType === 'stalker'
         ) {
             const playlist = (await firstValueFrom(
@@ -559,11 +573,19 @@ export class UnifiedFavoritesDataService {
             }
 
             const rows = await this.dbService.getFavorites(playlistId);
-            return (rows as unknown as XtreamFavoriteRow[]).map((r) => ({
-                ...this.mapXtreamRow(r),
-                playlistId,
-                playlistName: meta?.title || 'Xtream',
-            }));
+            const items = (rows as unknown as XtreamFavoriteRow[]).map(
+                (r) => ({
+                    ...this.mapXtreamRow(r),
+                    playlistId,
+                    playlistName: meta?.title || 'Xtream',
+                })
+            );
+
+            // Apply saved UID order so drag-drop reorder persists.
+            const order = await this.getSavedOrder();
+            return order.length > 0
+                ? this.applyOrder(items, order)
+                : items;
         } catch {
             return [];
         }

--- a/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.html
+++ b/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.html
@@ -61,6 +61,10 @@
 ></div>
 
 <mat-menu #channelContextMenu="matMenu">
+    <button mat-menu-item (click)="openEpgMapping()">
+        <mat-icon>settings_remote</mat-icon>
+        <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
+    </button>
     @if (contextMenuChannel()?.m3uChannel) {
         <button mat-menu-item (click)="openChannelDetails()">
             <mat-icon>info</mat-icon>

--- a/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.ts
+++ b/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.ts
@@ -22,6 +22,8 @@ import {
 } from '@iptvnator/ui/components';
 import { SettingsStore } from '@iptvnator/services';
 import { EpgProgram } from '@iptvnator/shared/interfaces';
+import { resolveChannelEpgLookupKey } from '@iptvnator/m3u-state';
+import { EpgMappingDialogComponent } from '@iptvnator/ui/components';
 import {
     DEFAULT_FAVORITES_CHANNEL_SORT_MODE,
     FavoritesChannelSortMode,
@@ -163,7 +165,33 @@ export class GlobalFavoritesListComponent {
     }
 
     hasChannelContextMenu(channel: UnifiedFavoriteChannel): boolean {
-        return Boolean(channel.m3uChannel) || this.mode() === 'recent';
+        return (
+            Boolean(channel.m3uChannel) ||
+            this.mode() === 'recent' ||
+            Boolean(channel.xtreamId)
+        );
+    }
+
+    openEpgMapping(): void {
+        const item = this.contextMenuChannel();
+        if (!item) return;
+
+        this.contextMenuTrigger().closeMenu();
+        const channelKey =
+            item.m3uChannel
+                ? resolveChannelEpgLookupKey(item.m3uChannel)
+                : (item.xtreamId ? String(item.xtreamId) : null);
+        if (!channelKey) return;
+
+        this.dialog.open(EpgMappingDialogComponent, {
+            data: {
+                channelKey,
+                channelName: item.name,
+                currentMapping: null,
+            },
+            width: '500px',
+            maxHeight: '90vh',
+        });
     }
 
     openChannelDetails(): void {

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-catchup.service.ts
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-catchup.service.ts
@@ -1,0 +1,163 @@
+import { inject, Injectable, signal } from '@angular/core';
+import { EpgRuntimeBridgeService } from '@iptvnator/epg/data-access';
+import { PlaylistsService } from '@iptvnator/services';
+import { EpgItem, EpgProgram, Playlist } from '@iptvnator/shared/interfaces';
+import {
+    resolveM3uCatchupUrl,
+} from '@iptvnator/shared/m3u-utils';
+import { XtreamUrlService } from '@iptvnator/portal/xtream/data-access';
+import {
+    EpgProgramActivationEvent,
+} from '@iptvnator/ui/epg';
+import {
+    ResolvedLiveCollectionDetail,
+    StreamResolverService,
+} from '@iptvnator/portal/shared/data-access';
+import {
+    UnifiedCollectionItem,
+} from '@iptvnator/portal/shared/util';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class UnifiedLiveCatchupService {
+    private readonly streamResolver = inject(StreamResolverService);
+    private readonly xtreamUrlService = inject(XtreamUrlService);
+    private readonly playlistsService = inject(PlaylistsService);
+    private readonly epgBridge = inject(EpgRuntimeBridgeService);
+
+    readonly activeItem = signal<UnifiedCollectionItem | null>(null);
+
+    /** Portal EPG items converted to EpgProgram for the interactive list component. */
+    epgItemsToPrograms(items: EpgItem[]): EpgProgram[] {
+        return items.map((item) => ({
+            start: item.start,
+            stop: item.stop ?? item.end,
+            channel: item.channel_id ?? item.id,
+            title: item.title,
+            desc: item.description ?? null,
+            category: null,
+            startTimestamp: this.parseEpgTimestamp(item.start_timestamp),
+            stopTimestamp: this.parseEpgTimestamp(item.stop_timestamp),
+        }));
+    }
+
+    /** Archive window (days) for the selected portal stream, or 0 if unavailable. */
+    portalArchiveDays(item: UnifiedCollectionItem | null): number {
+        if (!item?.xtreamId) return 0;
+        if (item.tvArchive === 0) return 0;
+        if (item.tvArchiveDuration != null && item.tvArchiveDuration !== 0) {
+            return Math.max(0, Number(item.tvArchiveDuration));
+        }
+        return 0;
+    }
+
+    async onProgramActivated(
+        event: EpgProgramActivationEvent,
+        detail: ResolvedLiveCollectionDetail | null,
+        item: UnifiedCollectionItem | null
+    ): Promise<ResolvedLiveCollectionDetail | null> {
+        if (!detail) return null;
+
+        if (event.type === 'live') {
+            return item
+                ? await this.streamResolver.resolveLiveDetail(item)
+                : null;
+        }
+
+        // M3U catchup
+        if (detail.epgMode === 'm3u' && detail.channel) {
+            const catchupUrl = resolveM3uCatchupUrl(
+                detail.channel,
+                event.program
+            );
+            if (!catchupUrl) return null;
+            return {
+                ...detail,
+                playback: { ...detail.playback, streamUrl: catchupUrl },
+            };
+        }
+
+        // Xtream catchup
+        if (!item?.xtreamId) return null;
+
+        try {
+            const credentials = await this.getXtreamCredentials(
+                item.playlistId
+            );
+            if (!credentials) return null;
+
+            const startTimestamp = this.parseEpochSeconds(
+                event.program.startTimestamp,
+                event.program.start
+            );
+            const stopTimestamp = this.parseEpochSeconds(
+                event.program.stopTimestamp,
+                event.program.stop
+            );
+            if (startTimestamp == null || stopTimestamp == null) return null;
+
+            const catchupUrl = await this.xtreamUrlService.resolveCatchupUrl(
+                item.playlistId,
+                credentials,
+                item.xtreamId,
+                startTimestamp,
+                stopTimestamp
+            );
+            if (!catchupUrl) return null;
+            return {
+                ...detail,
+                playback: { ...detail.playback, streamUrl: catchupUrl },
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    private parseEpgTimestamp(value: string | undefined): number | undefined {
+        const parsed = Number.parseInt(String(value ?? ''), 10);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+    }
+
+    private parseEpochSeconds(
+        timestamp: number | string | null | undefined,
+        fallbackIso: string
+    ): number | null {
+        const parsed = Number.parseInt(String(timestamp ?? ''), 10);
+        if (Number.isFinite(parsed) && parsed > 0) return parsed;
+        const ms = Date.parse(fallbackIso);
+        return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
+    }
+
+    private async getXtreamCredentials(
+        playlistId: string
+    ): Promise<{
+        serverUrl: string;
+        username: string;
+        password: string;
+    } | null> {
+        const electronPlaylist =
+            typeof window !== 'undefined'
+                ? await window.electron?.dbGetAppPlaylist?.(playlistId)
+                : null;
+        const playlist: Playlist | null =
+            electronPlaylist ??
+            (await firstValueFrom(
+                this.playlistsService.getPlaylistById(playlistId)
+            ));
+
+        if (
+            !playlist ||
+            !playlist.serverUrl ||
+            !playlist.username ||
+            !playlist.password
+        ) {
+            return null;
+        }
+
+        return {
+            serverUrl: playlist.serverUrl,
+            username: playlist.username,
+            password: playlist.password,
+        };
+    }
+}

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.html
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.html
@@ -80,7 +80,7 @@
                     <app-live-epg-panel
                         [collapsed]="isLiveEpgPanelCollapsed()"
                         [summary]="liveEpgPanelSummary()"
-                        [showDateNavigator]="isM3uSelection()"
+                        [showDateNavigator]="true"
                         [selectedDate]="selectedLiveEpgDate()"
                         (collapsedChange)="
                             onLiveEpgPanelCollapsedChange($event)
@@ -102,8 +102,21 @@
                                     "
                                 />
                             } @else {
-                                <app-epg-view
-                                    [epgItems]="currentPortalEpgItems()"
+                                <app-epg-list
+                                    [controlledPrograms]="
+                                        currentPortalEpgPrograms()
+                                    "
+                                    [controlledArchiveDays]="
+                                        currentPortalArchiveDays()
+                                    "
+                                    [selectedDate]="selectedLiveEpgDate()"
+                                    [showDateNavigator]="false"
+                                    (selectedDateChange)="
+                                        onLiveEpgSelectedDateChange($event)
+                                    "
+                                    (programActivated)="
+                                        onProgramActivated($event)
+                                    "
                                 />
                             }
                         </div>
@@ -117,10 +130,21 @@
                                 [archivePlaybackAvailable]="
                                     currentM3uArchivePlaybackAvailable()
                                 "
+                                (programActivated)="
+                                    onProgramActivated($event)
+                                "
                             />
                         } @else {
-                            <app-epg-view
-                                [epgItems]="currentPortalEpgItems()"
+                            <app-epg-list
+                                [controlledPrograms]="
+                                    currentPortalEpgPrograms()
+                                "
+                                [controlledArchiveDays]="
+                                    currentPortalArchiveDays()
+                                "
+                                (programActivated)="
+                                    onProgramActivated($event)
+                                "
                             />
                         }
                     </div>

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.html
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.html
@@ -80,12 +80,15 @@
                     <app-live-epg-panel
                         [collapsed]="isLiveEpgPanelCollapsed()"
                         [summary]="liveEpgPanelSummary()"
+                        [summaryLabelKey]="archiveLabelKey()"
+                        [showReturnToLive]="showReturnToLive()"
                         [showDateNavigator]="true"
                         [selectedDate]="selectedLiveEpgDate()"
                         (collapsedChange)="
                             onLiveEpgPanelCollapsedChange($event)
                         "
                         (dateNavigation)="onLiveEpgDateNavigation($event)"
+                        (returnToLive)="returnToLive()"
                     >
                         <div class="epg-content">
                             @if (isM3uSelection()) {

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.spec.ts
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.spec.ts
@@ -23,7 +23,9 @@ import {
     shiftEpgDateKey,
 } from '@iptvnator/ui/epg';
 import { ResizableDirective } from '@iptvnator/ui/components';
+import { XtreamUrlService } from '@iptvnator/portal/xtream/data-access';
 import {
+    PlaylistsService,
     RuntimeCapabilitiesService,
     SettingsStore,
 } from '@iptvnator/services';
@@ -35,7 +37,6 @@ import {
     VideoPlayer,
 } from '@iptvnator/shared/interfaces';
 import {
-    EpgViewComponent,
     LiveEpgPanelComponent,
     LiveEpgPanelSummary,
 } from '@iptvnator/ui/shared-portals';
@@ -93,19 +94,13 @@ class StubGlobalFavoritesListComponent {
 class StubEpgListComponent {
     readonly controlledChannel = input<Channel | null>(null);
     readonly controlledPrograms = input<EpgProgram[] | null>(null);
+    readonly controlledArchiveDays = input<number | null>(null);
     readonly archivePlaybackAvailable = input<boolean | null>(null);
+    readonly activeProgram = input<EpgProgram | null>(null);
     readonly selectedDate = input<string | null>(null);
     readonly showDateNavigator = input(true);
     readonly selectedDateChange = output<string>();
-}
-
-@Component({
-    selector: 'app-epg-view',
-    template: '<div class="stub-epg-view"></div>',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class StubEpgViewComponent {
-    readonly epgItems = input<EpgItem[]>([]);
+    readonly programActivated = output<{ program: EpgProgram; type: 'live' | 'timeshift' }>();
 }
 
 @Component({
@@ -165,6 +160,9 @@ describe('UnifiedLiveTabComponent', () => {
         openResolvedPlayback: jest.Mock;
         openExternalPlayback: jest.Mock;
     };
+    let playlistsService: {
+        getPlaylistById: jest.Mock;
+    };
     const originalElectron = window.electron;
 
     beforeEach(async () => {
@@ -183,6 +181,15 @@ describe('UnifiedLiveTabComponent', () => {
         recentData = {
             recordLivePlayback: jest.fn(),
         };
+        playlistsService = {
+            getPlaylistById: jest.fn().mockResolvedValue({
+                _id: 'playlist-1',
+                title: 'Test Playlist',
+                serverUrl: 'http://demo.example',
+                username: 'demo',
+                password: 'secret',
+            }),
+        };
         player = signal(VideoPlayer.VideoJs);
         portalPlayer = {
             isEmbeddedPlayer: jest.fn().mockReturnValue(false),
@@ -195,6 +202,7 @@ describe('UnifiedLiveTabComponent', () => {
             providers: [
                 { provide: StreamResolverService, useValue: streamResolver },
                 { provide: UnifiedRecentDataService, useValue: recentData },
+                { provide: PlaylistsService, useValue: playlistsService },
                 {
                     provide: RuntimeCapabilitiesService,
                     useValue: {
@@ -211,6 +219,7 @@ describe('UnifiedLiveTabComponent', () => {
                     },
                 },
                 { provide: PORTAL_PLAYER, useValue: portalPlayer },
+                { provide: XtreamUrlService, useValue: { resolveCatchupUrl: jest.fn() } },
             ],
         })
             .overrideComponent(UnifiedLiveTabComponent, {
@@ -218,7 +227,6 @@ describe('UnifiedLiveTabComponent', () => {
                     imports: [
                         AudioPlayerComponent,
                         EpgListComponent,
-                        EpgViewComponent,
                         GlobalFavoritesListComponent,
                         LiveEpgPanelComponent,
                         ResizableDirective,
@@ -229,7 +237,6 @@ describe('UnifiedLiveTabComponent', () => {
                     imports: [
                         StubAudioPlayerComponent,
                         StubEpgListComponent,
-                        StubEpgViewComponent,
                         StubGlobalFavoritesListComponent,
                         StubLiveEpgPanelComponent,
                         StubResizableDirective,
@@ -301,7 +308,6 @@ describe('UnifiedLiveTabComponent', () => {
         expect(
             fixture.nativeElement.querySelector('app-epg-list')
         ).not.toBeNull();
-        expect(fixture.nativeElement.querySelector('app-epg-view')).toBeNull();
     });
 
     it('skips EPG loading and hides the EPG panel in browser/PWA playback', async () => {
@@ -359,7 +365,6 @@ describe('UnifiedLiveTabComponent', () => {
         ).not.toBeNull();
         expect(fixture.nativeElement.querySelector('.epg')).toBeNull();
         expect(fixture.nativeElement.querySelector('app-epg-list')).toBeNull();
-        expect(fixture.nativeElement.querySelector('app-epg-view')).toBeNull();
     });
 
     it('passes recent mode and favorite state to the shared live collection list', async () => {
@@ -505,12 +510,12 @@ describe('UnifiedLiveTabComponent', () => {
             By.directive(StubLiveEpgPanelComponent)
         ).componentInstance as StubLiveEpgPanelComponent;
 
-        expect(panel.showDateNavigator()).toBe(false);
+        expect(panel.showDateNavigator()).toBe(true);
         expect(panel.summary()).toEqual(
             expect.objectContaining({ title: 'Xtream Now' })
         );
         expect(
-            fixture.nativeElement.querySelector('app-epg-view')
+            fixture.nativeElement.querySelector('app-epg-list')
         ).not.toBeNull();
 
         panel.collapsedChange.emit(true);
@@ -701,7 +706,6 @@ describe('UnifiedLiveTabComponent', () => {
             fixture.nativeElement.querySelector('app-audio-player')
         ).not.toBeNull();
         expect(fixture.nativeElement.querySelector('app-epg-list')).toBeNull();
-        expect(fixture.nativeElement.querySelector('app-epg-view')).toBeNull();
     });
 
     it('renders inline audio for Stalker radio items and skips external playback', async () => {
@@ -755,7 +759,7 @@ describe('UnifiedLiveTabComponent', () => {
             fixture.nativeElement.querySelector('app-audio-player')
         ).not.toBeNull();
         expect(fixture.nativeElement.querySelector('app-epg-list')).toBeNull();
-        expect(fixture.nativeElement.querySelector('app-epg-view')).toBeNull();
+        expect(fixture.nativeElement.querySelector('app-epg-list')).toBeNull();
 
         const audioPlayer = fixture.debugElement.query(
             By.directive(StubAudioPlayerComponent)
@@ -790,9 +794,8 @@ describe('UnifiedLiveTabComponent', () => {
 
         expect(recentData.recordLivePlayback).toHaveBeenCalledWith(item);
         expect(
-            fixture.nativeElement.querySelector('app-epg-view')
+            fixture.nativeElement.querySelector('app-epg-list')
         ).not.toBeNull();
-        expect(fixture.nativeElement.querySelector('app-epg-list')).toBeNull();
     });
 
     it('renders shared EPG view for Stalker items and records recent history', async () => {
@@ -820,7 +823,7 @@ describe('UnifiedLiveTabComponent', () => {
 
         expect(recentData.recordLivePlayback).toHaveBeenCalledWith(item);
         expect(
-            fixture.nativeElement.querySelector('app-epg-view')
+            fixture.nativeElement.querySelector('app-epg-list')
         ).not.toBeNull();
     });
 

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
@@ -369,14 +369,19 @@ export class UnifiedLiveTabComponent {
                 event.program
             );
             if (catchupUrl) {
-                this.activeDetail.set({
+                const updatedDetail = {
                     ...detail,
                     playback: {
                         ...detail.playback,
                         streamUrl: catchupUrl,
-                        isLive: false,
                     },
-                });
+                };
+                this.activeDetail.set(updatedDetail);
+                if (this.shouldOpenExternalPlayback(updatedDetail, true)) {
+                    this.portalPlayer.openResolvedPlayback(
+                        updatedDetail.playback
+                    );
+                }
             }
             return;
         }
@@ -414,14 +419,19 @@ export class UnifiedLiveTabComponent {
                 stopTimestamp
             );
             if (catchupUrl) {
-                this.activeDetail.set({
+                const updatedDetail = {
                     ...detail,
                     playback: {
                         ...detail.playback,
                         streamUrl: catchupUrl,
-                        isLive: false,
                     },
-                });
+                };
+                this.activeDetail.set(updatedDetail);
+                if (this.shouldOpenExternalPlayback(updatedDetail, true)) {
+                    this.portalPlayer.openResolvedPlayback(
+                        updatedDetail.playback
+                    );
+                }
             }
         } catch {
             // Keep current playback going if catchup fails.

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
@@ -13,7 +13,10 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslatePipe } from '@ngx-translate/core';
-import { isM3uCatchupPlaybackSupported } from '@iptvnator/shared/m3u-utils';
+import {
+    isM3uCatchupPlaybackSupported,
+    resolveM3uCatchupUrl,
+} from '@iptvnator/shared/m3u-utils';
 import {
     DEFAULT_FAVORITES_CHANNEL_SORT_MODE,
     FavoritesChannelSortMode,
@@ -34,6 +37,7 @@ import {
 import {
     EpgDateNavigationDirection,
     EpgListComponent,
+    EpgProgramActivationEvent,
     getTodayEpgDateKey,
     shiftEpgDateKey,
 } from '@iptvnator/ui/epg';
@@ -45,13 +49,14 @@ import {
     WebPlayerViewComponent,
 } from '@iptvnator/ui/playback';
 import { ResizableDirective } from '@iptvnator/ui/components';
-import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
-import { EpgItem, EpgProgram } from '@iptvnator/shared/interfaces';
+import { PlaylistsService, RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
+import { EpgItem, EpgProgram, Playlist } from '@iptvnator/shared/interfaces';
+import { XtreamUrlService } from '@iptvnator/portal/xtream/data-access';
 import {
-    EpgViewComponent,
     LiveEpgPanelComponent,
     LiveEpgPanelSummary,
 } from '@iptvnator/ui/shared-portals';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
     selector: 'app-unified-live-tab',
@@ -61,7 +66,6 @@ import {
     imports: [
         AudioPlayerComponent,
         EpgListComponent,
-        EpgViewComponent,
         GlobalFavoritesListComponent,
         LiveEpgPanelComponent,
         MatButtonModule,
@@ -96,6 +100,11 @@ export class UnifiedLiveTabComponent {
     private readonly settingsStore = inject(SettingsStore);
     private readonly portalPlayer = inject(PORTAL_PLAYER);
     private readonly destroyRef = inject(DestroyRef);
+    private readonly xtreamUrlService = inject(XtreamUrlService);
+    private readonly playlistsService = inject(PlaylistsService);
+
+    /** Tracks the item whose detail is currently loaded for catchup lookups. */
+    private readonly activeItem = signal<UnifiedCollectionItem | null>(null);
 
     readonly player = this.settingsStore.player;
     readonly supportsEpg = this.runtime.supportsEpg;
@@ -144,6 +153,33 @@ export class UnifiedLiveTabComponent {
     readonly currentM3uArchivePlaybackAvailable = computed(() =>
         isM3uCatchupPlaybackSupported(this.currentM3uChannel())
     );
+    /** Portal EPG items converted to EpgProgram for the interactive list component. */
+    readonly currentPortalEpgPrograms = computed<EpgProgram[]>(() =>
+        this.currentPortalEpgItems().map((item) => ({
+            start: item.start,
+            stop: item.stop ?? item.end,
+            channel: item.channel_id ?? item.id,
+            title: item.title,
+            desc: item.description ?? null,
+            category: null,
+            startTimestamp: this.parseEpgTimestamp(item.start_timestamp),
+            stopTimestamp: this.parseEpgTimestamp(item.stop_timestamp),
+        }))
+    );
+    /** Archive window (days) for the selected portal stream, or 0 if unavailable. */
+    readonly currentPortalArchiveDays = computed(() => {
+        const item = this.activeItem();
+        if (!item?.xtreamId) return 0;
+        // Match the all-channels detection: explicit 0 means no archive.
+        if (item.tvArchive === 0) return 0;
+        // Items that have a stored duration get that window; everything
+        // else (no tv_archive data in the DB) gets 0 so the EPG matches
+        // the all-channels view's "history but no catchup" notice.
+        if (item.tvArchiveDuration != null && item.tvArchiveDuration !== 0) {
+            return Math.max(0, Number(item.tvArchiveDuration));
+        }
+        return 0;
+    });
     readonly activeRadioChannel = computed(() => {
         const channel = this.activeDetail()?.channel ?? null;
         return channel?.radio === 'true' ? channel : null;
@@ -309,11 +345,95 @@ export class UnifiedLiveTabComponent {
         );
     }
 
+    async onProgramActivated(event: EpgProgramActivationEvent): Promise<void> {
+        const detail = this.activeDetail();
+        const item = this.activeItem();
+        if (!detail) {
+            return;
+        }
+
+        if (event.type === 'live') {
+            const originalDetail = item
+                ? await this.streamResolver.resolveLiveDetail(item)
+                : null;
+            if (originalDetail) {
+                this.activeDetail.set(originalDetail);
+            }
+            return;
+        }
+
+        // Timeshift / catchup — M3U path
+        if (detail.epgMode === 'm3u' && detail.channel) {
+            const catchupUrl = resolveM3uCatchupUrl(
+                detail.channel,
+                event.program
+            );
+            if (catchupUrl) {
+                this.activeDetail.set({
+                    ...detail,
+                    playback: {
+                        ...detail.playback,
+                        streamUrl: catchupUrl,
+                        isLive: false,
+                    },
+                });
+            }
+            return;
+        }
+
+        // Timeshift / catchup — Xtream (portal) path
+        if (!item?.xtreamId) {
+            return;
+        }
+
+        try {
+            const credentials = await this.getXtreamCredentials(
+                item.playlistId
+            );
+            if (!credentials) {
+                return;
+            }
+
+            const startTimestamp = this.parseEpochSeconds(
+                event.program.startTimestamp,
+                event.program.start
+            );
+            const stopTimestamp = this.parseEpochSeconds(
+                event.program.stopTimestamp,
+                event.program.stop
+            );
+            if (startTimestamp == null || stopTimestamp == null) {
+                return;
+            }
+
+            const catchupUrl = await this.xtreamUrlService.resolveCatchupUrl(
+                item.playlistId,
+                credentials,
+                item.xtreamId,
+                startTimestamp,
+                stopTimestamp
+            );
+            if (catchupUrl) {
+                this.activeDetail.set({
+                    ...detail,
+                    playback: {
+                        ...detail.playback,
+                        streamUrl: catchupUrl,
+                        isLive: false,
+                    },
+                });
+            }
+        } catch {
+            // Keep current playback going if catchup fails.
+        }
+    }
+
     onClose(): void {
         this.selectionRequestId += 1;
         this.isSelecting.set(false);
         this.activeDetail.set(null);
         this.activeUid.set(null);
+        this.activeItem.set(null);
     }
 
     private async loadEpgMap(items: UnifiedCollectionItem[]): Promise<void> {
@@ -346,6 +466,7 @@ export class UnifiedLiveTabComponent {
         this.activeUid.set(item.uid);
         this.activeDetail.set(null);
         this.isSelecting.set(true);
+        this.activeItem.set(item);
 
         try {
             const detail =
@@ -537,5 +658,57 @@ export class UnifiedLiveTabComponent {
 
         const parsedDate = Date.parse(rawDate ?? '');
         return Number.isFinite(parsedDate) ? parsedDate : null;
+    }
+
+    private parseEpgTimestamp(
+        value: string | undefined
+    ): number | undefined {
+        const parsed = Number.parseInt(String(value ?? ''), 10);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+    }
+
+    private parseEpochSeconds(
+        timestamp: number | string | null | undefined,
+        fallbackIso: string
+    ): number | null {
+        const parsed = Number.parseInt(String(timestamp ?? ''), 10);
+        if (Number.isFinite(parsed) && parsed > 0) {
+            return parsed;
+        }
+        const ms = Date.parse(fallbackIso);
+        return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
+    }
+
+    private async getXtreamCredentials(
+        playlistId: string
+    ): Promise<{
+        serverUrl: string;
+        username: string;
+        password: string;
+    } | null> {
+        const electronPlaylist =
+            typeof window !== 'undefined'
+                ? await window.electron?.dbGetAppPlaylist?.(playlistId)
+                : null;
+        const playlist: Playlist | null =
+            electronPlaylist ??
+            (await firstValueFrom(
+                this.playlistsService.getPlaylistById(playlistId)
+            ));
+
+        if (
+            !playlist ||
+            !playlist.serverUrl ||
+            !playlist.username ||
+            !playlist.password
+        ) {
+            return null;
+        }
+
+        return {
+            serverUrl: playlist.serverUrl,
+            username: playlist.username,
+            password: playlist.password,
+        };
     }
 }

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
@@ -13,10 +13,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { TranslatePipe } from '@ngx-translate/core';
-import {
-    isM3uCatchupPlaybackSupported,
-    resolveM3uCatchupUrl,
-} from '@iptvnator/shared/m3u-utils';
+import { isM3uCatchupPlaybackSupported } from '@iptvnator/shared/m3u-utils';
 import {
     DEFAULT_FAVORITES_CHANNEL_SORT_MODE,
     FavoritesChannelSortMode,
@@ -49,14 +46,13 @@ import {
     WebPlayerViewComponent,
 } from '@iptvnator/ui/playback';
 import { ResizableDirective } from '@iptvnator/ui/components';
-import { PlaylistsService, RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
-import { EpgItem, EpgProgram, Playlist } from '@iptvnator/shared/interfaces';
-import { XtreamUrlService } from '@iptvnator/portal/xtream/data-access';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
+import { EpgItem, EpgProgram } from '@iptvnator/shared/interfaces';
 import {
     LiveEpgPanelComponent,
     LiveEpgPanelSummary,
 } from '@iptvnator/ui/shared-portals';
-import { firstValueFrom } from 'rxjs';
+import { UnifiedLiveCatchupService } from './unified-live-catchup.service';
 
 @Component({
     selector: 'app-unified-live-tab',
@@ -100,11 +96,7 @@ export class UnifiedLiveTabComponent {
     private readonly settingsStore = inject(SettingsStore);
     private readonly portalPlayer = inject(PORTAL_PLAYER);
     private readonly destroyRef = inject(DestroyRef);
-    private readonly xtreamUrlService = inject(XtreamUrlService);
-    private readonly playlistsService = inject(PlaylistsService);
-
-    /** Tracks the item whose detail is currently loaded for catchup lookups. */
-    private readonly activeItem = signal<UnifiedCollectionItem | null>(null);
+    readonly catchupService = inject(UnifiedLiveCatchupService);
 
     readonly player = this.settingsStore.player;
     readonly supportsEpg = this.runtime.supportsEpg;
@@ -155,31 +147,12 @@ export class UnifiedLiveTabComponent {
     );
     /** Portal EPG items converted to EpgProgram for the interactive list component. */
     readonly currentPortalEpgPrograms = computed<EpgProgram[]>(() =>
-        this.currentPortalEpgItems().map((item) => ({
-            start: item.start,
-            stop: item.stop ?? item.end,
-            channel: item.channel_id ?? item.id,
-            title: item.title,
-            desc: item.description ?? null,
-            category: null,
-            startTimestamp: this.parseEpgTimestamp(item.start_timestamp),
-            stopTimestamp: this.parseEpgTimestamp(item.stop_timestamp),
-        }))
+        this.catchupService.epgItemsToPrograms(this.currentPortalEpgItems())
     );
     /** Archive window (days) for the selected portal stream, or 0 if unavailable. */
-    readonly currentPortalArchiveDays = computed(() => {
-        const item = this.activeItem();
-        if (!item?.xtreamId) return 0;
-        // Match the all-channels detection: explicit 0 means no archive.
-        if (item.tvArchive === 0) return 0;
-        // Items that have a stored duration get that window; everything
-        // else (no tv_archive data in the DB) gets 0 so the EPG matches
-        // the all-channels view's "history but no catchup" notice.
-        if (item.tvArchiveDuration != null && item.tvArchiveDuration !== 0) {
-            return Math.max(0, Number(item.tvArchiveDuration));
-        }
-        return 0;
-    });
+    readonly currentPortalArchiveDays = computed(() =>
+        this.catchupService.portalArchiveDays(this.catchupService.activeItem())
+    );
     readonly activeRadioChannel = computed(() => {
         const channel = this.activeDetail()?.channel ?? null;
         return channel?.radio === 'true' ? channel : null;
@@ -347,94 +320,19 @@ export class UnifiedLiveTabComponent {
 
     async onProgramActivated(event: EpgProgramActivationEvent): Promise<void> {
         const detail = this.activeDetail();
-        const item = this.activeItem();
-        if (!detail) {
-            return;
-        }
+        const item = this.catchupService.activeItem();
+        if (!detail) return;
 
-        if (event.type === 'live') {
-            const originalDetail = item
-                ? await this.streamResolver.resolveLiveDetail(item)
-                : null;
-            if (originalDetail) {
-                this.activeDetail.set(originalDetail);
-            }
-            return;
-        }
+        const updatedDetail = await this.catchupService.onProgramActivated(
+            event,
+            detail,
+            item
+        );
+        if (!updatedDetail) return;
 
-        // Timeshift / catchup — M3U path
-        if (detail.epgMode === 'm3u' && detail.channel) {
-            const catchupUrl = resolveM3uCatchupUrl(
-                detail.channel,
-                event.program
-            );
-            if (catchupUrl) {
-                const updatedDetail = {
-                    ...detail,
-                    playback: {
-                        ...detail.playback,
-                        streamUrl: catchupUrl,
-                    },
-                };
-                this.activeDetail.set(updatedDetail);
-                if (this.shouldOpenExternalPlayback(updatedDetail, true)) {
-                    this.portalPlayer.openResolvedPlayback(
-                        updatedDetail.playback
-                    );
-                }
-            }
-            return;
-        }
-
-        // Timeshift / catchup — Xtream (portal) path
-        if (!item?.xtreamId) {
-            return;
-        }
-
-        try {
-            const credentials = await this.getXtreamCredentials(
-                item.playlistId
-            );
-            if (!credentials) {
-                return;
-            }
-
-            const startTimestamp = this.parseEpochSeconds(
-                event.program.startTimestamp,
-                event.program.start
-            );
-            const stopTimestamp = this.parseEpochSeconds(
-                event.program.stopTimestamp,
-                event.program.stop
-            );
-            if (startTimestamp == null || stopTimestamp == null) {
-                return;
-            }
-
-            const catchupUrl = await this.xtreamUrlService.resolveCatchupUrl(
-                item.playlistId,
-                credentials,
-                item.xtreamId,
-                startTimestamp,
-                stopTimestamp
-            );
-            if (catchupUrl) {
-                const updatedDetail = {
-                    ...detail,
-                    playback: {
-                        ...detail.playback,
-                        streamUrl: catchupUrl,
-                    },
-                };
-                this.activeDetail.set(updatedDetail);
-                if (this.shouldOpenExternalPlayback(updatedDetail, true)) {
-                    this.portalPlayer.openResolvedPlayback(
-                        updatedDetail.playback
-                    );
-                }
-            }
-        } catch {
-            // Keep current playback going if catchup fails.
+        this.activeDetail.set(updatedDetail);
+        if (this.shouldOpenExternalPlayback(updatedDetail, true)) {
+            this.portalPlayer.openResolvedPlayback(updatedDetail.playback);
         }
     }
 
@@ -443,7 +341,7 @@ export class UnifiedLiveTabComponent {
         this.isSelecting.set(false);
         this.activeDetail.set(null);
         this.activeUid.set(null);
-        this.activeItem.set(null);
+        this.catchupService.activeItem.set(null);
     }
 
     private async loadEpgMap(items: UnifiedCollectionItem[]): Promise<void> {
@@ -476,7 +374,7 @@ export class UnifiedLiveTabComponent {
         this.activeUid.set(item.uid);
         this.activeDetail.set(null);
         this.isSelecting.set(true);
-        this.activeItem.set(item);
+        this.catchupService.activeItem.set(item);
 
         try {
             const detail =
@@ -670,55 +568,4 @@ export class UnifiedLiveTabComponent {
         return Number.isFinite(parsedDate) ? parsedDate : null;
     }
 
-    private parseEpgTimestamp(
-        value: string | undefined
-    ): number | undefined {
-        const parsed = Number.parseInt(String(value ?? ''), 10);
-        return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-    }
-
-    private parseEpochSeconds(
-        timestamp: number | string | null | undefined,
-        fallbackIso: string
-    ): number | null {
-        const parsed = Number.parseInt(String(timestamp ?? ''), 10);
-        if (Number.isFinite(parsed) && parsed > 0) {
-            return parsed;
-        }
-        const ms = Date.parse(fallbackIso);
-        return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
-    }
-
-    private async getXtreamCredentials(
-        playlistId: string
-    ): Promise<{
-        serverUrl: string;
-        username: string;
-        password: string;
-    } | null> {
-        const electronPlaylist =
-            typeof window !== 'undefined'
-                ? await window.electron?.dbGetAppPlaylist?.(playlistId)
-                : null;
-        const playlist: Playlist | null =
-            electronPlaylist ??
-            (await firstValueFrom(
-                this.playlistsService.getPlaylistById(playlistId)
-            ));
-
-        if (
-            !playlist ||
-            !playlist.serverUrl ||
-            !playlist.username ||
-            !playlist.password
-        ) {
-            return null;
-        }
-
-        return {
-            serverUrl: playlist.serverUrl,
-            username: playlist.username,
-            password: playlist.password,
-        };
-    }
 }

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
@@ -105,6 +105,19 @@ export class UnifiedLiveTabComponent {
     );
 
     readonly activeDetail = signal<ResolvedLiveCollectionDetail | null>(null);
+    /** Snapshot of the live (non-catchup) detail, captured before catchup modifies activeDetail. */
+    private readonly priorDetail = signal<ResolvedLiveCollectionDetail | null>(
+        null
+    );
+    /** The archived EPG program the user selected for catchup playback. */
+    readonly archiveProgram = signal<EpgProgram | null>(null);
+    /** True when archive/catchup playback is active and the user can return to live. */
+    readonly showReturnToLive = computed(() => this.priorDetail() !== null);
+    readonly archiveLabelKey = computed(() =>
+        this.showReturnToLive()
+            ? 'EPG.ARCHIVE_PLAYBACK'
+            : 'EPG.CURRENT_PROGRAM'
+    );
     readonly activeUid = signal<string | null>(null);
     readonly isSelecting = signal(false);
     readonly epgMap = signal<Map<string, EpgProgram | null>>(new Map());
@@ -168,6 +181,10 @@ export class UnifiedLiveTabComponent {
     );
     readonly liveEpgPanelSummary = computed(() => {
         this.progressTick();
+        const archiveProg = this.archiveProgram();
+        if (archiveProg) {
+            return this.toLiveEpgPanelSummary(archiveProg);
+        }
         return this.getLiveEpgPanelSummary(this.activeDetail());
     });
 
@@ -330,10 +347,31 @@ export class UnifiedLiveTabComponent {
         );
         if (!updatedDetail) return;
 
+        if (event.type === 'timeshift') {
+            // Snapshot the live detail before switching to catchup so we can
+            // restore it on "Return to Live".
+            if (!this.priorDetail()) {
+                this.priorDetail.set(detail);
+            }
+            this.archiveProgram.set(event.program);
+        } else {
+            // Live program clicked — clear any active archive state.
+            this.priorDetail.set(null);
+            this.archiveProgram.set(null);
+        }
+
         this.activeDetail.set(updatedDetail);
         if (this.shouldOpenExternalPlayback(updatedDetail, true)) {
             this.portalPlayer.openResolvedPlayback(updatedDetail.playback);
         }
+    }
+
+    returnToLive(): void {
+        const prior = this.priorDetail();
+        if (!prior) return;
+        this.priorDetail.set(null);
+        this.archiveProgram.set(null);
+        this.activeDetail.set(prior);
     }
 
     onClose(): void {
@@ -342,6 +380,7 @@ export class UnifiedLiveTabComponent {
         this.activeDetail.set(null);
         this.activeUid.set(null);
         this.catchupService.activeItem.set(null);
+        this.priorDetail.set(null);
     }
 
     private async loadEpgMap(items: UnifiedCollectionItem[]): Promise<void> {

--- a/libs/portal/shared/util/src/lib/collection/collection-helpers.ts
+++ b/libs/portal/shared/util/src/lib/collection/collection-helpers.ts
@@ -13,6 +13,7 @@ export interface XtreamFavoriteRow {
     readonly rating?: string | null;
     readonly tv_archive?: number | null;
     readonly tv_archive_duration?: number | null;
+    readonly epg_channel_id?: string | null;
     readonly added_at?: string | null;
     readonly position?: number | null;
 }

--- a/libs/portal/shared/util/src/lib/collection/collection-helpers.ts
+++ b/libs/portal/shared/util/src/lib/collection/collection-helpers.ts
@@ -11,6 +11,8 @@ export interface XtreamFavoriteRow {
     readonly type: string;
     readonly poster_url?: string | null;
     readonly rating?: string | null;
+    readonly tv_archive?: number | null;
+    readonly tv_archive_duration?: number | null;
     readonly added_at?: string | null;
     readonly position?: number | null;
 }

--- a/libs/portal/shared/util/src/lib/collection/unified-collection-item.interface.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-collection-item.interface.ts
@@ -56,6 +56,8 @@ export interface UnifiedCollectionItem {
     /** Xtream DB content id — used for reorder / remove IPC */
     contentId?: number;
 
+    /** Stable EPG channel identifier from the provider (used for XMLTV matching) */
+    epgChannelId?: string | null;
     /** Whether the Xtream provider has timeshift / archive enabled for this stream */
     tvArchive?: number | null;
     /** Timeshift / archive window in hours (Xtream) */

--- a/libs/portal/shared/util/src/lib/collection/unified-collection-item.interface.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-collection-item.interface.ts
@@ -56,6 +56,11 @@ export interface UnifiedCollectionItem {
     /** Xtream DB content id — used for reorder / remove IPC */
     contentId?: number;
 
+    /** Whether the Xtream provider has timeshift / archive enabled for this stream */
+    tvArchive?: number | null;
+    /** Timeshift / archive window in hours (Xtream) */
+    tvArchiveDuration?: number | null;
+
     /** Stalker cmd for stream resolution */
     stalkerId?: string | number;
     stalkerCmd?: string;

--- a/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.spec.ts
+++ b/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.spec.ts
@@ -156,6 +156,7 @@ describe('withEpg', () => {
             selectedItem: { xtream_id: 101, epg_channel_id: null },
         });
         xtreamApiService.getFullEpg.mockResolvedValue([]);
+        xtreamApiService.getShortEpg.mockResolvedValue([]);
 
         const result = await store.loadEpg();
 

--- a/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.ts
+++ b/libs/portal/xtream/data-access/src/lib/stores/features/with-epg.feature.ts
@@ -119,6 +119,10 @@ export function withEpg() {
                  * if the Xtream provider returns no programs and the channel
                  * has an `epg_channel_id`. The order is reversed when the user
                  * sets `preferUploadedEpgOverXtream`.
+                 *
+                 * When both Xtream full-EPG and XMLTV are empty, the short-EPG
+                 * endpoint (`get_short_epg`) is tried as a last resort — many
+                 * providers support it even when the full endpoint is unavailable.
                  */
                 async loadEpg(): Promise<EpgItem[]> {
                     if (!supportsEpg()) {
@@ -147,13 +151,28 @@ export function withEpg() {
                     patchState(store, { epgItems: [], isLoadingEpg: true });
 
                     try {
-                        const epgItems =
+                        let epgItems =
                             await fallbackService.resolveCurrentEpg({
                                 epgChannelId: selectedItem.epg_channel_id,
                                 preferUploaded: preferUploaded(),
                                 fetchProvider: () =>
                                     fetchFullProvider(credentials, xtreamId),
                             });
+
+                        // Last resort: short-EPG endpoint with a generous
+                        // limit. Many Xtream providers don't implement
+                        // get_simple_data_table but *do* support get_short_epg.
+                        if (epgItems.length === 0) {
+                            const shortEpg = await apiService.getShortEpg(
+                                credentials,
+                                xtreamId,
+                                200,
+                                { suppressErrorLog: true }
+                            );
+                            if (Array.isArray(shortEpg)) {
+                                epgItems = shortEpg;
+                            }
+                        }
 
                         patchState(store, {
                             epgItems,

--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.ts
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.ts
@@ -186,10 +186,17 @@ export class LiveStreamLayoutComponent implements OnInit, OnDestroy {
     );
     readonly archivePlaybackAvailable = computed(() => {
         const selectedItem = this.selectedLiveItem();
-        return (
-            Number(selectedItem?.tv_archive ?? 0) === 1 &&
-            this.controlledArchiveDays() > 0
-        );
+        const tvArchive = selectedItem?.tv_archive;
+
+        // When the provider explicitly sets tv_archive=0, archives are not
+        // available.  But many providers omit the field entirely, so we only
+        // treat an explicit 0 as "no"; undefined/null falls through to the
+        // duration check below so catchup can work without the boolean flag.
+        if (tvArchive === 0) {
+            return false;
+        }
+
+        return this.controlledArchiveDays() > 0;
     });
     readonly hasPastPrograms = computed(() => {
         const now = this.currentTimeMs();

--- a/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.html
+++ b/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.html
@@ -43,12 +43,30 @@
                 "
                 [showFavoriteButton]="true"
                 [showProgramInfoButton]="false"
+                [showDetailsContextMenu]="true"
                 [isFavorite]="favorites.get(favoriteKeyFor(item)) ?? false"
                 (clicked)="playClicked.emit(item)"
                 (activated)="playbackRequested.emit(item)"
                 (favoriteToggled)="toggleFavorite($event, item)"
+                (contextMenuRequested)="onChannelContextMenu(item, $event)"
             />
         </cdk-virtual-scroll-viewport>
+
+        <div
+            aria-hidden="true"
+            class="channel-context-menu-anchor"
+            [style.left]="contextMenuPosition().x"
+            [style.top]="contextMenuPosition().y"
+            [matMenuTriggerFor]="channelContextMenu"
+            #contextMenuTrigger="matMenuTrigger"
+        ></div>
+
+        <mat-menu #channelContextMenu="matMenu">
+            <button mat-menu-item (click)="openEpgMapping()">
+                <mat-icon>settings_remote</mat-icon>
+                <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
+            </button>
+        </mat-menu>
     } @else {
         <div class="empty-search-state">
             <mat-icon class="empty-state-icon">search_off</mat-icon>

--- a/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.scss
+++ b/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.scss
@@ -171,3 +171,11 @@
         transform: translateY(0);
     }
 }
+
+.channel-context-menu-anchor {
+    position: fixed;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+}

--- a/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.ts
+++ b/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.ts
@@ -13,10 +13,14 @@ import {
     input,
     OnDestroy,
     output,
+    signal,
     untracked,
     viewChild,
 } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { ActivatedRoute } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
@@ -27,9 +31,11 @@ import {
     XtreamCategory,
     XtreamItem,
 } from '@iptvnator/shared/interfaces';
+import { resolveChannelEpgLookupKey } from '@iptvnator/m3u-state';
 import {
     ChannelListItemComponent,
     ChannelListSkeletonComponent,
+    EpgMappingDialogComponent,
 } from '@iptvnator/ui/components';
 import {
     PortalChannelSortMode,
@@ -66,7 +72,9 @@ interface XtreamCategoryLike {
     imports: [
         ChannelListItemComponent,
         ChannelListSkeletonComponent,
+        MatButtonModule,
         MatIcon,
+        MatMenuModule,
         ScrollingModule,
         TranslatePipe,
     ],
@@ -83,6 +91,12 @@ export class PortalChannelsListComponent implements AfterViewInit, OnDestroy {
     private readonly epgQueueService = inject(EpgQueueService);
     private readonly route = inject(ActivatedRoute);
     private readonly runtime = inject(RuntimeCapabilitiesService);
+    private readonly dialog = inject(MatDialog);
+
+    readonly contextMenuTrigger =
+        viewChild.required<MatMenuTrigger>('contextMenuTrigger');
+    readonly contextMenuChannel = signal<XtreamChannelListItem | null>(null);
+    readonly contextMenuPosition = signal({ x: '0px', y: '0px' });
     readonly supportsEpg = this.runtime.supportsEpg;
     readonly isSelectedTypeContentLoading =
         this.xtreamStore.selectedTypeContentLoading;
@@ -458,5 +472,43 @@ export class PortalChannelsListComponent implements AfterViewInit, OnDestroy {
         return Number.isFinite(parsedDate)
             ? Math.floor(parsedDate / 1000)
             : null;
+    }
+
+    // ── Context menu ────────────────────────────────────────────
+
+    onChannelContextMenu(channel: XtreamChannelListItem, event: MouseEvent): void {
+        this.contextMenuChannel.set(channel);
+        this.contextMenuPosition.set({
+            x: `${event.clientX}px`,
+            y: `${event.clientY}px`,
+        });
+
+        const trigger = this.contextMenuTrigger();
+        if (trigger.menuOpen) {
+            trigger.closeMenu();
+        }
+
+        queueMicrotask(() => {
+            this.contextMenuTrigger().openMenu();
+        });
+    }
+
+    openEpgMapping(): void {
+        const channel = this.contextMenuChannel();
+        if (!channel) return;
+
+        this.contextMenuTrigger().closeMenu();
+        const channelKey = String(channel.xtream_id ?? channel.id ?? '');
+        if (!channelKey) return;
+
+        this.dialog.open(EpgMappingDialogComponent, {
+            data: {
+                channelKey,
+                channelName: channel.title ?? channel.name ?? channelKey,
+                currentMapping: null,
+            },
+            width: '500px',
+            maxHeight: '90vh',
+        });
     }
 }

--- a/libs/services/src/lib/runtime-capabilities.service.ts
+++ b/libs/services/src/lib/runtime-capabilities.service.ts
@@ -115,6 +115,15 @@ export class RuntimeCapabilitiesService {
         return this.hasElectronMethod('searchEpgPrograms');
     }
 
+    get supportsEpgMapping(): boolean {
+        return (
+            this.hasElectronMethod('getEpgMapping') &&
+            this.hasElectronMethod('setEpgMapping') &&
+            this.hasElectronMethod('deleteEpgMapping') &&
+            this.hasElectronMethod('searchEpgChannels')
+        );
+    }
+
     get supportsSqlite(): boolean {
         return [
             'dbDeleteAllPlaylists',

--- a/libs/shared/database/src/lib/connection.ts
+++ b/libs/shared/database/src/lib/connection.ts
@@ -250,6 +250,15 @@ const CREATE_TABLE_STATEMENTS = [
       INSERT INTO epg_programs_fts(rowid, title, description, category)
       VALUES (new.id, new.title, new.description, new.category);
   END`,
+    // EPG channel mappings (manual user overrides)
+    `CREATE TABLE IF NOT EXISTS epg_channel_mappings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      channel_key TEXT NOT NULL UNIQUE,
+      epg_channel_id TEXT NOT NULL,
+      playlist_id TEXT,
+      updated_at TEXT DEFAULT (datetime('now'))
+  )`,
+    `CREATE INDEX IF NOT EXISTS idx_epg_channel_mappings_playlist ON epg_channel_mappings(playlist_id)`,
     // Playback Positions table
     `CREATE TABLE IF NOT EXISTS playback_positions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/libs/shared/database/src/lib/schema.ts
+++ b/libs/shared/database/src/lib/schema.ts
@@ -347,5 +347,25 @@ export const downloads = sqliteTable(
     })
 );
 
+// EPG channel mappings (manual user overrides)
+export const epgChannelMappings = sqliteTable(
+    'epg_channel_mappings',
+    {
+        id: integer('id').primaryKey({ autoIncrement: true }),
+        channelKey: text('channel_key').notNull().unique(),
+        epgChannelId: text('epg_channel_id').notNull(),
+        playlistId: text('playlist_id'),
+        updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`),
+    },
+    (table) => ({
+        playlistIdx: index('idx_epg_channel_mappings_playlist').on(
+            table.playlistId
+        ),
+    })
+);
+
+export type EpgChannelMapping = typeof epgChannelMappings.$inferSelect;
+export type NewEpgChannelMapping = typeof epgChannelMappings.$inferInsert;
+
 export type Download = typeof downloads.$inferSelect;
 export type NewDownload = typeof downloads.$inferInsert;

--- a/libs/shared/interfaces/src/lib/electron-api.interface.ts
+++ b/libs/shared/interfaces/src/lib/electron-api.interface.ts
@@ -264,6 +264,19 @@ export interface ElectronBridgeEpgFreshnessResult {
     freshUrls: string[];
 }
 
+export interface ElectronBridgeEpgMapping {
+    id: number;
+    channelKey: string;
+    epgChannelId: string;
+    playlistId: string | null;
+}
+
+export interface ElectronBridgeEpgSearchResult {
+    id: string;
+    displayName: string;
+    iconUrl: string | null;
+}
+
 export interface ElectronBridgeEpgLookupOptions {
     sourceUrls?: string[];
 }
@@ -612,6 +625,22 @@ export interface ElectronBridgeApi {
         searchTerm: string,
         limit?: number
     ) => Promise<EpgProgram[]>;
+
+    // EPG channel mapping (manual user overrides)
+    getEpgMapping: (
+        channelKey: string
+    ) => Promise<ElectronBridgeEpgMapping | null>;
+    setEpgMapping: (
+        channelKey: string,
+        epgChannelId: string,
+        playlistId?: string
+    ) => Promise<ElectronBridgeResult>;
+    deleteEpgMapping: (channelKey: string) => Promise<ElectronBridgeResult>;
+    searchEpgChannels: (
+        searchTerm: string,
+        limit?: number
+    ) => Promise<ElectronBridgeEpgSearchResult[]>;
+
     updateSettings: (settings: Partial<Settings>) => Promise<void>;
     getAiSettings: () => Promise<ElectronBridgeAiSettings>;
     setMpvPlayerPath: (mpvPlayerPath: string) => Promise<void>;

--- a/libs/ui/components/src/index.ts
+++ b/libs/ui/components/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/channel-list-container/channel-list-container.component';
 export * from './lib/channel-list-container/channel-details-dialog/channel-details-dialog.component';
+export * from './lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component';
 export * from './lib/channel-list-container/channel-list-item/channel-list-item.component';
 export * from './lib/channel-list-container/channel-list-item-skeleton/channel-list-item-skeleton.component';
 export * from './lib/channel-list-container/channel-list-skeleton/channel-list-skeleton.component';

--- a/libs/ui/components/src/lib/channel-list-container/all-channels-view/all-channels-view.component.html
+++ b/libs/ui/components/src/lib/channel-list-container/all-channels-view/all-channels-view.component.html
@@ -110,6 +110,10 @@
 ></div>
 
 <mat-menu #channelContextMenu="matMenu">
+    <button mat-menu-item (click)="openEpgMapping()">
+        <mat-icon>settings_remote</mat-icon>
+        <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
+    </button>
     <button mat-menu-item (click)="openChannelDetails()">
         <mat-icon>info</mat-icon>
         <span>{{ 'CHANNELS.SHOW_DETAILS' | translate }}</span>

--- a/libs/ui/components/src/lib/channel-list-container/all-channels-view/all-channels-view.component.ts
+++ b/libs/ui/components/src/lib/channel-list-container/all-channels-view/all-channels-view.component.ts
@@ -27,6 +27,7 @@ import {
 } from '../channel-list-sort.util';
 import { resolveChannelLogo } from '../channel-logo-fallback.util';
 import { ChannelDetailsDialogComponent } from '../channel-details-dialog/channel-details-dialog.component';
+import { EpgMappingDialogComponent } from '../epg-mapping-dialog/epg-mapping-dialog.component';
 import { ChannelListItemComponent } from '../channel-list-item/channel-list-item.component';
 
 const ALL_CHANNELS_SORT_STORAGE_KEY = 'm3u-all-channels-sort-mode';
@@ -248,6 +249,29 @@ export class AllChannelsViewComponent {
             data: channel,
             maxWidth: '720px',
             width: 'calc(100vw - 32px)',
+        });
+    }
+
+    openEpgMapping(): void {
+        const channel = this.contextMenuChannel();
+        if (!channel) {
+            return;
+        }
+
+        this.contextMenuTrigger().closeMenu();
+        const channelKey = resolveChannelEpgLookupKey(channel);
+        if (!channelKey) {
+            return;
+        }
+
+        this.dialog.open(EpgMappingDialogComponent, {
+            data: {
+                channelKey,
+                channelName: channel.name ?? channelKey,
+                currentMapping: null,
+            },
+            width: '500px',
+            maxHeight: '90vh',
         });
     }
 }

--- a/libs/ui/components/src/lib/channel-list-container/channel-details-dialog/channel-details-dialog.component.html
+++ b/libs/ui/components/src/lib/channel-list-container/channel-details-dialog/channel-details-dialog.component.html
@@ -227,6 +227,10 @@
 </mat-dialog-content>
 
 <mat-dialog-actions class="channel-dialog__actions">
+    <button mat-stroked-button (click)="openEpgMapping()">
+        <mat-icon>settings_remote</mat-icon>
+        {{ 'CHANNELS.MAP_EPG' | translate }}
+    </button>
     <button mat-stroked-button mat-dialog-close class="channel-dialog__close">
         {{ 'CLOSE' | translate }}
     </button>

--- a/libs/ui/components/src/lib/channel-list-container/channel-details-dialog/channel-details-dialog.component.ts
+++ b/libs/ui/components/src/lib/channel-list-container/channel-details-dialog/channel-details-dialog.component.ts
@@ -1,11 +1,17 @@
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import {
+    MAT_DIALOG_DATA,
+    MatDialog,
+    MatDialogModule,
+} from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslatePipe } from '@ngx-translate/core';
 import { getM3uArchiveDays, isM3uCatchupPlaybackSupported } from '@iptvnator/shared/m3u-utils';
 import { Channel } from '@iptvnator/shared/interfaces';
+import { resolveChannelEpgLookupKey } from '@iptvnator/m3u-state';
+import { EpgMappingDialogComponent } from '../epg-mapping-dialog/epg-mapping-dialog.component';
 
 interface ChannelDetailField {
     readonly empty?: boolean;
@@ -35,6 +41,7 @@ interface HeroStat {
 })
 export class ChannelDetailsDialogComponent {
     readonly channel = inject<Channel>(MAT_DIALOG_DATA);
+    private readonly dialog = inject(MatDialog);
 
     readonly archiveDays = getM3uArchiveDays(this.channel);
     readonly catchupAvailable = this.archiveDays > 0;
@@ -181,5 +188,20 @@ export class ChannelDetailsDialogComponent {
         }
 
         return { labelKey, monospace, value: normalized };
+    }
+
+    openEpgMapping(): void {
+        const channelKey = resolveChannelEpgLookupKey(this.channel);
+        if (!channelKey) return;
+
+        this.dialog.open(EpgMappingDialogComponent, {
+            data: {
+                channelKey,
+                channelName: this.channel.name ?? channelKey,
+                currentMapping: null,
+            },
+            width: '500px',
+            maxHeight: '90vh',
+        });
     }
 }

--- a/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.html
+++ b/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.html
@@ -1,0 +1,69 @@
+<h2 mat-dialog-title>{{ 'CHANNELS.MAP_EPG' | translate }}</h2>
+
+<mat-dialog-content>
+    <p class="epg-mapping-subtitle">
+        {{ 'EPG_MAPPING_DIALOG.SUBTITLE' | translate : { channelName: data.channelName } }}
+    </p>
+
+    <div class="epg-mapping-current">
+        <span class="epg-mapping-current__label">
+            {{ 'EPG_MAPPING_DIALOG.CURRENT_MAPPING' | translate }}:
+        </span>
+        <span class="epg-mapping-current__value">
+            {{ currentMapping() || ('EPG_MAPPING_DIALOG.NO_MAPPING' | translate) }}
+        </span>
+    </div>
+
+    <mat-form-field class="epg-mapping-search" appearance="outline">
+        <mat-label>{{ 'EPG_MAPPING_DIALOG.SEARCH_PLACEHOLDER' | translate }}</mat-label>
+        <input
+            matInput
+            [ngModel]="searchTerm()"
+            (ngModelChange)="onSearchInput($event)"
+            [placeholder]="'EPG_MAPPING_DIALOG.SEARCH_PLACEHOLDER' | translate"
+        />
+        <mat-icon matPrefix>search</mat-icon>
+        @if (loading()) {
+            <mat-spinner matSuffix diameter="20" />
+        }
+    </mat-form-field>
+
+    @if (hasSearchTerm()) {
+        <div class="epg-mapping-results">
+            @for (channel of results(); track channel.id) {
+                <button
+                    class="epg-mapping-result"
+                    [class.epg-mapping-result--selected]="selectedId() === channel.id"
+                    (click)="selectChannel(channel.id)"
+                >
+                    <span class="epg-mapping-result__name">{{ channel.displayName }}</span>
+                    <span class="epg-mapping-result__id">{{ channel.id }}</span>
+                </button>
+            } @empty {
+                <div class="epg-mapping-empty">
+                    <mat-icon>search_off</mat-icon>
+                    <span>{{ 'EPG_MAPPING_DIALOG.NO_RESULTS' | translate }}</span>
+                </div>
+            }
+        </div>
+    }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+    @if (currentMapping()) {
+        <button mat-button color="warn" (click)="removeMapping()">
+            {{ 'EPG_MAPPING_DIALOG.REMOVE' | translate }}
+        </button>
+    }
+    <button mat-button (click)="close()">
+        {{ 'EPG_MAPPING_DIALOG.CLOSE' | translate }}
+    </button>
+    <button
+        mat-raised-button
+        color="primary"
+        [disabled]="!selectedId()"
+        (click)="save()"
+    >
+        {{ 'EPG_MAPPING_DIALOG.SAVE' | translate }}
+    </button>
+</mat-dialog-actions>

--- a/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.scss
+++ b/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.scss
@@ -1,0 +1,95 @@
+.epg-mapping-subtitle {
+    margin: 0 0 16px;
+    color: var(--mat-sys-on-surface-variant);
+    font-size: 14px;
+}
+
+.epg-mapping-current {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: var(--mat-sys-surface-container-high);
+
+    &__label {
+        font-size: 12px;
+        color: var(--mat-sys-on-surface-variant);
+    }
+
+    &__value {
+        font-size: 14px;
+        font-weight: 500;
+        font-family: monospace;
+    }
+}
+
+.epg-mapping-search {
+    width: 100%;
+    margin-bottom: 8px;
+}
+
+.epg-mapping-results {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.epg-mapping-result {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+    padding: 10px 12px;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+    color: inherit;
+    transition: background 0.15s, border-color 0.15s;
+
+    &:hover {
+        background: var(--mat-sys-surface-container-high);
+    }
+
+    &--selected {
+        border-color: var(--mat-sys-primary);
+        background: color-mix(
+            in srgb,
+            var(--mat-sys-primary) 10%,
+            transparent
+        );
+    }
+
+    &__name {
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--mat-sys-on-surface);
+    }
+
+    &__id {
+        font-size: 11px;
+        color: var(--mat-sys-on-surface-variant);
+        font-family: monospace;
+    }
+}
+
+.epg-mapping-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 32px;
+    color: var(--mat-sys-on-surface-variant);
+
+    mat-icon {
+        font-size: 40px;
+        width: 40px;
+        height: 40px;
+    }
+}

--- a/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.ts
+++ b/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.ts
@@ -1,0 +1,139 @@
+import {
+    ChangeDetectionStrategy,
+    Component,
+    computed,
+    inject,
+    signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import {
+    MAT_DIALOG_DATA,
+    MatDialogModule,
+    MatDialogRef,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { EpgRuntimeBridgeService, EpgService } from '@iptvnator/epg/data-access';
+import { TranslatePipe } from '@ngx-translate/core';
+import { debounceTime, from, Subject, switchMap } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
+
+export interface EpgMappingDialogData {
+    channelKey: string;
+    channelName: string;
+    currentMapping: string | null;
+}
+
+export interface EpgMappingDialogResult {
+    channelKey: string;
+    epgChannelId: string;
+}
+
+@Component({
+    selector: 'app-epg-mapping-dialog',
+    templateUrl: './epg-mapping-dialog.component.html',
+    styleUrl: './epg-mapping-dialog.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [
+        FormsModule,
+        MatButtonModule,
+        MatDialogModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatInputModule,
+        MatProgressSpinnerModule,
+        TranslatePipe,
+    ],
+})
+export class EpgMappingDialogComponent {
+    readonly data = inject<EpgMappingDialogData>(MAT_DIALOG_DATA);
+    private readonly dialogRef = inject(
+        MatDialogRef<EpgMappingDialogComponent, EpgMappingDialogResult>
+    );
+    private readonly epgBridge = inject(EpgRuntimeBridgeService);
+    private readonly epgService = inject(EpgService);
+
+    readonly searchTerm = signal('');
+    readonly loading = signal(false);
+    readonly results = signal<
+        Array<{ id: string; displayName: string; iconUrl: string | null }>
+    >([]);
+    readonly selectedId = signal<string | null>(null);
+    readonly currentMapping = signal<string | null>(null);
+
+    private readonly search$ = new Subject<string>();
+
+    constructor() {
+        // Fetch the current mapping (if any) on open — callers may not know it.
+        this.epgBridge
+            .getEpgMapping(this.data.channelKey)
+            ?.then((m) => this.currentMapping.set(m?.epgChannelId ?? null));
+
+        this.search$
+        this.search$
+            .pipe(
+                debounceTime(300),
+                switchMap((term) => {
+                    if (term.trim().length < 2) {
+                        return from(Promise.resolve([]));
+                    }
+                    this.loading.set(true);
+                    const promise = this.epgBridge.searchEpgChannels(term);
+                    return from(promise ?? Promise.resolve([]));
+                })
+            )
+            .subscribe({
+                next: (items) => {
+                    this.results.set(items ?? []);
+                    this.loading.set(false);
+                },
+                error: () => {
+                    this.results.set([]);
+                    this.loading.set(false);
+                },
+            });
+    }
+
+    readonly hasSearchTerm = computed(
+        () => this.searchTerm().trim().length >= 2
+    );
+
+    onSearchInput(value: string): void {
+        this.searchTerm.set(value);
+        this.search$.next(value);
+    }
+
+    selectChannel(id: string): void {
+        this.selectedId.set(id);
+    }
+
+    save(): void {
+        const epgChannelId = this.selectedId();
+        if (!epgChannelId) {
+            return;
+        }
+
+        this.epgBridge
+            .setEpgMapping(this.data.channelKey, epgChannelId)
+            ?.then(() => {
+                this.epgService.clearCache();
+                this.dialogRef.close({
+                    channelKey: this.data.channelKey,
+                    epgChannelId,
+                });
+            });
+    }
+
+    removeMapping(): void {
+        this.epgBridge.deleteEpgMapping(this.data.channelKey)?.then(() => {
+            this.dialogRef.close();
+        });
+    }
+
+    close(): void {
+        this.dialogRef.close();
+    }
+}

--- a/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.ts
+++ b/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.ts
@@ -73,7 +73,6 @@ export class EpgMappingDialogComponent {
             ?.then((m) => this.currentMapping.set(m?.epgChannelId ?? null));
 
         this.search$
-        this.search$
             .pipe(
                 debounceTime(300),
                 switchMap((term) => {
@@ -112,13 +111,12 @@ export class EpgMappingDialogComponent {
 
     save(): void {
         const epgChannelId = this.selectedId();
-        if (!epgChannelId) {
-            return;
-        }
+        if (!epgChannelId) return;
 
-        this.epgBridge
-            .setEpgMapping(this.data.channelKey, epgChannelId)
-            ?.then(() => {
+        (this.epgBridge.setEpgMapping(this.data.channelKey, epgChannelId) ??
+            Promise.resolve(null))
+            .then((result) => {
+                if (result?.success === false) return;
                 this.epgService.clearCache();
                 this.dialogRef.close({
                     channelKey: this.data.channelKey,
@@ -128,9 +126,12 @@ export class EpgMappingDialogComponent {
     }
 
     removeMapping(): void {
-        this.epgBridge.deleteEpgMapping(this.data.channelKey)?.then(() => {
-            this.dialogRef.close();
-        });
+        (this.epgBridge.deleteEpgMapping(this.data.channelKey) ??
+            Promise.resolve(null))
+            .then((result) => {
+                if (result?.success === false) return;
+                this.dialogRef.close();
+            });
     }
 
     close(): void {

--- a/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.ts
+++ b/libs/ui/components/src/lib/channel-list-container/epg-mapping-dialog/epg-mapping-dialog.component.ts
@@ -130,6 +130,7 @@ export class EpgMappingDialogComponent {
             Promise.resolve(null))
             .then((result) => {
                 if (result?.success === false) return;
+                this.epgService.clearCache();
                 this.dialogRef.close();
             });
     }

--- a/libs/ui/components/src/lib/channel-list-container/favorites-view/favorites-view.component.html
+++ b/libs/ui/components/src/lib/channel-list-container/favorites-view/favorites-view.component.html
@@ -69,6 +69,10 @@
 ></div>
 
 <mat-menu #channelContextMenu="matMenu">
+    <button mat-menu-item (click)="openEpgMapping()">
+        <mat-icon>settings_remote</mat-icon>
+        <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
+    </button>
     <button mat-menu-item (click)="openChannelDetails()">
         <mat-icon>info</mat-icon>
         <span>{{ 'CHANNELS.SHOW_DETAILS' | translate }}</span>

--- a/libs/ui/components/src/lib/channel-list-container/favorites-view/favorites-view.component.ts
+++ b/libs/ui/components/src/lib/channel-list-container/favorites-view/favorites-view.component.ts
@@ -20,6 +20,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { resolveChannelEpgLookupKey } from '@iptvnator/m3u-state';
 import { Channel, EpgProgram } from '@iptvnator/shared/interfaces';
 import { ChannelEpgMetadata } from '../all-channels-view/all-channels-view.component';
+import { EpgMappingDialogComponent } from '../epg-mapping-dialog/epg-mapping-dialog.component';
 import { ChannelDetailsDialogComponent } from '../channel-details-dialog/channel-details-dialog.component';
 import { resolveChannelLogo } from '../channel-logo-fallback.util';
 import { ChannelListItemComponent } from '../channel-list-item/channel-list-item.component';
@@ -180,6 +181,24 @@ export class FavoritesViewComponent {
         });
     }
 
+    openEpgMapping(): void {
+        const channel = this.contextMenuChannel();
+        if (!channel) return;
+        this.contextMenuTrigger().closeMenu();
+        const channelKey = resolveChannelEpgLookupKey(channel);
+        if (!channelKey) return;
+        this.dialog.open(EpgMappingDialogComponent, {
+            data: {
+                channelKey,
+                channelName: channel.name ?? channelKey,
+                currentMapping: null,
+            },
+            width: '500px',
+            maxHeight: '90vh',
+        });
+    }
+
+    
     openChannelDetails(): void {
         const channel = this.contextMenuChannel();
         if (!channel) {

--- a/libs/ui/components/src/lib/channel-list-container/groups-view/groups-view.component.html
+++ b/libs/ui/components/src/lib/channel-list-container/groups-view/groups-view.component.html
@@ -331,6 +331,10 @@
 ></div>
 
 <mat-menu #channelContextMenu="matMenu">
+    <button mat-menu-item (click)="openEpgMapping()">
+        <mat-icon>settings_remote</mat-icon>
+        <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
+    </button>
     <button mat-menu-item (click)="openChannelDetails()">
         <mat-icon>info</mat-icon>
         <span>{{ 'CHANNELS.SHOW_DETAILS' | translate }}</span>

--- a/libs/ui/components/src/lib/channel-list-container/groups-view/groups-view.component.ts
+++ b/libs/ui/components/src/lib/channel-list-container/groups-view/groups-view.component.ts
@@ -30,6 +30,7 @@ import {
     sortPlaylistChannelItems,
 } from '../channel-list-sort.util';
 import { resolveChannelLogo } from '../channel-logo-fallback.util';
+import { EpgMappingDialogComponent } from '../epg-mapping-dialog/epg-mapping-dialog.component';
 import { ChannelDetailsDialogComponent } from '../channel-details-dialog/channel-details-dialog.component';
 import { ChannelListItemComponent } from '../channel-list-item/channel-list-item.component';
 import { ResizableDirective } from '../../resizable/resizable.directive';
@@ -498,6 +499,24 @@ export class GroupsViewComponent {
         });
     }
 
+    openEpgMapping(): void {
+        const channel = this.contextMenuChannel();
+        if (!channel) return;
+        this.contextMenuTrigger().closeMenu();
+        const channelKey = resolveChannelEpgLookupKey(channel);
+        if (!channelKey) return;
+        this.dialog.open(EpgMappingDialogComponent, {
+            data: {
+                channelKey,
+                channelName: channel.name ?? channelKey,
+                currentMapping: null,
+            },
+            width: '500px',
+            maxHeight: '90vh',
+        });
+    }
+
+    
     openChannelDetails(): void {
         const channel = this.contextMenuChannel();
         if (!channel) {

--- a/libs/ui/components/src/lib/channel-list-container/recent-view/recent-view.component.html
+++ b/libs/ui/components/src/lib/channel-list-container/recent-view/recent-view.component.html
@@ -62,6 +62,10 @@
 ></div>
 
 <mat-menu #channelContextMenu="matMenu">
+    <button mat-menu-item (click)="openEpgMapping()">
+        <mat-icon>settings_remote</mat-icon>
+        <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
+    </button>
     <button mat-menu-item (click)="openChannelDetails()">
         <mat-icon>info</mat-icon>
         <span>{{ 'CHANNELS.SHOW_DETAILS' | translate }}</span>

--- a/libs/ui/components/src/lib/channel-list-container/recent-view/recent-view.component.ts
+++ b/libs/ui/components/src/lib/channel-list-container/recent-view/recent-view.component.ts
@@ -14,6 +14,7 @@ import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { TranslatePipe } from '@ngx-translate/core';
 import { resolveChannelEpgLookupKey } from '@iptvnator/m3u-state';
 import { Channel, EpgProgram } from '@iptvnator/shared/interfaces';
+import { EpgMappingDialogComponent } from '../epg-mapping-dialog/epg-mapping-dialog.component';
 import { ChannelDetailsDialogComponent } from '../channel-details-dialog/channel-details-dialog.component';
 import { resolveChannelLogo } from '../channel-logo-fallback.util';
 import { ChannelListItemComponent } from '../channel-list-item/channel-list-item.component';
@@ -147,6 +148,24 @@ export class RecentViewComponent {
         });
     }
 
+    openEpgMapping(): void {
+        const channel = this.contextMenuChannel();
+        if (!channel) return;
+        this.contextMenuTrigger().closeMenu();
+        const channelKey = resolveChannelEpgLookupKey(channel);
+        if (!channelKey) return;
+        this.dialog.open(EpgMappingDialogComponent, {
+            data: {
+                channelKey,
+                channelName: channel.name ?? channelKey,
+                currentMapping: null,
+            },
+            width: '500px',
+            maxHeight: '90vh',
+        });
+    }
+
+    
     openChannelDetails(): void {
         const channel = this.contextMenuChannel();
         if (!channel) {


### PR DESCRIPTION
I’m using IPTVNator with xstream providers and my experience left a lot to be desired so I tried to fix some of that.

I did some work on EPG and catch-up features which seemed broken in several ways, especially when browsing from the favourites tab. This PR tries to fix many problems I encountered. 

While fixing stuff like not being able to load all the EPG data properly from the favourites list, not being able to activate catch-up, I also tried to fix some other things as well.

Some caveats:
- I’m a crappy coder, so the code is probably janky in places, my hope was mainly that this is useful as a baseline for someone that knows better;
- My abilities to iterate on this code are probably going to be limited, but I’ll try my best;
- I was only able to test it out on xstream streams from two providers - further testing is needed for m3u to make sure I didn’t break something;
- I was only able to test it out on Linux, further testing is needed on other platforms;
- Currently all internal players seem to have buffering issues during catch-up and stop after 3 minutes (mpv is fine) - this could be due to my providers or the players themselves, TBD;