### PR TITLE
refactor(database): split EPG mapping schema out of oversized schema.ts

### DIFF
--- a/libs/shared/database/src/lib/epg-mapping.schema.ts
+++ b/libs/shared/database/src/lib/epg-mapping.schema.ts
@@ -1,0 +1,30 @@
+/**
+ * Drizzle ORM schema for manual EPG-to-channel mappings.
+ *
+ * Split out of schema.ts to keep that file within the repository's
+ * max-lines budget; re-exported from there so `import * as schema`
+ * consumers keep seeing a single schema namespace.
+ */
+
+import { sql } from 'drizzle-orm';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+// EPG channel mappings (manual user overrides)
+export const epgChannelMappings = sqliteTable(
+    'epg_channel_mappings',
+    {
+        id: integer('id').primaryKey({ autoIncrement: true }),
+        channelKey: text('channel_key').notNull().unique(),
+        epgChannelId: text('epg_channel_id').notNull(),
+        playlistId: text('playlist_id'),
+        updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`),
+    },
+    (table) => ({
+        playlistIdx: index('idx_epg_channel_mappings_playlist').on(
+            table.playlistId
+        ),
+    })
+);
+
+export type EpgChannelMapping = typeof epgChannelMappings.$inferSelect;
+export type NewEpgChannelMapping = typeof epgChannelMappings.$inferInsert;

--- a/libs/shared/database/src/lib/schema.ts
+++ b/libs/shared/database/src/lib/schema.ts
@@ -16,6 +16,10 @@ import {
     uniqueIndex,
 } from 'drizzle-orm/sqlite-core';
 
+// Manual EPG-to-channel mappings live in their own schema module; re-export
+// them so `import * as schema from './schema'` keeps a complete namespace.
+export * from './epg-mapping.schema';
+
 // Playlists table
 export const playlists = sqliteTable('playlists', {
     id: text('id').primaryKey(),
@@ -349,26 +353,6 @@ export const downloads = sqliteTable(
         ).on(table.xtreamId, table.playlistId, table.contentType),
     })
 );
-
-// EPG channel mappings (manual user overrides)
-export const epgChannelMappings = sqliteTable(
-    'epg_channel_mappings',
-    {
-        id: integer('id').primaryKey({ autoIncrement: true }),
-        channelKey: text('channel_key').notNull().unique(),
-        epgChannelId: text('epg_channel_id').notNull(),
-        playlistId: text('playlist_id'),
-        updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`),
-    },
-    (table) => ({
-        playlistIdx: index('idx_epg_channel_mappings_playlist').on(
-            table.playlistId
-        ),
-    })
-);
-
-export type EpgChannelMapping = typeof epgChannelMappings.$inferSelect;
-export type NewEpgChannelMapping = typeof epgChannelMappings.$inferInsert;
 
 export type Download = typeof downloads.$inferSelect;
 export type NewDownload = typeof downloads.$inferInsert;


### PR DESCRIPTION
## Summary

CI lint on `master` is currently red: `libs/shared/database/src/lib/schema.ts` reached 402 lines with the manual EPG-to-channel mapping table from #1165, exceeding the 400-line `max-lines` budget (see the failing master run for ec6fc403). Every open PR inherits this failure through the merge ref.

- Move `epgChannelMappings` plus its `EpgChannelMapping`/`NewEpgChannelMapping` types into a new `epg-mapping.schema.ts`
- Re-export it from `schema.ts`, so `import * as schema from './schema'` (used by `connection.ts` for the Drizzle schema map) and all barrel/compat-shim imports keep working unchanged
- `schema.ts` is back to 386 lines; no new baseline entry needed

## Test plan

- [x] `pnpm nx lint database` green (max-lines error gone)
- [x] `pnpm nx test database` green (22 tests)
- [x] `pnpm nx test electron-backend --testPathPatterns "epg-mapping|epg.events"` green (mapping operations + EPG events consumers)