### PR TITLE
fix(theme): make scrollbars follow the app theme instead of the OS color scheme

### DIFF
--- a/apps/web/src/styles.scss
+++ b/apps/web/src/styles.scss
@@ -108,6 +108,20 @@ body.frameless-platform #epg-navigation {
 }
 
 // ─── Base ─────────────────────────────────────────────────────────────────────
+// Native UI (scrollbars, form controls, popups) must follow the app theme,
+// not the OS preference. Chromium colors unstyled/native scrollbars from the
+// element's color-scheme, so declare it explicitly for both themes.
+html {
+    color-scheme: light;
+}
+
+// The root scroller (html) sits outside body.dark-theme, so flip it via
+// :has(); the color-scheme declaration in .dark-theme below keeps the body
+// subtree covered in engines without :has() support.
+html:has(> body.dark-theme) {
+    color-scheme: dark;
+}
+
 body,
 html {
     user-select: none;
@@ -155,6 +169,7 @@ textarea,
 // ─── Dark Theme ───────────────────────────────────────────────────────────────
 .dark-theme {
     background: var(--mat-sys-surface) !important;
+    color-scheme: dark;
 
     // Refined scrollbar for dark mode
     ::-webkit-scrollbar {
@@ -167,11 +182,15 @@ textarea,
     }
 
     ::-webkit-scrollbar-thumb {
-        background-color: var(--mat-sys-outline-variant);
+        background-color: color-mix(
+            in srgb,
+            var(--app-muted-color) 70%,
+            transparent
+        );
         border-radius: 999px;
 
         &:hover {
-            background-color: var(--mat-sys-outline);
+            background-color: var(--app-muted-color);
         }
     }
 }

--- a/libs/portal/catalog/feature/src/lib/category-content-view/category-content-view.component.scss
+++ b/libs/portal/catalog/feature/src/lib/category-content-view/category-content-view.component.scss
@@ -245,7 +245,8 @@ app-grid-list {
     padding: 16px 20px 20px;
     display: block;
     scrollbar-width: thin;
-    scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
+    scrollbar-color: color-mix(in srgb, var(--app-muted-color) 55%, transparent)
+        transparent;
 }
 
 @media (max-width: 768px) {

--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.scss
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.scss
@@ -77,7 +77,8 @@ app-grid-list.live-all-items-grid {
     overflow-y: auto;
     padding: 16px 20px 20px;
     scrollbar-width: thin;
-    scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
+    scrollbar-color: color-mix(in srgb, var(--app-muted-color) 55%, transparent)
+        transparent;
 }
 
 .loading-indicator {

--- a/libs/ui/epg/src/lib/epg-progress-panel/epg-progress-panel.component.scss
+++ b/libs/ui/epg/src/lib/epg-progress-panel/epg-progress-panel.component.scss
@@ -120,6 +120,8 @@
     overflow-y: auto;
     padding: 4px 0;
     scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--app-muted-color) 55%, transparent)
+        transparent;
 }
 
 .import-item {

--- a/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-player.component.scss
+++ b/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-player.component.scss
@@ -454,6 +454,8 @@
     max-height: 240px;
     overflow-y: auto;
     scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--app-muted-color) 55%, transparent)
+        transparent;
 }
 
 .embedded-mpv-player__audio-track {

--- a/libs/ui/styles/_detail-view.scss
+++ b/libs/ui/styles/_detail-view.scss
@@ -223,6 +223,12 @@
             overflow-x: auto;
             padding-bottom: 8px;
             scrollbar-width: thin;
+            scrollbar-color: color-mix(
+                    in srgb,
+                    var(--app-muted-color) 55%,
+                    transparent
+                )
+                transparent;
         }
 
         &__similar-card {

--- a/libs/workspace/shell/feature/src/lib/workspace-command-palette/workspace-command-palette.component.scss
+++ b/libs/workspace/shell/feature/src/lib/workspace-command-palette/workspace-command-palette.component.scss
@@ -89,7 +89,8 @@
     overflow-x: hidden;
     padding: 6px;
     scrollbar-width: thin;
-    scrollbar-color: var(--mat-sys-outline-variant) transparent;
+    scrollbar-color: color-mix(in srgb, var(--app-muted-color) 55%, transparent)
+        transparent;
 }
 
 // ─── Group ───────────────────────────────────────────────────────────────────

--- a/libs/workspace/shell/feature/src/lib/workspace-context-panel/workspace-context-panel.component.scss
+++ b/libs/workspace/shell/feature/src/lib/workspace-context-panel/workspace-context-panel.component.scss
@@ -177,7 +177,8 @@ app-workspace-context-category-view {
     overflow-x: hidden;
     overscroll-behavior: contain;
     scrollbar-width: thin;
-    scrollbar-color: var(--mat-sys-outline-variant) transparent;
+    scrollbar-color: color-mix(in srgb, var(--app-muted-color) 55%, transparent)
+        transparent;
 }
 
 .context-skeleton {


### PR DESCRIPTION
## What

On Windows with a light OS theme, scrollbars rendered as wide light native bars even when the app theme was set to dark. This PR makes all scrollbars follow the app theme in both Electron and PWA.

## Why (two combined root causes)

1. **No `color-scheme` declaration.** Chromium colors native/unstyled scrollbars from the element''s `color-scheme`, which defaulted to the OS preference (light). The page now declares `color-scheme: light` on `html` and flips it to `dark` via `html:has(> body.dark-theme)` (plus the `.dark-theme` block itself as a `:has()`-less fallback). This also fixes native form controls (`<select>`, date pickers, autofill) in dark mode.

2. **Scrollbar styles referenced `--mat-sys-*` tokens that are never emitted.** The theme setup in `m3-theme.scss` uses `mat.define-theme` + `mat.all-component-themes`/`all-component-colors`, which emit component tokens with literal values but no `--mat-sys-*` system tokens. Every `scrollbar-color: var(--mat-sys-outline-variant) transparent` therefore computed to `auto` → native scrollbar → light. Scrollbar styling now uses the real `--app-muted-color` design token (defined for both themes), matching the existing `.app-scrollbar` utility. Hardcoded white `rgba(255,255,255,.08)` thumbs were replaced, and containers that only set `scrollbar-width: thin` got an explicit themed `scrollbar-color`.

## Touched surfaces

- Global: `color-scheme` declarations, dark-theme `::-webkit-scrollbar-thumb` (previously invisible — it referenced the undefined token)
- Workspace context panel (category sidebar — the reported case), command palette
- Portal catalog grid, Xtream live grid
- Detail-view similar strip, EPG progress panel, embedded MPV track list

## Verification

Verified live in Electron via CDP in both themes: computed `color-scheme` flips light↔dark with the theme, `scrollbar-color` resolves to the muted token in both themes, and screenshots confirm thin dark scrollbars in dark theme on a light-themed Windows 11 host, with no light-theme regressions. Styling-only change (SCSS); no unit-test impact.

## Reviewer note

The undefined `--mat-sys-*` issue is much broader (~510 references across ~55 SCSS files are silent no-ops). This PR intentionally fixes only the scrollbar-related usages; a separate audit should decide between migrating to `mat.theme()` or replacing usages with `--app-*` tokens, since making those tokens suddenly resolve would change visuals app-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)