### PR TITLE
feat: add catch-up functionality from global favourites & catch-up of currently live programme

### DIFF
--- a/apps/electron-backend/src/app/database/operations/favorites.operations.ts
+++ b/apps/electron-backend/src/app/database/operations/favorites.operations.ts
@@ -73,6 +73,8 @@ export async function getFavorites(db: AppDatabase, playlistId: string) {
             poster_url: schema.content.posterUrl,
             xtream_id: schema.content.xtreamId,
             type: schema.content.type,
+            tv_archive: schema.content.tvArchive,
+            tv_archive_duration: schema.content.tvArchiveDuration,
             added_at: schema.favorites.addedAt,
             position: schema.favorites.position,
         })

--- a/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/stream-resolver.service.ts
@@ -443,7 +443,14 @@ export class StreamResolverService {
         return this.fetchStalkerShortEpg(playlist, channelId, size);
     }
 
-    private async getXtreamCredentials(playlistId: string) {
+    private async getXtreamCredentials(
+        playlistId: string
+    ): Promise<{
+        serverUrl: string;
+        username: string;
+        password: string;
+        serverTimezone?: string;
+    } | null> {
         const playlist =
             (await this.getElectronPlaylist(playlistId)) ??
             ((await firstValueFrom(
@@ -458,7 +465,35 @@ export class StreamResolverService {
             serverUrl: playlist.serverUrl,
             username: playlist.username,
             password: playlist.password,
+            serverTimezone: playlist.serverTimezone,
         };
+    }
+
+    /**
+     * Resolve an Xtream archive/catch-up URL for a given programme.
+     * Returns the timeshift playback URL, or null when credentials are
+     * missing or the provider doesn't support it.
+     */
+    async resolveXtreamCatchupUrl(
+        item: UnifiedCollectionItem,
+        startTimestamp: number,
+        stopTimestamp: number
+    ): Promise<string | null> {
+        const creds = await this.getXtreamCredentials(item.playlistId);
+        if (!creds || !item.xtreamId) return null;
+
+        try {
+            return await this.xtreamUrl.resolveCatchupUrl(
+                item.playlistId,
+                creds,
+                item.xtreamId,
+                startTimestamp,
+                stopTimestamp,
+                creds.serverTimezone
+            );
+        } catch {
+            return null;
+        }
     }
 
     private async loadM3uEpg(

--- a/libs/portal/shared/data-access/src/lib/collection/unified-favorites-data.service.ts
+++ b/libs/portal/shared/data-access/src/lib/collection/unified-favorites-data.service.ts
@@ -609,6 +609,8 @@ export class UnifiedFavoritesDataService {
             categoryId: row.category_id,
             tvgId: ct === 'live' ? String(row.xtream_id) : undefined,
             rating: row.rating ?? undefined,
+            tvArchive: row.tv_archive ?? null,
+            tvArchiveDuration: row.tv_archive_duration ?? null,
             addedAt:
                 normalizeStalkerDate(row.added_at) || new Date(0).toISOString(),
             position: row.position ?? 0,
@@ -635,6 +637,8 @@ export class UnifiedFavoritesDataService {
             categoryId: item.category_id,
             tvgId: ct === 'live' ? String(item.xtream_id) : undefined,
             rating: item.rating ?? undefined,
+            tvArchive: item.tv_archive ?? null,
+            tvArchiveDuration: item.tv_archive_duration ?? null,
             addedAt:
                 normalizeStalkerDate(item.added_at ?? item.added) ||
                 new Date(0).toISOString(),

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-epg-summary.util.ts
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-epg-summary.util.ts
@@ -94,6 +94,22 @@ function findCurrentPortalProgram(
     );
 }
 
+/**
+ * Convert program start/stop to epoch seconds, preferring the
+ * numeric timestamp (which is provider-native) over the ISO string.
+ */
+export function toEpochSeconds(
+    timestamp: number | null | undefined,
+    fallbackIso: string
+): number | null {
+    if (timestamp != null && Number.isFinite(timestamp)) {
+        return timestamp;
+    }
+
+    const ms = Date.parse(fallbackIso);
+    return Number.isFinite(ms) ? Math.floor(ms / 1000) : null;
+}
+
 function getProgramTimeMs(
     rawDate: string | null | undefined,
     rawTimestamp?: number | string | null

--- a/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
+++ b/libs/portal/shared/ui/src/lib/components/unified-collection/unified-live-tab.component.ts
@@ -47,6 +47,7 @@ import {
 import {
     getLiveEpgPanelSummary,
     toEpgProgram,
+    toEpochSeconds,
     toLiveEpgPanelSummary,
 } from './unified-live-epg-summary.util';
 import { GlobalFavoritesListComponent } from '../global-favorites-list/global-favorites-list.component';
@@ -113,6 +114,10 @@ export class UnifiedLiveTabComponent {
 
     readonly activeDetail = signal<ResolvedLiveCollectionDetail | null>(null);
     readonly activeUid = signal<string | null>(null);
+    /** Full collection item for the active selection — used to read
+     *  portal archive fields (tvArchive/tvArchiveDuration) and to
+     *  supply credentials for Xtream catch-up URL resolution. */
+    readonly activeItem = signal<UnifiedCollectionItem | null>(null);
     readonly isSelecting = signal(false);
     readonly epgMap = signal<Map<string, EpgProgram | null>>(new Map());
     readonly progressTick = signal(0);
@@ -195,22 +200,35 @@ export class UnifiedLiveTabComponent {
             this.activeDetail()?.playback?.thumbnail ??
             ''
     );
-    readonly timelineArchiveAvailable = computed(
-        () =>
-            this.isM3uSelection() && this.currentM3uArchivePlaybackAvailable()
-    );
+    readonly timelineArchiveAvailable = computed(() => {
+        if (this.isM3uSelection()) {
+            return this.currentM3uArchivePlaybackAvailable();
+        }
+
+        // Portal archive: tvArchive === 1 means the provider has
+        // timeshift / archive enabled for this channel.
+        const item = this.activeItem();
+        return item?.tvArchive === 1 && (item.tvArchiveDuration ?? 0) > 0;
+    });
     /**
-     * Catch-up window (days) for the active M3U channel, so the timeline can
+     * Catch-up window (days) for the active channel, so the timeline can
      * gate "Watch" to programmes inside it. Without this the timeline defaults
      * `archiveDays` to 0 (treated as unlimited) and offers catch-up on
-     * programmes older than the channel's real `catchup-days`/`timeshift`/
-     * `tvg-rec` window. 0 for portal selections (archive is M3U-only here).
+     * programmes older than the real archive window.
+     *
+     * M3U: reads catchup-days / timeshift / tvg-rec from the channel attrs.
+     * Portal: uses the raw tv_archive_duration from the Xtream provider,
+     * matching the live-stream-layout component's controlledArchiveDays.
      */
-    readonly timelineArchiveDays = computed(() =>
-        this.timelineArchiveAvailable()
-            ? getM3uArchiveDays(this.currentM3uChannel())
-            : 0
-    );
+    readonly timelineArchiveDays = computed(() => {
+        if (!this.timelineArchiveAvailable()) return 0;
+
+        if (this.isM3uSelection()) {
+            return getM3uArchiveDays(this.currentM3uChannel());
+        }
+
+        return Math.max(1, Number(this.activeItem()?.tvArchiveDuration ?? 0));
+    });
     readonly activeRadioChannel = computed(() => {
         const channel = this.activeDetail()?.channel ?? null;
         return channel?.radio === 'true' ? channel : null;
@@ -387,9 +405,20 @@ export class UnifiedLiveTabComponent {
             return;
         }
 
+        if (this.isM3uSelection()) {
+            this.activateM3uCatchup(event.program);
+        } else {
+            void this.activatePortalCatchup(event.program);
+        }
+    }
+
+    /**
+     * M3U catch-up: resolve via the M3U timeshift URL resolver.
+     */
+    private activateM3uCatchup(program: EpgProgram): void {
         const playbackUrl = resolveM3uCatchupUrl(
             this.currentM3uChannel(),
-            event.program
+            program
         );
         if (!playbackUrl) {
             this.snackBar.open(
@@ -400,10 +429,68 @@ export class UnifiedLiveTabComponent {
             return;
         }
 
-        this.activeTimeshift.set({ url: playbackUrl, program: event.program });
+        this.activeTimeshift.set({ url: playbackUrl, program });
 
-        // No inline player (external MPV/VLC configured) → hand the archive
-        // stream to the external player, mirroring the live-selection flow.
+        const playback = this.activeDetail()?.playback;
+        if (!this.shouldUseInlinePlayer() && playback) {
+            void this.portalPlayer.openResolvedPlayback({
+                ...playback,
+                streamUrl: playbackUrl,
+                isLive: false,
+            });
+        }
+    }
+
+    /**
+     * Portal (Xtream) catch-up: compute start/stop as epoch seconds and
+     * resolve via the provider's timeshift endpoint.
+     */
+    private async activatePortalCatchup(program: EpgProgram): Promise<void> {
+        const requestId = this.selectionRequestId;
+        const item = this.activeItem();
+        if (!item?.xtreamId) {
+            this.snackBar.open(
+                this.translate.instant('EPG.TIMELINE.CATCHUP_FAILED'),
+                undefined,
+                { duration: 4000 }
+            );
+            return;
+        }
+
+        const startEpoch = toEpochSeconds(
+            program.startTimestamp,
+            program.start
+        );
+        const stopEpoch = toEpochSeconds(
+            program.stopTimestamp,
+            program.stop
+        );
+        if (startEpoch == null || stopEpoch == null) {
+            this.snackBar.open(
+                this.translate.instant('EPG.TIMELINE.CATCHUP_FAILED'),
+                undefined,
+                { duration: 4000 }
+            );
+            return;
+        }
+
+        const playbackUrl = await this.streamResolver.resolveXtreamCatchupUrl(
+            item,
+            startEpoch,
+            stopEpoch
+        );
+        if (!playbackUrl || requestId !== this.selectionRequestId) {
+            if (playbackUrl) return; // switched channel, no feedback needed
+            this.snackBar.open(
+                this.translate.instant('EPG.TIMELINE.CATCHUP_FAILED'),
+                undefined,
+                { duration: 4000 }
+            );
+            return;
+        }
+
+        this.activeTimeshift.set({ url: playbackUrl, program });
+
         const playback = this.activeDetail()?.playback;
         if (!this.shouldUseInlinePlayer() && playback) {
             void this.portalPlayer.openResolvedPlayback({
@@ -439,6 +526,7 @@ export class UnifiedLiveTabComponent {
         this.isSelecting.set(false);
         this.activeDetail.set(null);
         this.activeUid.set(null);
+        this.activeItem.set(null);
         this.activeTimeshift.set(null);
     }
 
@@ -470,6 +558,7 @@ export class UnifiedLiveTabComponent {
 
         const requestId = ++this.selectionRequestId;
         this.activeUid.set(item.uid);
+        this.activeItem.set(item);
         this.activeDetail.set(null);
         this.activeTimeshift.set(null);
         this.isSelecting.set(true);

--- a/libs/portal/shared/util/src/lib/collection/collection-helpers.ts
+++ b/libs/portal/shared/util/src/lib/collection/collection-helpers.ts
@@ -11,6 +11,8 @@ export interface XtreamFavoriteRow {
     readonly type: string;
     readonly poster_url?: string | null;
     readonly rating?: string | null;
+    readonly tv_archive?: number | null;
+    readonly tv_archive_duration?: number | null;
     readonly added_at?: string | null;
     readonly position?: number | null;
 }

--- a/libs/portal/shared/util/src/lib/collection/unified-collection-item.interface.ts
+++ b/libs/portal/shared/util/src/lib/collection/unified-collection-item.interface.ts
@@ -56,6 +56,13 @@ export interface UnifiedCollectionItem {
     /** Xtream DB content id — used for reorder / remove IPC */
     contentId?: number;
 
+    /** Whether the Xtream provider has timeshift / archive enabled for this stream */
+    tvArchive?: number | null;
+    /** Timeshift / archive window in days (Xtream `tv_archive_duration`).
+     *  Treat as days — consistent with how `live-stream-layout` exposes it
+     *  via `controlledArchiveDays`. */
+    tvArchiveDuration?: number | null;
+
     /** Stalker cmd for stream resolution */
     stalkerId?: string | number;
     stalkerCmd?: string;

--- a/libs/shared/interfaces/src/lib/playlist.interface.ts
+++ b/libs/shared/interfaces/src/lib/playlist.interface.ts
@@ -54,6 +54,8 @@ export interface Playlist {
     recentlyViewed?: PlaylistRecentlyViewedItem[];
     /** Indicates if this is a full stalker portal URL (e.g., /stalker_portal/c) requiring handshake authentication */
     isFullStalkerPortal?: boolean;
+    /** Xtream server timezone string for catch-up URL construction */
+    serverTimezone?: string;
     /** Session token for full stalker portal authentication - persisted for session */
     stalkerToken?: string;
     /** Serial number for stalker portal - generated once and stored for consistency */

--- a/libs/ui/epg/src/lib/epg-timeline/epg-archive.util.ts
+++ b/libs/ui/epg/src/lib/epg-timeline/epg-archive.util.ts
@@ -21,7 +21,8 @@ export function isWithinArchiveWindow(
     return startMs >= nowMs - archiveDays * DAY_MS;
 }
 
-/** Whether a past programme is playable from the catch-up archive. */
+/** Whether a programme is playable from the catch-up archive —
+ *  both past programmes and the currently-airing programme (start-over). */
 export function canCatchUpProgramme(
     when: TimelineWhen,
     startMs: number,
@@ -31,7 +32,7 @@ export function canCatchUpProgramme(
 ): boolean {
     return (
         archivePlaybackAvailable &&
-        when === 'past' &&
+        (when === 'past' || when === 'now') &&
         isWithinArchiveWindow(startMs, archiveDays, nowMs)
     );
 }
@@ -41,7 +42,7 @@ export function epgDialogActionFor(
     when: TimelineWhen,
     canCatchUp: boolean
 ): EpgItemDialogAction | null {
-    if (when === 'now') {
+    if (when === 'now' && !canCatchUp) {
         return 'live';
     }
     if (canCatchUp) {

--- a/libs/ui/epg/src/lib/epg-timeline/epg-timeline-render.util.ts
+++ b/libs/ui/epg/src/lib/epg-timeline/epg-timeline-render.util.ts
@@ -109,7 +109,7 @@ function toRenderBlock(
         nowFillPercent: nowFillFor(block, nowMs),
         canCatchUp:
             archivePlaybackAvailable &&
-            block.when === 'past' &&
+            (block.when === 'past' || block.when === 'now') &&
             block.startMs >= archiveWindowStartMs,
     };
 }

--- a/libs/ui/epg/src/lib/epg-timeline/epg-timeline-track.component.html
+++ b/libs/ui/epg/src/lib/epg-timeline/epg-timeline-track.component.html
@@ -80,6 +80,15 @@
                     <span class="epg-timeline__tag is-now">{{
                         'EPG.TIMELINE.ON_NOW' | translate
                     }}</span>
+                    @if (item.canCatchUp) {
+                        <button
+                            type="button"
+                            class="epg-timeline__watch"
+                            (click)="watchClick.emit(item.block); $event.stopPropagation()"
+                        >
+                            <mat-icon>replay</mat-icon>
+                        </button>
+                    }
                 } @else if (isPlaying(item)) {
                     <span class="epg-timeline__tag is-arch">{{
                         'EPG.TIMELINE.FROM_ARCHIVE' | translate

--- a/libs/ui/epg/src/lib/epg-timeline/epg-timeline-track.component.scss
+++ b/libs/ui/epg/src/lib/epg-timeline/epg-timeline-track.component.scss
@@ -167,6 +167,9 @@ $font-mono: var(--font-mono, ui-monospace, 'SF Mono', Menlo, monospace);
     position: relative;
     z-index: 1;
     flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .epg-timeline__block-time {

--- a/libs/ui/epg/src/lib/epg-timeline/epg-timeline.component.ts
+++ b/libs/ui/epg/src/lib/epg-timeline/epg-timeline.component.ts
@@ -316,15 +316,15 @@ export class EpgTimelineComponent {
 
     onBlockClick(block: TimelineBlock): void {
         this.selectedKey.set(block.key);
-        if (block.when === 'now') {
-            this.returnToLive.emit();
-            return;
-        }
         if (this.canCatchUp(block)) {
             this.programActivated.emit({
                 program: block.program,
                 type: 'timeshift',
             });
+            return;
+        }
+        if (block.when === 'now') {
+            this.returnToLive.emit();
         }
     }
 


### PR DESCRIPTION
Extends the existing catch-up infrastructure to the global favorites list and the EPG timeline. Adds tv_archive/tv_archive_duration through the data pipeline (DB queries → data service → UI component) so the timeline can detect when a provider has timeshift/archive enabled. 

The Watch from start button now appears on the current program in the timeline, and catch-up URL resolution works for both M3U and Xtream portals in the favorites context. Includes serverTimezone support for correct Xtream timeshift URL generation.