### PR TITLE
fix(lint): quote eslint globs so Linux CI lints the full web-backend and database trees

### DIFF
--- a/apps/web-backend/project.json
+++ b/apps/web-backend/project.json
@@ -37,7 +37,7 @@
             }
         },
         "lint": {
-            "command": "eslint apps/web-backend/**/*.ts"
+            "command": "eslint \"apps/web-backend/**/*.ts\""
         },
         "test": {
             "executor": "@nx/jest:jest",

--- a/libs/shared/database/project.json
+++ b/libs/shared/database/project.json
@@ -25,7 +25,7 @@
             }
         },
         "lint": {
-            "command": "eslint libs/shared/database/**/*.ts"
+            "command": "eslint \"libs/shared/database/**/*.ts\""
         }
     }
 }


### PR DESCRIPTION
## What changed

Quoted the glob argument in two `nx:run-commands` lint targets:

- `apps/web-backend/project.json`: `eslint "apps/web-backend/**/*.ts"`
- `libs/shared/database/project.json` (project `database`): `eslint "libs/shared/database/**/*.ts"`

## Why

With an unquoted glob, the POSIX shell on Linux CI expands `**` itself (shallow match), so ESLint only received a subset of files there. On Windows the literal pattern reaches ESLint, which expands it recursively — so the two platforms linted different file sets. Quoting the pattern (the style `tools/packaging/project.json` already uses) hands expansion to ESLint on both platforms, making lint coverage host-agnostic.

## Verification

- `pnpm nx lint web-backend --skip-nx-cache` — ✅ green
- `pnpm nx lint database --skip-nx-cache` — ✅ green

Both runs executed on Windows, where the full recursive tree is linted — i.e. the exact file set Linux CI will now see — so the widened coverage introduces no new lint errors.

## Reviewer note

`apps/electron-backend/project.json` has the same unquoted-glob pattern on `master`; it is deliberately **not** touched here because its quoting (plus fixes for the Windows-only eslint errors it surfaces) is handled on the `claude/dazzling-easley-9f438c` branch. If that branch doesn't land, electron-backend needs the same one-line fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)