### PR TITLE
fix(search): find punctuation-joined words like "A&E" anywhere in titles

### DIFF
--- a/apps/electron-backend/src/app/database/operations/content-search.util.spec.ts
+++ b/apps/electron-backend/src/app/database/operations/content-search.util.spec.ts
@@ -1,0 +1,123 @@
+import {
+    buildCompoundFtsMatchQuery,
+    buildCompoundLikePatterns,
+    buildM3uPayloadCompoundPatterns,
+    getCompoundSearchWords,
+    scoreSearchTextMatch,
+    shouldUseContentTitlePrefixIndex,
+} from './content-search.util';
+
+describe('content-search.util', () => {
+    describe('getCompoundSearchWords', () => {
+        it('extracts punctuation-joined words from the raw search term', () => {
+            expect(getCompoundSearchWords('A&E')).toEqual(['A&E']);
+            expect(getCompoundSearchWords('US A&E HD')).toEqual(['A&E']);
+            expect(getCompoundSearchWords('Spider-Man')).toEqual([
+                'Spider-Man',
+            ]);
+            expect(getCompoundSearchWords("L'Équipe")).toEqual(["L'Équipe"]);
+        });
+
+        it('trims edge punctuation before deciding whether a word is compound', () => {
+            expect(getCompoundSearchWords('(A&E)')).toEqual(['A&E']);
+            expect(getCompoundSearchWords('"A&E:"')).toEqual(['A&E']);
+        });
+
+        it('ignores plain words, standalone punctuation and too-short fragments', () => {
+            expect(getCompoundSearchWords('History')).toEqual([]);
+            expect(getCompoundSearchWords('Tom & Jerry')).toEqual([]);
+            expect(getCompoundSearchWords('a&')).toEqual([]);
+            expect(getCompoundSearchWords('')).toEqual([]);
+            expect(getCompoundSearchWords(undefined)).toEqual([]);
+        });
+
+    });
+
+    describe('buildCompoundFtsMatchQuery', () => {
+        it('quotes each compound word as a trigram substring phrase', () => {
+            expect(buildCompoundFtsMatchQuery('A&E')).toBe('"a&e"');
+            expect(buildCompoundFtsMatchQuery('X-Men')).toBe('"x-men"');
+        });
+
+        it('keeps accented and diacritic-stripped variants', () => {
+            expect(buildCompoundFtsMatchQuery("L'Équipe")).toBe(
+                '("l\'équipe" OR "l\'equipe")'
+            );
+        });
+
+        it('joins multiple compound words with AND', () => {
+            expect(buildCompoundFtsMatchQuery('A&E X-Men')).toBe(
+                '"a&e" AND "x-men"'
+            );
+        });
+
+        it('returns an empty query for terms without compound words', () => {
+            expect(buildCompoundFtsMatchQuery('History Channel')).toBe('');
+            expect(buildCompoundFtsMatchQuery('tv')).toBe('');
+        });
+    });
+
+    describe('buildCompoundLikePatterns', () => {
+        it('builds case-variant contains patterns around the intact word', () => {
+            const patterns = buildCompoundLikePatterns('A&E');
+
+            expect(patterns).toContain('%a&e%');
+            expect(patterns).toContain('%A&E%');
+            expect(
+                patterns.every(
+                    (pattern) =>
+                        pattern.startsWith('%') && pattern.endsWith('%')
+                )
+            ).toBe(true);
+        });
+
+        it('escapes LIKE wildcards inside the compound word', () => {
+            expect(buildCompoundLikePatterns('a_b')).toContain('%a\\_b%');
+        });
+    });
+
+    describe('buildM3uPayloadCompoundPatterns', () => {
+        it('scopes compound contains patterns to payload name/title fields', () => {
+            const patterns = buildM3uPayloadCompoundPatterns('A&E');
+
+            expect(patterns).toContain('%"name":"%a&e%"%');
+            expect(patterns).toContain('%"title":"%a&e%"%');
+        });
+    });
+
+    describe('shouldUseContentTitlePrefixIndex', () => {
+        it('still routes compound short-token terms through the prefix index', () => {
+            // The compound FTS lookup supplements the prefix arm instead of
+            // replacing it, so titles starting with "A & E" keep matching.
+            expect(shouldUseContentTitlePrefixIndex('A&E')).toBe(true);
+            expect(shouldUseContentTitlePrefixIndex('Spider-Man')).toBe(false);
+        });
+    });
+
+    describe('scoreSearchTextMatch', () => {
+        it('matches compound words anywhere in the title (issue #1161)', () => {
+            expect(scoreSearchTextMatch('US: A&E', 'A&E')).toBe(40);
+            expect(scoreSearchTextMatch('US | A&E HD', 'A&E HD')).toBe(40);
+            expect(scoreSearchTextMatch('(US) A&E', 'A&E')).toBe(40);
+        });
+
+        it('keeps exact and prefix compound matches ranked above mid-title ones', () => {
+            expect(scoreSearchTextMatch('A&E', 'A&E')).toBe(0);
+            expect(scoreSearchTextMatch('A&E HD', 'A&E')).toBe(10);
+        });
+
+        it('does not match the phrase across word boundaries', () => {
+            expect(scoreSearchTextMatch('Casa e Villa', 'A&E')).toBeNull();
+            expect(scoreSearchTextMatch('Bravo Espana', 'A&E')).toBeNull();
+        });
+
+        it('requires every extra token, not just the compound word', () => {
+            expect(scoreSearchTextMatch('US: A&E', 'A&E HD')).toBeNull();
+        });
+
+        it('keeps single short tokens anchored to the title start', () => {
+            expect(scoreSearchTextMatch('TV Sport News', 'tv')).toBe(10);
+            expect(scoreSearchTextMatch('Test TV', 'tv')).toBeNull();
+        });
+    });
+});

--- a/apps/electron-backend/src/app/database/operations/content-search.util.spec.ts
+++ b/apps/electron-backend/src/app/database/operations/content-search.util.spec.ts
@@ -2,7 +2,9 @@ import {
     buildCompoundFtsMatchQuery,
     buildCompoundLikePatterns,
     buildM3uPayloadCompoundPatterns,
+    getCompoundResidualTokenGroups,
     getCompoundSearchWords,
+    getSearchWordPlans,
     scoreSearchTextMatch,
     shouldUseContentTitlePrefixIndex,
 } from './content-search.util';
@@ -31,6 +33,32 @@ describe('content-search.util', () => {
             expect(getCompoundSearchWords(undefined)).toEqual([]);
         });
 
+    });
+
+    describe('getSearchWordPlans', () => {
+        it('keeps each word with its own token groups and compound flag', () => {
+            expect(getSearchWordPlans('A&E HD')).toEqual([
+                { compound: 'A&E', tokenGroups: [['a'], ['e']] },
+                { compound: null, tokenGroups: [['hd']] },
+            ]);
+        });
+
+        it('skips punctuation-only words', () => {
+            expect(getSearchWordPlans('Tom & Jerry')).toEqual([
+                { compound: null, tokenGroups: [['tom']] },
+                { compound: null, tokenGroups: [['jerry']] },
+            ]);
+        });
+    });
+
+    describe('getCompoundResidualTokenGroups', () => {
+        it('returns the token groups of the non-compound words only', () => {
+            expect(getCompoundResidualTokenGroups('A&E HD')).toEqual([['hd']]);
+            expect(getCompoundResidualTokenGroups('A&E')).toEqual([]);
+            expect(getCompoundResidualTokenGroups('History')).toEqual([
+                ['history'],
+            ]);
+        });
     });
 
     describe('buildCompoundFtsMatchQuery', () => {

--- a/apps/electron-backend/src/app/database/operations/content-search.util.ts
+++ b/apps/electron-backend/src/app/database/operations/content-search.util.ts
@@ -1,0 +1,319 @@
+/**
+ * Pure text helpers for the content search pipeline (global search,
+ * per-playlist search and M3U payload search). Everything here is
+ * side-effect free and independent of drizzle so it can be unit tested
+ * without database mocks; the SQL condition builders that consume these
+ * helpers live in `content.operations.ts`.
+ */
+
+/** Minimum length the trigram FTS index can match (trigram = 3 chars). */
+const MIN_COMPOUND_WORD_LENGTH = 3;
+
+const WORD_EDGE_PUNCTUATION_REGEXP = /^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu;
+const INNER_PUNCTUATION_REGEXP = /[^\p{L}\p{N}]/u;
+
+export function escapeLikePattern(term: string): string {
+    return term.replace(/[%_\\]/g, '\\$&');
+}
+
+export function normalizeSearchMatchText(value: unknown): string {
+    return typeof value === 'string'
+        ? value
+              .normalize('NFKD')
+              .replace(/[\u0300-\u036f]/g, '')
+              .toLocaleLowerCase()
+              .replace(/[^\p{L}\p{N}]+/gu, ' ')
+              .trim()
+              .replace(/\s+/g, ' ')
+        : '';
+}
+
+function normalizeSqlSearchText(value: unknown): string {
+    return typeof value === 'string'
+        ? value
+              .toLocaleLowerCase()
+              .replace(/[^\p{L}\p{N}]+/gu, ' ')
+              .trim()
+              .replace(/\s+/g, ' ')
+        : '';
+}
+
+function getSearchTokens(value: unknown): string[] {
+    const normalized = normalizeSearchMatchText(value);
+    return normalized ? normalized.split(' ') : [];
+}
+
+export function getSqlSearchTokenGroups(value: unknown): string[][] {
+    const rawTokens = normalizeSqlSearchText(value).split(' ').filter(Boolean);
+    const normalizedTokens = getSearchTokens(value);
+    const tokenCount = Math.max(rawTokens.length, normalizedTokens.length);
+
+    return Array.from({ length: tokenCount }, (_, index) =>
+        [...new Set([rawTokens[index], normalizedTokens[index]])].filter(
+            Boolean
+        )
+    ).filter((group) => group.length > 0);
+}
+
+export function isShortSearchTokenGroup(tokens: readonly string[]): boolean {
+    return tokens.some((token) => token.length <= 2);
+}
+
+function getSqlSearchTokenVariants(value: unknown): string[] {
+    return [...new Set(getSqlSearchTokenGroups(value).flat())];
+}
+
+export function buildLikePatterns(
+    term: string,
+    mode: 'contains' | 'prefix' = 'contains'
+): string[] {
+    const variants = new Set<string>();
+
+    for (const value of [term, ...getSqlSearchTokenVariants(term)]) {
+        const trimmedValue = value.trim();
+        if (!trimmedValue) {
+            continue;
+        }
+
+        const titleCase =
+            trimmedValue.length > 0
+                ? trimmedValue.charAt(0).toLocaleUpperCase() +
+                  trimmedValue.slice(1).toLocaleLowerCase()
+                : trimmedValue;
+
+        variants.add(trimmedValue);
+        variants.add(trimmedValue.toLocaleLowerCase());
+        variants.add(trimmedValue.toLocaleUpperCase());
+        variants.add(titleCase);
+    }
+
+    return [...variants].map((value) => {
+        const escapedValue = escapeLikePattern(value);
+        return mode === 'prefix' ? `${escapedValue}%` : `%${escapedValue}%`;
+    });
+}
+
+export function buildGlobPrefixPatterns(token: string): string[] {
+    const variants = new Set<string>();
+
+    for (const value of [token, ...getSqlSearchTokenVariants(token)]) {
+        variants.add(value);
+        variants.add(value.toLocaleLowerCase());
+        variants.add(value.toLocaleUpperCase());
+        variants.add(
+            value.charAt(0).toLocaleUpperCase() +
+                value.slice(1).toLocaleLowerCase()
+        );
+    }
+
+    return [...variants].map((value) => `${value}*`);
+}
+
+export function shouldUseContentTitlePrefixIndex(searchTerm: string): boolean {
+    const [firstTokenGroup] = getSqlSearchTokenGroups(searchTerm);
+
+    return !!firstTokenGroup && isShortSearchTokenGroup(firstTokenGroup);
+}
+
+export function buildContentTitleFtsMatchQuery(searchTerm: string): string {
+    return getSqlSearchTokenGroups(searchTerm)
+        .map((tokens) => {
+            const quotedTokens = tokens
+                .filter((token) => token.length >= 3)
+                .map((token) => `"${token.replace(/"/g, '""')}"`);
+
+            if (quotedTokens.length <= 1) {
+                return quotedTokens[0] ?? '';
+            }
+
+            return `(${quotedTokens.join(' OR ')})`;
+        })
+        .filter(Boolean)
+        .join(' AND ');
+}
+
+export function shouldUseContentTitleFts(searchTerm: string): boolean {
+    return (
+        !shouldUseContentTitlePrefixIndex(searchTerm) &&
+        buildContentTitleFtsMatchQuery(searchTerm).length > 0
+    );
+}
+
+/**
+ * Whitespace-delimited words from the raw search term that still contain
+ * internal punctuation after trimming their edges — e.g. `a&e`, `x-men`,
+ * `l'équipe`. Tokenization splits these into (often 1-letter) fragments
+ * whose short-token handling anchors the search to the title start, so the
+ * intact word is preserved as an additional exact-substring search unit
+ * (issue #1161: "A&E" not finding "US: A&E").
+ */
+export function getCompoundSearchWords(value: unknown): string[] {
+    if (typeof value !== 'string') {
+        return [];
+    }
+
+    const words = new Set<string>();
+    for (const rawWord of value.split(/\s+/)) {
+        const word = rawWord.replace(WORD_EDGE_PUNCTUATION_REGEXP, '');
+        if (
+            word.length < MIN_COMPOUND_WORD_LENGTH ||
+            !INNER_PUNCTUATION_REGEXP.test(word)
+        ) {
+            continue;
+        }
+        words.add(word);
+    }
+
+    return [...words];
+}
+
+/** As-typed plus diacritic-stripped forms, both long enough for trigram FTS. */
+function getCompoundWordVariants(word: string): string[] {
+    const stripped = word.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+
+    return [...new Set([word, stripped])].filter(
+        (variant) => variant.length >= MIN_COMPOUND_WORD_LENGTH
+    );
+}
+
+/**
+ * Case/diacritic LIKE variants of a compound word as contains patterns
+ * (`%a&e%`). SQLite LIKE is only case-insensitive for ASCII, so the same
+ * lower/upper/title-case expansion as `buildLikePatterns` is applied.
+ */
+export function buildCompoundLikePatterns(word: string): string[] {
+    const variants = new Set<string>();
+
+    for (const value of getCompoundWordVariants(word)) {
+        variants.add(value);
+        variants.add(value.toLocaleLowerCase());
+        variants.add(value.toLocaleUpperCase());
+        variants.add(
+            value.charAt(0).toLocaleUpperCase() +
+                value.slice(1).toLocaleLowerCase()
+        );
+    }
+
+    return [...variants].map((value) => `%${escapeLikePattern(value)}%`);
+}
+
+/**
+ * Trigram FTS match query treating each compound word as a quoted substring
+ * phrase: `"a&e"`, `("café" OR "cafe")`. The trigram tokenizer matches
+ * case-insensitive substrings of >= 3 chars, so this finds the compound word
+ * anywhere in the title without a table scan. Returns '' when the term has
+ * no compound words.
+ */
+export function buildCompoundFtsMatchQuery(searchTerm: string): string {
+    return getCompoundSearchWords(searchTerm)
+        .map((word) => {
+            const quotedVariants = [
+                ...new Set(
+                    getCompoundWordVariants(word).map((variant) =>
+                        variant.toLocaleLowerCase()
+                    )
+                ),
+            ].map((variant) => `"${variant.replace(/"/g, '""')}"`);
+
+            if (quotedVariants.length <= 1) {
+                return quotedVariants[0] ?? '';
+            }
+
+            return `(${quotedVariants.join(' OR ')})`;
+        })
+        .filter(Boolean)
+        .join(' AND ');
+}
+
+export function buildM3uPayloadTextFieldPatterns(
+    token: string,
+    mode: 'contains' | 'prefix'
+): string[] {
+    return buildLikePatterns(token, mode).flatMap((pattern) =>
+        wrapM3uPayloadTextFieldPattern(pattern)
+    );
+}
+
+/** Compound-word contains patterns scoped to M3U payload name/title fields. */
+export function buildM3uPayloadCompoundPatterns(word: string): string[] {
+    return buildCompoundLikePatterns(word).flatMap((pattern) =>
+        wrapM3uPayloadTextFieldPattern(pattern)
+    );
+}
+
+function wrapM3uPayloadTextFieldPattern(pattern: string): string[] {
+    return [
+        `%"name":"${pattern}"%`,
+        `%"name": "${pattern}"%`,
+        `%"title":"${pattern}"%`,
+        `%"title": "${pattern}"%`,
+    ];
+}
+
+export function scoreSearchTextMatch(
+    value: string,
+    searchTerm: string
+): number | null {
+    const candidateText = normalizeSearchMatchText(value);
+    const searchText = normalizeSearchMatchText(searchTerm);
+    if (!candidateText || !searchText) {
+        return null;
+    }
+
+    const searchTokens = searchText.split(' ');
+    const candidateTokens = candidateText.split(' ');
+    const firstSearchToken = searchTokens[0];
+
+    if (
+        firstSearchToken.length <= 2 &&
+        !candidateText.startsWith(firstSearchToken)
+    ) {
+        // Short first tokens stay prefix-anchored to keep one-letter noise
+        // out, but a multi-token phrase ("a e" from "A&E") may still match as
+        // a whole word sequence anywhere in the title ("US: A&E").
+        if (
+            searchTokens.length > 1 &&
+            ` ${candidateText} `.includes(` ${searchText} `)
+        ) {
+            return 40;
+        }
+        return null;
+    }
+
+    if (candidateText === searchText) {
+        return 0;
+    }
+
+    if (
+        candidateText.startsWith(searchText) &&
+        (searchTokens.length > 1 || firstSearchToken.length <= 2)
+    ) {
+        return 10;
+    }
+
+    if (candidateTokens.some((token) => token.startsWith(searchText))) {
+        return 20;
+    }
+
+    if (
+        searchTokens.every((searchToken) =>
+            candidateTokens.some((candidateToken) =>
+                candidateToken.startsWith(searchToken)
+            )
+        )
+    ) {
+        return 30;
+    }
+
+    if (candidateText.includes(searchText)) {
+        return 40;
+    }
+
+    if (
+        searchTokens.every((searchToken) => candidateText.includes(searchToken))
+    ) {
+        return 50;
+    }
+
+    return null;
+}

--- a/apps/electron-backend/src/app/database/operations/content-search.util.ts
+++ b/apps/electron-backend/src/app/database/operations/content-search.util.ts
@@ -167,6 +167,57 @@ export function getCompoundSearchWords(value: unknown): string[] {
     return [...words];
 }
 
+/**
+ * One whitespace-delimited search word with its token groups. `compound` is
+ * the intact word when it contains internal punctuation (see
+ * `getCompoundSearchWords`), else null. SQL condition builders compose
+ * per-word conditions from this so a compound word's substring arm stays
+ * AND-constrained by the other words of the query — `A&E HD` must not let
+ * plain `A&E` titles flood the SQL candidate window before scoring runs.
+ */
+export interface SearchWordPlan {
+    compound: string | null;
+    tokenGroups: string[][];
+}
+
+export function getSearchWordPlans(value: unknown): SearchWordPlan[] {
+    if (typeof value !== 'string') {
+        return [];
+    }
+
+    const plans: SearchWordPlan[] = [];
+    for (const rawWord of value.split(/\s+/)) {
+        const word = rawWord.replace(WORD_EDGE_PUNCTUATION_REGEXP, '');
+        if (!word) {
+            continue;
+        }
+
+        const tokenGroups = getSqlSearchTokenGroups(word);
+        if (tokenGroups.length === 0) {
+            continue;
+        }
+
+        const isCompound =
+            word.length >= MIN_COMPOUND_WORD_LENGTH &&
+            INNER_PUNCTUATION_REGEXP.test(word);
+        plans.push({ compound: isCompound ? word : null, tokenGroups });
+    }
+
+    return plans;
+}
+
+/**
+ * Token groups of the non-compound words of the term. When the compound FTS
+ * arm looks up `"a&e"` for `A&E HD`, these groups (`hd`) are re-applied as
+ * LIKE conditions so the supplement cannot fill the candidate limit with
+ * titles that match the compound word alone.
+ */
+export function getCompoundResidualTokenGroups(value: unknown): string[][] {
+    return getSearchWordPlans(value)
+        .filter((plan) => plan.compound === null)
+        .flatMap((plan) => plan.tokenGroups);
+}
+
 /** As-typed plus diacritic-stripped forms, both long enough for trigram FTS. */
 function getCompoundWordVariants(word: string): string[] {
     const stripped = word.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');

--- a/apps/electron-backend/src/app/database/operations/content.operations.spec.ts
+++ b/apps/electron-backend/src/app/database/operations/content.operations.spec.ts
@@ -12,6 +12,10 @@ const inArrayMock = jest.fn((left: unknown, values: unknown[]) => ({
     left,
     values,
 }));
+const orMock = jest.fn((...conditions: unknown[]) => ({
+    kind: 'or',
+    conditions,
+}));
 const sqlJoinMock = jest.fn((chunks: unknown[], separator?: unknown) => ({
     kind: 'sql.join',
     chunks,
@@ -34,7 +38,7 @@ jest.mock('drizzle-orm', () => ({
     desc: jest.fn(),
     eq: (left: unknown, right: unknown) => eqMock(left, right),
     inArray: (left: unknown, values: unknown[]) => inArrayMock(left, values),
-    or: jest.fn(),
+    or: (...conditions: unknown[]) => orMock(...conditions),
     sql: sqlMock,
 }));
 
@@ -47,6 +51,7 @@ import {
     getGlobalRecentlyAdded,
     saveContent,
     scoreSearchTextMatch,
+    searchContent,
 } from './content.operations';
 
 function createDbMock(result: unknown[] = []) {
@@ -111,6 +116,7 @@ describe('content.operations', () => {
         andMock.mockClear();
         eqMock.mockClear();
         inArrayMock.mockClear();
+        orMock.mockClear();
         sqlJoinMock.mockClear();
         sqlMock.mockClear();
     });
@@ -750,6 +756,237 @@ describe('content.operations', () => {
                     pattern.includes('"name"') || pattern.includes('"title"')
             )
         ).toBe(true);
+    });
+
+    it('finds compound-word channels anywhere in M3U channel names (issue #1161)', () => {
+        const makeChannel = (id: string, name: string) => ({
+            id,
+            url: `https://stream.test/${id}.m3u8`,
+            name,
+            group: { title: 'Entertainment' },
+            tvg: {
+                id,
+                name: '',
+                url: '',
+                logo: '',
+                rec: '',
+            },
+            http: {
+                referrer: '',
+                'user-agent': '',
+                origin: '',
+            },
+            radio: '',
+        });
+
+        const results = buildM3uGlobalSearchResults(
+            [
+                {
+                    id: 'm3u-1',
+                    name: 'M3U One',
+                    payload: JSON.stringify({
+                        playlist: {
+                            items: [
+                                makeChannel('prefixed', 'US: A&E'),
+                                makeChannel('exact', 'A&E'),
+                                makeChannel('noise', 'Casa e Villa'),
+                                makeChannel('other', 'Bravo Espana'),
+                            ],
+                        },
+                    }),
+                },
+            ],
+            'A&E',
+            false
+        );
+
+        expect(results.map((item) => item.title)).toEqual(['A&E', 'US: A&E']);
+    });
+
+    it('finds compound-word titles anywhere via per-playlist search (issue #1161)', async () => {
+        const makeRow = (id: number, title: string) => ({
+            id,
+            category_id: 10,
+            title,
+            rating: '',
+            added: '',
+            poster_url: '',
+            epg_channel_id: '',
+            tv_archive: 0,
+            tv_archive_duration: 0,
+            direct_source: '',
+            xtream_id: id,
+            type: 'live',
+        });
+        const limit = jest
+            .fn()
+            .mockResolvedValue([
+                makeRow(1, 'US: A&E'),
+                makeRow(2, 'Casa e Villa'),
+            ]);
+        const where = jest.fn().mockReturnValue({ limit });
+        const innerJoin = jest.fn().mockReturnValue({ where });
+        const from = jest.fn().mockReturnValue({ innerJoin });
+        const select = jest.fn().mockReturnValue({ from });
+        const db = {
+            select,
+        } as unknown as AppDatabase;
+
+        const results = await searchContent(db, 'playlist-1', 'A&E', ['live']);
+
+        expect(results.map((item) => item.title)).toEqual(['US: A&E']);
+
+        // The intact compound word must reach SQL as a contains pattern and
+        // be OR-combined with the prefix-anchored token conditions.
+        const patterns = sqlMock.mock.calls
+            .flatMap(([, ...values]) => values)
+            .filter((value): value is string => typeof value === 'string');
+        expect(patterns).toContain('%a&e%');
+        expect(where.mock.calls[0][0].conditions).toEqual(
+            expect.arrayContaining([expect.objectContaining({ kind: 'or' })])
+        );
+    });
+
+    it('supplements short compound global searches with a trigram FTS substring lookup', async () => {
+        const makeRow = (id: number, title: string) => ({
+            id,
+            category_id: 10,
+            title,
+            rating: '',
+            added: '',
+            poster_url: '',
+            epg_channel_id: '',
+            tv_archive: 0,
+            tv_archive_duration: 0,
+            direct_source: '',
+            xtream_id: id,
+            type: 'live',
+            playlist_id: 'playlist-1',
+            playlist_name: 'Playlist One',
+        });
+        const all = jest
+            .fn()
+            // Prefix-index arm: titles starting with the short first token.
+            .mockResolvedValueOnce([makeRow(1, 'A&E')])
+            // FTS arm: compound substring matches, overlapping with the
+            // prefix arm to prove candidates are deduplicated.
+            .mockResolvedValueOnce([
+                makeRow(2, 'US: A&E'),
+                makeRow(1, 'A&E'),
+            ]);
+        const select = jest.fn();
+        const db = {
+            all,
+            select,
+        } as unknown as AppDatabase;
+
+        const results = await globalSearch(
+            db,
+            'A&E',
+            ['live'],
+            false,
+            ['xtream'],
+            { limit: 10 }
+        );
+
+        expect(all).toHaveBeenCalledTimes(2);
+        expect(select).not.toHaveBeenCalled();
+
+        const matchSqlCall = sqlMock.mock.calls.find(([strings]) =>
+            Array.from(strings as TemplateStringsArray)
+                .join(' ')
+                .includes('content_title_fts MATCH')
+        );
+        expect(matchSqlCall?.[1]).toBe('"a&e"');
+
+        expect(results.map((item) => item.title)).toEqual(['A&E', 'US: A&E']);
+    });
+
+    it('falls back to a content scan when the compound FTS lookup fails', async () => {
+        const globRow = {
+            id: 1,
+            category_id: 10,
+            title: 'A&E',
+            rating: '',
+            added: '',
+            poster_url: '',
+            epg_channel_id: '',
+            tv_archive: 0,
+            tv_archive_duration: 0,
+            direct_source: '',
+            xtream_id: 1,
+            type: 'live',
+            playlist_id: 'playlist-1',
+            playlist_name: 'Playlist One',
+        };
+        const scanRow = {
+            ...globRow,
+            id: 2,
+            xtream_id: 2,
+            title: 'US: A&E',
+        };
+        const all = jest
+            .fn()
+            .mockResolvedValueOnce([globRow])
+            .mockRejectedValueOnce(new Error('no such table: content_title_fts'));
+        const limit = jest.fn().mockResolvedValue([globRow, scanRow]);
+        const orderBy = jest.fn().mockReturnValue({ limit });
+        const where = jest.fn().mockReturnValue({ orderBy });
+        const innerJoin2 = jest.fn().mockReturnValue({ where });
+        const innerJoin1 = jest.fn().mockReturnValue({ innerJoin: innerJoin2 });
+        const from = jest.fn().mockReturnValue({ innerJoin: innerJoin1 });
+        const select = jest.fn().mockReturnValue({ from });
+        const db = {
+            all,
+            select,
+        } as unknown as AppDatabase;
+
+        const results = await globalSearch(
+            db,
+            'A&E',
+            ['live'],
+            false,
+            ['xtream'],
+            { limit: 10 }
+        );
+
+        expect(all).toHaveBeenCalledTimes(2);
+        expect(select).toHaveBeenCalledTimes(1);
+        expect(results.map((item) => item.title)).toEqual(['A&E', 'US: A&E']);
+    });
+
+    it('adds compound contains patterns to the M3U payload prefilter', async () => {
+        const limit = jest.fn().mockResolvedValue([]);
+        const orderedQuery = {
+            limit,
+            then: (resolve: (value: unknown[]) => void) => resolve([]),
+        };
+        const orderBy = jest.fn().mockReturnValue(orderedQuery);
+        const where = jest.fn().mockReturnValue({ orderBy });
+        const from = jest.fn().mockReturnValue({ where });
+        const select = jest.fn().mockReturnValue({ from });
+        const db = {
+            select,
+        } as unknown as AppDatabase;
+
+        await globalSearch(db, 'A&E', ['live'], false, ['m3u'], {
+            limit: 10,
+        });
+
+        const searchPatterns = sqlMock.mock.calls
+            .flatMap(([, ...values]) => values)
+            .filter(
+                (value): value is string =>
+                    typeof value === 'string' &&
+                    value.toLocaleLowerCase().includes('a&e')
+            );
+
+        expect(searchPatterns).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining('"name":"%a&e%"'),
+                expect.stringContaining('"title":"%a&e%"'),
+            ])
+        );
     });
 
     it('keeps accented M3U payload text field variants in SQL prefilters', async () => {

--- a/apps/electron-backend/src/app/database/operations/content.operations.spec.ts
+++ b/apps/electron-backend/src/app/database/operations/content.operations.spec.ts
@@ -902,6 +902,68 @@ describe('content.operations', () => {
         expect(results.map((item) => item.title)).toEqual(['A&E', 'US: A&E']);
     });
 
+    it('keeps non-compound tokens as conditions on the compound FTS supplement', async () => {
+        const all = jest.fn().mockResolvedValue([]);
+        const db = {
+            all,
+            select: jest.fn(),
+        } as unknown as AppDatabase;
+
+        await globalSearch(db, 'A&E HD', ['live'], false, ['xtream'], {
+            limit: 10,
+        });
+
+        expect(all).toHaveBeenCalledTimes(2);
+
+        const matchSqlCall = sqlMock.mock.calls.find(([strings]) =>
+            Array.from(strings as TemplateStringsArray)
+                .join(' ')
+                .includes('content_title_fts MATCH')
+        );
+        expect(matchSqlCall?.[1]).toBe('"a&e"');
+
+        // The FTS arm must AND-in the residual "hd" token so plain "A&E"
+        // titles cannot exhaust the candidate limit before scoring runs.
+        const residualPatterns = sqlMock.mock.calls
+            .filter(([strings]) =>
+                Array.from(strings as TemplateStringsArray)
+                    .join(' ')
+                    .includes('c.title LIKE')
+            )
+            .flatMap(([, ...values]) => values)
+            .filter((value): value is string => typeof value === 'string');
+        expect(residualPatterns).toContain('%hd%');
+    });
+
+    it('requires every word of a multi-token compound term in per-playlist SQL conditions', async () => {
+        const limit = jest.fn().mockResolvedValue([]);
+        const where = jest.fn().mockReturnValue({ limit });
+        const innerJoin = jest.fn().mockReturnValue({ where });
+        const from = jest.fn().mockReturnValue({ innerJoin });
+        const select = jest.fn().mockReturnValue({ from });
+        const db = {
+            select,
+        } as unknown as AppDatabase;
+
+        await searchContent(db, 'playlist-1', 'A&E HD', ['live']);
+
+        // One condition per word: the compound "A&E" word (an OR with the
+        // intact-substring arm) plus the plain "hd" word — both AND-ed, so
+        // the compound arm cannot bypass the "hd" requirement.
+        const conditions = where.mock.calls[0][0].conditions as Array<{
+            kind: string;
+        }>;
+        expect(conditions).toHaveLength(4);
+        expect(conditions[2]).toEqual(expect.objectContaining({ kind: 'or' }));
+        expect(conditions[3]).toEqual(expect.objectContaining({ kind: 'and' }));
+
+        const patterns = sqlMock.mock.calls
+            .flatMap(([, ...values]) => values)
+            .filter((value): value is string => typeof value === 'string');
+        expect(patterns).toContain('%a&e%');
+        expect(patterns).toContain('%hd%');
+    });
+
     it('falls back to a content scan when the compound FTS lookup fails', async () => {
         const globRow = {
             id: 1,

--- a/apps/electron-backend/src/app/database/operations/content.operations.ts
+++ b/apps/electron-backend/src/app/database/operations/content.operations.ts
@@ -15,92 +15,29 @@ import {
 } from '@iptvnator/shared/interfaces';
 import type { AppDatabase } from '../database.types';
 import {
+    buildCompoundFtsMatchQuery,
+    buildCompoundLikePatterns,
+    buildContentTitleFtsMatchQuery,
+    buildGlobPrefixPatterns,
+    buildLikePatterns,
+    buildM3uPayloadCompoundPatterns,
+    buildM3uPayloadTextFieldPatterns,
+    getCompoundSearchWords,
+    getSqlSearchTokenGroups,
+    isShortSearchTokenGroup,
+    normalizeSearchMatchText,
+    scoreSearchTextMatch,
+    shouldUseContentTitleFts,
+    shouldUseContentTitlePrefixIndex,
+} from './content-search.util';
+import {
     checkpointOperation,
     chunkValues,
     type OperationControl,
     reportOperationProgress,
 } from './operation-control';
 
-function escapeLikePattern(term: string): string {
-    return term.replace(/[%_\\]/g, '\\$&');
-}
-
-function normalizeSearchMatchText(value: unknown): string {
-    return typeof value === 'string'
-        ? value
-              .normalize('NFKD')
-              .replace(/[\u0300-\u036f]/g, '')
-              .toLocaleLowerCase()
-              .replace(/[^\p{L}\p{N}]+/gu, ' ')
-              .trim()
-              .replace(/\s+/g, ' ')
-        : '';
-}
-
-function normalizeSqlSearchText(value: unknown): string {
-    return typeof value === 'string'
-        ? value
-              .toLocaleLowerCase()
-              .replace(/[^\p{L}\p{N}]+/gu, ' ')
-              .trim()
-              .replace(/\s+/g, ' ')
-        : '';
-}
-
-function getSearchTokens(value: unknown): string[] {
-    const normalized = normalizeSearchMatchText(value);
-    return normalized ? normalized.split(' ') : [];
-}
-
-function getSqlSearchTokenGroups(value: unknown): string[][] {
-    const rawTokens = normalizeSqlSearchText(value).split(' ').filter(Boolean);
-    const normalizedTokens = getSearchTokens(value);
-    const tokenCount = Math.max(rawTokens.length, normalizedTokens.length);
-
-    return Array.from({ length: tokenCount }, (_, index) =>
-        [...new Set([rawTokens[index], normalizedTokens[index]])].filter(
-            Boolean
-        )
-    ).filter((group) => group.length > 0);
-}
-
-function isShortSearchTokenGroup(tokens: readonly string[]): boolean {
-    return tokens.some((token) => token.length <= 2);
-}
-
-function getSqlSearchTokenVariants(value: unknown): string[] {
-    return [...new Set(getSqlSearchTokenGroups(value).flat())];
-}
-
-function buildLikePatterns(
-    term: string,
-    mode: 'contains' | 'prefix' = 'contains'
-): string[] {
-    const variants = new Set<string>();
-
-    for (const value of [term, ...getSqlSearchTokenVariants(term)]) {
-        const trimmedValue = value.trim();
-        if (!trimmedValue) {
-            continue;
-        }
-
-        const titleCase =
-            trimmedValue.length > 0
-                ? trimmedValue.charAt(0).toLocaleUpperCase() +
-                  trimmedValue.slice(1).toLocaleLowerCase()
-                : trimmedValue;
-
-        variants.add(trimmedValue);
-        variants.add(trimmedValue.toLocaleLowerCase());
-        variants.add(trimmedValue.toLocaleUpperCase());
-        variants.add(titleCase);
-    }
-
-    return [...variants].map((value) => {
-        const escapedValue = escapeLikePattern(value);
-        return mode === 'prefix' ? `${escapedValue}%` : `%${escapedValue}%`;
-    });
-}
+export { scoreSearchTextMatch } from './content-search.util';
 
 const DEFAULT_GLOBAL_SEARCH_LIMIT = 50;
 const MAX_GLOBAL_SEARCH_LIMIT = 500;
@@ -174,65 +111,6 @@ function normalizeGlobalSearchPagination(
     return { limit, offset };
 }
 
-export function scoreSearchTextMatch(
-    value: string,
-    searchTerm: string
-): number | null {
-    const candidateText = normalizeSearchMatchText(value);
-    const searchText = normalizeSearchMatchText(searchTerm);
-    if (!candidateText || !searchText) {
-        return null;
-    }
-
-    const searchTokens = searchText.split(' ');
-    const candidateTokens = candidateText.split(' ');
-    const firstSearchToken = searchTokens[0];
-
-    if (
-        firstSearchToken.length <= 2 &&
-        !candidateText.startsWith(firstSearchToken)
-    ) {
-        return null;
-    }
-
-    if (candidateText === searchText) {
-        return 0;
-    }
-
-    if (
-        candidateText.startsWith(searchText) &&
-        (searchTokens.length > 1 || firstSearchToken.length <= 2)
-    ) {
-        return 10;
-    }
-
-    if (candidateTokens.some((token) => token.startsWith(searchText))) {
-        return 20;
-    }
-
-    if (
-        searchTokens.every((searchToken) =>
-            candidateTokens.some((candidateToken) =>
-                candidateToken.startsWith(searchToken)
-            )
-        )
-    ) {
-        return 30;
-    }
-
-    if (candidateText.includes(searchText)) {
-        return 40;
-    }
-
-    if (
-        searchTokens.every((searchToken) => candidateText.includes(searchToken))
-    ) {
-        return 50;
-    }
-
-    return null;
-}
-
 function compareScoredGlobalSearchResults(
     first: ScoredGlobalSearchResult,
     second: ScoredGlobalSearchResult
@@ -284,7 +162,7 @@ function buildContentTitleSearchConditions(searchTerm: string) {
         return [];
     }
 
-    return tokenGroups
+    const groupConditions = tokenGroups
         .map((tokens, index) => {
             const mode =
                 index === 0 && isShortSearchTokenGroup(tokens)
@@ -299,52 +177,24 @@ function buildContentTitleSearchConditions(searchTerm: string) {
             return or(...likeConditions);
         })
         .filter((condition) => condition !== undefined);
-}
 
-function shouldUseContentTitlePrefixIndex(searchTerm: string): boolean {
-    const [firstTokenGroup] = getSqlSearchTokenGroups(searchTerm);
-
-    return !!firstTokenGroup && isShortSearchTokenGroup(firstTokenGroup);
-}
-
-function buildContentTitleFtsMatchQuery(searchTerm: string): string {
-    return getSqlSearchTokenGroups(searchTerm)
-        .map((tokens) => {
-            const quotedTokens = tokens
-                .filter((token) => token.length >= 3)
-                .map((token) => `"${token.replace(/"/g, '""')}"`);
-
-            if (quotedTokens.length <= 1) {
-                return quotedTokens[0] ?? '';
-            }
-
-            return `(${quotedTokens.join(' OR ')})`;
-        })
-        .filter(Boolean)
-        .join(' AND ');
-}
-
-function shouldUseContentTitleFts(searchTerm: string): boolean {
-    return (
-        !shouldUseContentTitlePrefixIndex(searchTerm) &&
-        buildContentTitleFtsMatchQuery(searchTerm).length > 0
+    // Punctuation-joined words ("A&E") tokenize into short fragments whose
+    // prefix anchoring would miss "US: A&E", so the intact word also matches
+    // as a contains pattern anywhere in the title (issue #1161).
+    const compoundConditions = getCompoundSearchWords(searchTerm).flatMap(
+        (word) =>
+            buildCompoundLikePatterns(word).map(
+                (pattern) =>
+                    sql`${schema.content.title} LIKE ${pattern} ESCAPE '\\'`
+            )
     );
-}
 
-function buildGlobPrefixPatterns(token: string): string[] {
-    const variants = new Set<string>();
-
-    for (const value of [token, ...getSqlSearchTokenVariants(token)]) {
-        variants.add(value);
-        variants.add(value.toLocaleLowerCase());
-        variants.add(value.toLocaleUpperCase());
-        variants.add(
-            value.charAt(0).toLocaleUpperCase() +
-                value.slice(1).toLocaleLowerCase()
-        );
+    if (compoundConditions.length === 0 || groupConditions.length === 0) {
+        return groupConditions;
     }
 
-    return [...variants].map((value) => `${value}*`);
+    const combined = or(and(...groupConditions), ...compoundConditions);
+    return combined === undefined ? groupConditions : [combined];
 }
 
 function buildRawContentTitleSearchSql(searchTerm: string): SQL[] {
@@ -368,6 +218,20 @@ function buildRawContentTitleSearchSql(searchTerm: string): SQL[] {
             ),
             sql` OR `
         )})`;
+    });
+}
+
+function dedupeXtreamCandidatesById(
+    candidates: XtreamGlobalSearchCandidate[]
+): XtreamGlobalSearchCandidate[] {
+    const seenIds = new Set<number>();
+
+    return candidates.filter((candidate) => {
+        if (seenIds.has(candidate.id)) {
+            return false;
+        }
+        seenIds.add(candidate.id);
+        return true;
     });
 }
 
@@ -415,12 +279,11 @@ async function selectXtreamGlobalSearchCandidatesWithTitleIndex(
 
 async function selectXtreamGlobalSearchCandidatesWithFts(
     db: AppDatabase,
-    searchTerm: string,
+    matchQuery: string,
     types: string[],
     excludeHidden: boolean,
     candidateLimit: number
 ): Promise<XtreamGlobalSearchCandidate[]> {
-    const matchQuery = buildContentTitleFtsMatchQuery(searchTerm);
     if (!matchQuery || types.length === 0) {
         return [];
     }
@@ -495,25 +358,13 @@ async function selectXtreamGlobalSearchCandidatesWithContentScan(
         .limit(candidateLimit);
 }
 
-function buildM3uPayloadTextFieldPatterns(
-    token: string,
-    mode: 'contains' | 'prefix'
-): string[] {
-    return buildLikePatterns(token, mode).flatMap((pattern) => [
-        `%"name":"${pattern}"%`,
-        `%"name": "${pattern}"%`,
-        `%"title":"${pattern}"%`,
-        `%"title": "${pattern}"%`,
-    ]);
-}
-
 function buildM3uPayloadSearchConditions(searchTerm: string) {
     const tokenGroups = getSqlSearchTokenGroups(searchTerm);
     if (tokenGroups.length === 0) {
         return [];
     }
 
-    return tokenGroups
+    const groupConditions = tokenGroups
         .map((tokens, index) => {
             const mode =
                 index === 0 && isShortSearchTokenGroup(tokens)
@@ -529,6 +380,24 @@ function buildM3uPayloadSearchConditions(searchTerm: string) {
             return or(...likeConditions);
         })
         .filter((condition) => condition !== undefined);
+
+    // Same compound-word rescue as the content title conditions: "A&E" must
+    // match channel names like "US: A&E" that the prefix-anchored short
+    // tokens would exclude at the playlist payload prefilter (issue #1161).
+    const compoundConditions = getCompoundSearchWords(searchTerm).flatMap(
+        (word) =>
+            buildM3uPayloadCompoundPatterns(word).map(
+                (pattern) =>
+                    sql`${schema.playlists.payload} LIKE ${pattern} ESCAPE '\\'`
+            )
+    );
+
+    if (compoundConditions.length === 0 || groupConditions.length === 0) {
+        return groupConditions;
+    }
+
+    const combined = or(and(...groupConditions), ...compoundConditions);
+    return combined === undefined ? groupConditions : [combined];
 }
 
 function asStringArray(value: unknown): string[] {
@@ -1207,11 +1076,42 @@ export async function globalSearch(
                 excludeHidden,
                 candidateLimit
             );
+
+            // The prefix arm only sees titles that start with the short first
+            // token ("A&E" -> GLOB 'a*'), so a compound word like "a&e" is
+            // additionally looked up as a trigram FTS substring to reach
+            // titles such as "US: A&E" (issue #1161).
+            const compoundMatchQuery = buildCompoundFtsMatchQuery(searchTerm);
+            if (compoundMatchQuery) {
+                try {
+                    const compoundCandidates =
+                        await selectXtreamGlobalSearchCandidatesWithFts(
+                            db,
+                            compoundMatchQuery,
+                            types,
+                            excludeHidden,
+                            candidateLimit
+                        );
+                    candidates = dedupeXtreamCandidatesById([
+                        ...candidates,
+                        ...compoundCandidates,
+                    ]);
+                } catch {
+                    candidates =
+                        await selectXtreamGlobalSearchCandidatesWithContentScan(
+                            db,
+                            searchTerm,
+                            types,
+                            excludeHidden,
+                            candidateLimit
+                        );
+                }
+            }
         } else if (shouldUseContentTitleFts(searchTerm)) {
             try {
                 candidates = await selectXtreamGlobalSearchCandidatesWithFts(
                     db,
-                    searchTerm,
+                    buildContentTitleFtsMatchQuery(searchTerm),
                     types,
                     excludeHidden,
                     candidateLimit

--- a/apps/electron-backend/src/app/database/operations/content.operations.ts
+++ b/apps/electron-backend/src/app/database/operations/content.operations.ts
@@ -22,7 +22,8 @@ import {
     buildLikePatterns,
     buildM3uPayloadCompoundPatterns,
     buildM3uPayloadTextFieldPatterns,
-    getCompoundSearchWords,
+    getCompoundResidualTokenGroups,
+    getSearchWordPlans,
     getSqlSearchTokenGroups,
     isShortSearchTokenGroup,
     normalizeSearchMatchText,
@@ -156,45 +157,55 @@ function getGlobalSearchCandidateLimit(): number {
     return MAX_GLOBAL_SEARCH_CANDIDATE_LIMIT;
 }
 
+/**
+ * Per-word title conditions, AND-ed by the caller. A word's condition is the
+ * AND of its token-group LIKE conditions; a punctuation-joined word ("A&E")
+ * additionally matches as an intact contains pattern anywhere in the title
+ * (issue #1161). Composing per word keeps the other words' constraints on
+ * the compound arm, so "A&E HD" cannot fill the SQL candidate limit with
+ * titles that only contain "A&E".
+ */
 function buildContentTitleSearchConditions(searchTerm: string) {
-    const tokenGroups = getSqlSearchTokenGroups(searchTerm);
-    if (tokenGroups.length === 0) {
-        return [];
-    }
+    let groupIndex = 0;
 
-    const groupConditions = tokenGroups
-        .map((tokens, index) => {
-            const mode =
-                index === 0 && isShortSearchTokenGroup(tokens)
-                    ? 'prefix'
-                    : 'contains';
-            const likeConditions = tokens.flatMap((token) =>
-                buildLikePatterns(token, mode).map(
-                    (pattern) =>
-                        sql`${schema.content.title} LIKE ${pattern} ESCAPE '\\'`
-                )
-            );
-            return or(...likeConditions);
-        })
-        .filter((condition) => condition !== undefined);
+    return getSearchWordPlans(searchTerm)
+        .map((plan) => {
+            const tokenConditions = plan.tokenGroups
+                .map((tokens) => {
+                    const mode =
+                        groupIndex === 0 && isShortSearchTokenGroup(tokens)
+                            ? 'prefix'
+                            : 'contains';
+                    groupIndex += 1;
+                    const likeConditions = tokens.flatMap((token) =>
+                        buildLikePatterns(token, mode).map(
+                            (pattern) =>
+                                sql`${schema.content.title} LIKE ${pattern} ESCAPE '\\'`
+                        )
+                    );
+                    return or(...likeConditions);
+                })
+                .filter((condition) => condition !== undefined);
 
-    // Punctuation-joined words ("A&E") tokenize into short fragments whose
-    // prefix anchoring would miss "US: A&E", so the intact word also matches
-    // as a contains pattern anywhere in the title (issue #1161).
-    const compoundConditions = getCompoundSearchWords(searchTerm).flatMap(
-        (word) =>
-            buildCompoundLikePatterns(word).map(
+            const tokenArm =
+                tokenConditions.length > 0
+                    ? and(...tokenConditions)
+                    : undefined;
+            if (plan.compound === null) {
+                return tokenArm;
+            }
+
+            const compoundConditions = buildCompoundLikePatterns(
+                plan.compound
+            ).map(
                 (pattern) =>
                     sql`${schema.content.title} LIKE ${pattern} ESCAPE '\\'`
-            )
-    );
-
-    if (compoundConditions.length === 0 || groupConditions.length === 0) {
-        return groupConditions;
-    }
-
-    const combined = or(and(...groupConditions), ...compoundConditions);
-    return combined === undefined ? groupConditions : [combined];
+            );
+            return tokenArm === undefined
+                ? or(...compoundConditions)
+                : or(tokenArm, ...compoundConditions);
+        })
+        .filter((condition) => condition !== undefined);
 }
 
 function buildRawContentTitleSearchSql(searchTerm: string): SQL[] {
@@ -219,6 +230,26 @@ function buildRawContentTitleSearchSql(searchTerm: string): SQL[] {
             sql` OR `
         )})`;
     });
+}
+
+/**
+ * Contains-mode LIKE conditions for the non-compound words of the term,
+ * applied on top of the compound FTS lookup so `A&E HD` only surfaces
+ * candidates that also contain `hd` (the FTS phrase can only express the
+ * compound word — trigram tokens need >= 3 chars).
+ */
+function buildCompoundResidualTitleSql(searchTerm: string): SQL[] {
+    return getCompoundResidualTokenGroups(searchTerm).map(
+        (tokens) =>
+            sql`(${sql.join(
+                tokens.flatMap((token) =>
+                    buildLikePatterns(token).map(
+                        (pattern) => sql`c.title LIKE ${pattern} ESCAPE '\\'`
+                    )
+                ),
+                sql` OR `
+            )})`
+    );
 }
 
 function dedupeXtreamCandidatesById(
@@ -282,7 +313,8 @@ async function selectXtreamGlobalSearchCandidatesWithFts(
     matchQuery: string,
     types: string[],
     excludeHidden: boolean,
-    candidateLimit: number
+    candidateLimit: number,
+    residualTitleConditions: SQL[] = []
 ): Promise<XtreamGlobalSearchCandidate[]> {
     if (!matchQuery || types.length === 0) {
         return [];
@@ -313,6 +345,11 @@ async function selectXtreamGlobalSearchCandidatesWithFts(
             types.map((type) => sql`${type}`),
             sql`, `
         )})
+        ${
+            residualTitleConditions.length > 0
+                ? sql`AND ${sql.join(residualTitleConditions, sql` AND `)}`
+                : sql``
+        }
         ${excludeHidden ? sql`AND cat.hidden = 0` : sql``}
         ORDER BY rank, c.title
         LIMIT ${candidateLimit}
@@ -358,46 +395,54 @@ async function selectXtreamGlobalSearchCandidatesWithContentScan(
         .limit(candidateLimit);
 }
 
+/**
+ * Per-word M3U payload prefilter conditions, AND-ed by the caller — the same
+ * compound-word composition as `buildContentTitleSearchConditions`: "A&E"
+ * must reach channel names like "US: A&E" (issue #1161), while the other
+ * words of the query keep constraining the candidate playlists.
+ */
 function buildM3uPayloadSearchConditions(searchTerm: string) {
-    const tokenGroups = getSqlSearchTokenGroups(searchTerm);
-    if (tokenGroups.length === 0) {
-        return [];
-    }
+    let groupIndex = 0;
 
-    const groupConditions = tokenGroups
-        .map((tokens, index) => {
-            const mode =
-                index === 0 && isShortSearchTokenGroup(tokens)
-                    ? 'prefix'
-                    : 'contains';
-            const patterns = tokens.flatMap((token) =>
-                buildM3uPayloadTextFieldPatterns(token, mode)
-            );
-            const likeConditions = patterns.map(
+    return getSearchWordPlans(searchTerm)
+        .map((plan) => {
+            const tokenConditions = plan.tokenGroups
+                .map((tokens) => {
+                    const mode =
+                        groupIndex === 0 && isShortSearchTokenGroup(tokens)
+                            ? 'prefix'
+                            : 'contains';
+                    groupIndex += 1;
+                    const patterns = tokens.flatMap((token) =>
+                        buildM3uPayloadTextFieldPatterns(token, mode)
+                    );
+                    const likeConditions = patterns.map(
+                        (pattern) =>
+                            sql`${schema.playlists.payload} LIKE ${pattern} ESCAPE '\\'`
+                    );
+                    return or(...likeConditions);
+                })
+                .filter((condition) => condition !== undefined);
+
+            const tokenArm =
+                tokenConditions.length > 0
+                    ? and(...tokenConditions)
+                    : undefined;
+            if (plan.compound === null) {
+                return tokenArm;
+            }
+
+            const compoundConditions = buildM3uPayloadCompoundPatterns(
+                plan.compound
+            ).map(
                 (pattern) =>
                     sql`${schema.playlists.payload} LIKE ${pattern} ESCAPE '\\'`
             );
-            return or(...likeConditions);
+            return tokenArm === undefined
+                ? or(...compoundConditions)
+                : or(tokenArm, ...compoundConditions);
         })
         .filter((condition) => condition !== undefined);
-
-    // Same compound-word rescue as the content title conditions: "A&E" must
-    // match channel names like "US: A&E" that the prefix-anchored short
-    // tokens would exclude at the playlist payload prefilter (issue #1161).
-    const compoundConditions = getCompoundSearchWords(searchTerm).flatMap(
-        (word) =>
-            buildM3uPayloadCompoundPatterns(word).map(
-                (pattern) =>
-                    sql`${schema.playlists.payload} LIKE ${pattern} ESCAPE '\\'`
-            )
-    );
-
-    if (compoundConditions.length === 0 || groupConditions.length === 0) {
-        return groupConditions;
-    }
-
-    const combined = or(and(...groupConditions), ...compoundConditions);
-    return combined === undefined ? groupConditions : [combined];
 }
 
 function asStringArray(value: unknown): string[] {
@@ -1080,7 +1125,9 @@ export async function globalSearch(
             // The prefix arm only sees titles that start with the short first
             // token ("A&E" -> GLOB 'a*'), so a compound word like "a&e" is
             // additionally looked up as a trigram FTS substring to reach
-            // titles such as "US: A&E" (issue #1161).
+            // titles such as "US: A&E" (issue #1161). The non-compound words
+            // of the query stay applied as LIKE conditions so this arm cannot
+            // fill the candidate limit with compound-only matches.
             const compoundMatchQuery = buildCompoundFtsMatchQuery(searchTerm);
             if (compoundMatchQuery) {
                 try {
@@ -1090,7 +1137,8 @@ export async function globalSearch(
                             compoundMatchQuery,
                             types,
                             excludeHidden,
-                            candidateLimit
+                            candidateLimit,
+                            buildCompoundResidualTitleSql(searchTerm)
                         );
                     candidates = dedupeXtreamCandidatesById([
                         ...candidates,

--- a/docs/architecture/sqlite-db-worker.md
+++ b/docs/architecture/sqlite-db-worker.md
@@ -241,7 +241,16 @@ Xtream-only row shape:
    short first tokens such as `tv` stay anchored to the start of the title, so
    `TV Sport` matches but `Test TV` does not. These short first-token queries
    bypass trigram FTS and use the `idx_content_title` prefix index path because
-   trigram tokenization cannot match 1-2 character terms.
+   trigram tokenization cannot match 1-2 character terms. Punctuation-joined
+   words such as `A&E` or `X-Men` are an exception: tokenization splits them
+   into short fragments, so the intact word is preserved as a "compound word"
+   (`content-search.util.ts`) that additionally matches as an exact substring —
+   a supplemental trigram FTS `MATCH '"a&e"'` query for the Xtream arm (merged
+   and deduped with the prefix-index candidates), intact-word `LIKE` contains
+   patterns for the per-playlist and M3U payload prefilters, and a
+   space-bounded whole-phrase check in the ranking step. This lets `A&E` find
+   `US: A&E` anywhere in the title while single short tokens stay
+   prefix-anchored (issue #1161).
 6. `excludeHidden` still filters hidden Xtream categories and also filters M3U
    channels whose `group.title` is listed in the playlist payload's
    `hiddenGroupTitles`.

--- a/docs/architecture/sqlite-db-worker.md
+++ b/docs/architecture/sqlite-db-worker.md
@@ -248,8 +248,12 @@ Xtream-only row shape:
    a supplemental trigram FTS `MATCH '"a&e"'` query for the Xtream arm (merged
    and deduped with the prefix-index candidates), intact-word `LIKE` contains
    patterns for the per-playlist and M3U payload prefilters, and a
-   space-bounded whole-phrase check in the ranking step. This lets `A&E` find
-   `US: A&E` anywhere in the title while single short tokens stay
+   space-bounded whole-phrase check in the ranking step. All compound arms
+   keep the remaining words of the query as SQL constraints — the FTS
+   supplement AND-s the non-compound tokens as `LIKE` conditions and the
+   `LIKE` prefilters compose per word — so `A&E HD` cannot fill the bounded
+   candidate window with titles that only contain `A&E`. This lets `A&E`
+   find `US: A&E` anywhere in the title while single short tokens stay
    prefix-anchored (issue #1161).
 6. `excludeHidden` still filters hidden Xtream categories and also filters M3U
    channels whose `group.title` is listed in the playlist payload's


### PR DESCRIPTION
Fixes #1161

## Problem

Searching for `A&E` in the global search (and in per-portal search) returned nothing for channels like `US: A&E`, even though the channel exists. The `&` itself was never the problem: search normalization splits `A&E` into two one-letter tokens `a` + `e`, and short (≤2 chars) first tokens are intentionally **prefix-anchored** for performance — both in SQL (`title GLOB 'a*'` via `idx_content_title`) and in the ranking gate (`scoreSearchTextMatch`). As a result only titles *starting* with `A` could ever match, and typical provider-prefixed names (`US: A&E`, `US | A&E HD`, `(US) A&E`) were unreachable. Plain words don't have this problem (`History` finds `US: History`), which made it look like `&` was broken.

## Fix (additive — no existing behavior removed)

A whitespace-delimited word that still contains internal punctuation after edge-trimming (`a&e`, `x-men`, `l'équipe`) is now preserved as a **compound word** and matched as an intact substring in addition to the existing token logic:

1. **Xtream global search**: the prefix/GLOB arm stays as-is; when compound words exist, a supplemental query against the existing `content_title_fts` trigram index (`MATCH '"a&e"'`) finds the word anywhere in the title. Candidates are merged and deduped by id; if FTS fails, it falls back to the content scan (whose conditions now include the compound contains arm).
2. **Ranking** (`scoreSearchTextMatch`): when the short-first-token gate fails, multi-token phrases can still match as a space-bounded whole-phrase substring of the normalized title (`"us a e"` contains `" a e "` → score 40). Word boundaries are respected: `Casa e Villa` does **not** match `A&E`.
3. **Per-playlist search** (`searchContent`) and the **M3U payload prefilter** get the same OR-augmented compound contains patterns, so in-portal search and M3U global search are fixed too.

Single short tokens (`tv`, `a`) keep their prefix-anchored behavior; queries without compound words are routed exactly as before (no extra SQL query).

## Refactoring

`content.operations.ts` (baselined at ~1300 lines) shed its pure text helpers into a new `content-search.util.ts` (~320 lines, drizzle-free), which makes the search pipeline unit-testable without DB mocks. `scoreSearchTextMatch` is re-exported for API compatibility.

## Ranking example (verified on a real SQLite DB with the trigram FTS index)

| Query `A&E` against | Before | After (score) |
|---|---|---|
| `A&E` | ✅ | ✅ (0 — exact) |
| `A&E HD`, `A & E HD` | ✅ | ✅ (10 — prefix) |
| `US: A&E`, `US \| A&E HD`, `(US) A&E`, `USA A&E FHD` | ❌ | ✅ (40 — mid-title) |
| `Casa e Villa`, `Bravo Espana` | ❌ | ❌ (no false positives) |

## Tests

- New `content-search.util.spec.ts`: compound-word extraction, FTS match query building, LIKE pattern building/escaping, ranking regression cases (16 tests).
- `content.operations.spec.ts`: 5 new tests — M3U results for `US: A&E`, per-playlist `searchContent` with the OR-combined compound conditions, the supplemental FTS arm + dedupe, the FTS-failure content-scan fallback, and the M3U payload compound prefilter. The regression tests **fail on the pre-fix code** (verified by reverting the source and re-running). The spec's `or()` drizzle mock now returns a condition object so the compound OR-composition branch actually executes under test.
- Full `electron-backend` suite: 533 tests green; typecheck green; lint green.
- Electron E2E: `pnpm nx run electron-backend-e2e:e2e-ci--src/search.e2e.ts` — 16/16 passed.
- Real-SQLite semantic verification: the exact generated GLOB/FTS/LIKE queries plus scoring were run against `sqlite3` with a `tokenize='trigram'` FTS5 table (see table above).

## Docs

`docs/architecture/sqlite-db-worker.md` — the search-ranking section now documents the compound-word behavior.

## Out of scope

The comment in #1161 about Stalker portals is a separate gap: Stalker content is never cached in the `content` table, so global search cannot see it by design. That deserves its own issue/feature request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
