### PR TITLE
fix(portals): live channels sidebar overwrites shell panel width in localStorage

### DIFF
--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.html
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.html
@@ -8,7 +8,7 @@
         [minWidth]="250"
         [maxWidth]="600"
         [defaultWidth]="400"
-        storageKey="sidebar-width"
+        storageKey="live-channels-sidebar-width"
     >
         <div class="sidebar-header category-content-header">
             <div class="category-meta">

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.spec.ts
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.spec.ts
@@ -590,6 +590,20 @@ describe('StalkerLiveStreamLayoutComponent', () => {
         expect(stalkerStore.setItvChannels).not.toHaveBeenCalled();
     });
 
+    it('persists the channels sidebar width under a dedicated storage key', () => {
+        // The shell context panel (category sidebar) is visible at the same
+        // time as this sidebar and persists its width under the shared
+        // "sidebar-width" key. Reusing that key here makes the two panels
+        // overwrite each other's stored width across reloads.
+        fixture.detectChanges();
+
+        const sidebar: HTMLElement =
+            fixture.nativeElement.querySelector('.sidebar');
+        expect(sidebar.getAttribute('storageKey')).toBe(
+            'live-channels-sidebar-width'
+        );
+    });
+
     it('keeps row previews empty before bulk epg is loaded', async () => {
         fixture.detectChanges();
         await fixture.whenStable();

--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.html
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.html
@@ -9,7 +9,7 @@
         [minWidth]="250"
         [maxWidth]="600"
         [defaultWidth]="400"
-        storageKey="sidebar-width"
+        storageKey="live-channels-sidebar-width"
     >
         <div class="sidebar-header">
             <div class="category-heading">

--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.spec.ts
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.spec.ts
@@ -1059,6 +1059,21 @@ describe('LiveStreamLayoutComponent', () => {
         ).toBeNull();
     });
 
+    it('persists the channels sidebar width under a dedicated storage key', () => {
+        // The shell context panel (category sidebar) is visible at the same
+        // time as this sidebar and persists its width under the shared
+        // "sidebar-width" key. Reusing that key here makes the two panels
+        // overwrite each other's stored width across reloads.
+        selectedCategoryId.set(1);
+        fixture.detectChanges();
+
+        const sidebar: HTMLElement =
+            fixture.nativeElement.querySelector('.sidebar');
+        expect(sidebar.getAttribute('storageKey')).toBe(
+            'live-channels-sidebar-width'
+        );
+    });
+
     describe('auto-open from Ctrl+F search navigation state', () => {
         const searchChannel = {
             xtream_id: 202,


### PR DESCRIPTION
## Problem

The live-layout channels sidebar (Xtream and Stalker) persists its width under the shared `sidebar-width` localStorage key — the same key used by the workspace shell context panel (the Groups/categories sidebar).

The unified key works well for the shell slot panels (sources / category / settings / collection), which swap in one place and are never visible together. But on the Live TV view the **category context panel and the channels sidebar are on screen at the same time**, both writing to the same key:

1. Open an Xtream (or Stalker) playlist → Live TV, so both the Groups panel and the channels sidebar are visible.
2. Resize the channels sidebar to e.g. 550px.
3. Reload — the Groups panel now also tries to restore 550px (clamped to its own max), and whichever panel was resized last always wins for both.

## Fix

Give the live channels sidebar its own `live-channels-sidebar-width` key. Xtream and Stalker share it, since those two never coexist — same reasoning as the existing unified key, applied at the correct boundary. This follows the precedent already in the codebase: `unified-live-tab-sidebar-width` and `m3u-groups-nav-width` are dedicated keys for exactly this kind of content-area panel.

The unified `sidebar-width` key is deliberately left in place for the shell slot panels, where sharing one width across swapped-in panels is the intended behavior (ff76eb1a).

Existing users lose only the stored width for this one sidebar on first load after the update (it falls back to the 400px default once, then persists normally).

## Testing

- Added a regression test in both `live-stream-layout.component.spec.ts` and `stalker-live-stream-layout.component.spec.ts` asserting the sidebar uses the dedicated key — verified it fails against the old shared key and passes with the fix.
- `pnpm nx test portal-xtream-feature` (35 tests) and `pnpm nx test portal-stalker-feature` (17 tests) pass.
- `pnpm nx run-many --target=lint --projects=portal-xtream-feature,portal-stalker-feature` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)