### PR TITLE
fix(e2e): stop saveSettings hanging on a spurious form-submit navigation wait

### DIFF
--- a/apps/electron-backend-e2e/src/electron-test-fixtures.ts
+++ b/apps/electron-backend-e2e/src/electron-test-fixtures.ts
@@ -632,8 +632,23 @@ export async function enableRemoteControl(
 export async function saveSettings(page: Page): Promise<void> {
     const saveButton = page.getByTestId('save-settings');
 
-    await saveButton.click();
+    // The save control is a native form submit (`<button type="submit">`
+    // inside `<form (ngSubmit)="onSubmit()">`). Clicking it makes Chromium
+    // register a form-submission navigation, which Angular's `ngSubmit`
+    // handler immediately cancels via `preventDefault()` — no real navigation
+    // ever happens. Playwright's default post-click "wait for signals" barrier
+    // still observes that requested-then-cancelled navigation and waits for it
+    // to settle; on slow/loaded CI runners that wait can stall for the full
+    // timeout ("waiting for scheduled navigations to finish"). We never depend
+    // on a navigation here, so opt out of the barrier and instead assert the
+    // deterministic post-save state below.
+    await saveButton.click({ noWaitAfter: true });
+    // `onSubmit()` calls `applyChangedSettings()` -> `markAsPristine()` once the
+    // settings write resolves, which disables the button. Awaiting that is a
+    // stronger, race-free confirmation that the save actually committed.
     await expect(saveButton).toBeDisabled();
+    // Let the fire-and-forget `window.electron.updateSettings(...)` IPC flush to
+    // the main process before callers may relaunch the app to assert persistence.
     await page.waitForTimeout(300);
 }
 


### PR DESCRIPTION
## What

Make the shared `saveSettings` E2E helper robust against a Playwright navigation-wait hang by clicking the save control with `{ noWaitAfter: true }`, while keeping the deterministic `await expect(saveButton).toBeDisabled()` assertion.

## Why

The `applies remote volume commands to radio audio playback` Electron E2E test (`remote-control.e2e.ts`) is flaky on `ubuntu-latest` CI ([example run](https://github.com/4gray/iptvnator/actions/runs/29188889521/job/86639954797)).

**Root cause.** `saveSettings` clicks `getByTestId('save-settings')`, which is a native `<button type="submit">` inside `<form (ngSubmit)="onSubmit()">`. Clicking it makes Chromium register a form-submission navigation; Angular's `ngSubmit` handler cancels it via `preventDefault()`, so **no real navigation ever happens**. But Playwright's default post-click "wait for signals" barrier still observes that *requested-then-cancelled* navigation and waits for it to settle. On a slow/loaded CI runner that wait stalls for the full timeout — the observed `"waiting for scheduled navigations to finish"` hang. The save flow itself never navigates (`onSubmit()` only writes settings and toggles theme/language; no router navigation or reload).

**Why the job failed despite the retry passing.** When attempt 1 hangs and times out, Playwright aborts the test and runs its `finally` block, which closes the Electron app. The still-pending click then rejects *late* — after the test has already finished — so Playwright can't attribute it and reports it at the worker level as `"1 error was not a part of any test"`. Playwright exits non-zero on any worker-level error even when every test passed or flaked (hence `78 passed / 1 flaky` yet exit 1). It's a downstream symptom of the same hang, so this one change resolves both.

## The fix

- Click with `{ noWaitAfter: true }` to skip the spurious navigation barrier. `noWaitAfter` only skips the *post-click* wait; the click still dispatches and the form still submits. (Valid `Locator.click` option in the pinned Playwright 1.57.)
- Keep asserting `toBeDisabled()` — a stronger, race-free confirmation that the save committed (`onSubmit()` → `applyChangedSettings()` → `markAsPristine()` disables the button once the settings write resolves).

Because the helper is shared, this hardens **all ~15 `saveSettings` callers** across the electron-backend-e2e suite, not just the radio test.

## Validation

- `nx lint electron-backend-e2e` → 0 errors (pre-existing warnings only; none in the changed file).
- `tsc -p apps/electron-backend-e2e/tsconfig.json` → no new errors (the few reported errors are pre-existing on `master`; none reference `noWaitAfter`).
- `nx run electron-backend-e2e:e2e-ci--src/remote-control.e2e.ts --skip-nx-cache` (full web + electron build, then Playwright) → **2 passed (35.2s)**, including the previously-flaky radio-playback test (8.6s). Exit 0.

## Notes for reviewers

- Product code is untouched; this is purely a test-infrastructure robustness fix. No user-visible behavior changes.
- Docs were intentionally not updated (isolated test-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
