### PR TITLE
fix(catchup): parse negative sub-hour XMLTV offsets correctly

### DIFF
--- a/libs/shared/m3u-utils/src/lib/catchup.utils.spec.ts
+++ b/libs/shared/m3u-utils/src/lib/catchup.utils.spec.ts
@@ -251,6 +251,24 @@ describe('catchup.utils', () => {
         );
     });
 
+    it('applies positive sub-hour XMLTV offsets such as +0030', () => {
+        // Regression: Number('+00') === 0, so a Math.sign()-based conversion
+        // dropped the minutes and treated +0030 as UTC.
+        expect(
+            resolveM3uCatchupUrl(
+                baseChannel,
+                {
+                    ...archivedProgram,
+                    start: '202604100800 +0030',
+                    startTimestamp: null,
+                },
+                1_775_820_000
+            )
+        ).toBe(
+            'https://streams.example.com/live/channel-1.m3u8?utc=1775806200&lutc=1775820000'
+        );
+    });
+
     it('treats a -0000 offset as UTC', () => {
         expect(
             resolveM3uCatchupUrl(

--- a/libs/shared/m3u-utils/src/lib/catchup.utils.spec.ts
+++ b/libs/shared/m3u-utils/src/lib/catchup.utils.spec.ts
@@ -217,6 +217,56 @@ describe('catchup.utils', () => {
         );
     });
 
+    it('applies negative sub-hour XMLTV offsets such as -0030', () => {
+        // Regression: Number('-00') === -0, so a Math.sign()-based conversion
+        // dropped the minutes' sign and treated -0030 as UTC.
+        expect(
+            resolveM3uCatchupUrl(
+                baseChannel,
+                {
+                    ...archivedProgram,
+                    start: '202604100800 -0030',
+                    startTimestamp: null,
+                },
+                1_775_820_000
+            )
+        ).toBe(
+            'https://streams.example.com/live/channel-1.m3u8?utc=1775809800&lutc=1775820000'
+        );
+    });
+
+    it('applies positive offsets with minutes such as +0530', () => {
+        expect(
+            resolveM3uCatchupUrl(
+                baseChannel,
+                {
+                    ...archivedProgram,
+                    start: '202604100800 +0530',
+                    startTimestamp: null,
+                },
+                1_775_820_000
+            )
+        ).toBe(
+            'https://streams.example.com/live/channel-1.m3u8?utc=1775788200&lutc=1775820000'
+        );
+    });
+
+    it('treats a -0000 offset as UTC', () => {
+        expect(
+            resolveM3uCatchupUrl(
+                baseChannel,
+                {
+                    ...archivedProgram,
+                    start: '202604100800 -0000',
+                    startTimestamp: null,
+                },
+                1_775_820_000
+            )
+        ).toBe(
+            'https://streams.example.com/live/channel-1.m3u8?utc=1775808000&lutc=1775820000'
+        );
+    });
+
     it('preserves catchup metadata when storing parsed playlist items', () => {
         const playlist = createPlaylistObject('Catchup playlist', {
             header: {

--- a/libs/shared/m3u-utils/src/lib/catchup.utils.ts
+++ b/libs/shared/m3u-utils/src/lib/catchup.utils.ts
@@ -112,9 +112,13 @@ function getEpgProgramTimestampSeconds(
         Number(hour),
         Number(minute)
     );
+    // Derive the sign from the string: for offsets like "-0030" the hour part
+    // is "-00", and Number("-00") === -0, so Math.sign() would drop the
+    // minutes' sign and yield a zero offset instead of -30 minutes.
+    const offsetSign = offsetHours.startsWith('-') ? -1 : 1;
     const offsetTotalMinutes =
-        Number(offsetHours) * 60 +
-        Math.sign(Number(offsetHours)) * Number(offsetMinutes);
+        offsetSign *
+        (Math.abs(Number(offsetHours)) * 60 + Number(offsetMinutes));
 
     return Math.floor((utcMillis - offsetTotalMinutes * 60_000) / 1000);
 }


### PR DESCRIPTION
## Summary

XMLTV timestamps carrying negative sub-hour timezone offsets (e.g. `202604100800 -0030`) were resolved as if they were UTC. The hour component of such an offset is the string `-00`, which evaluates to `-0`, and `Math.sign(-0)` returns `-0` — so the minutes' sign was dropped and the whole offset collapsed to zero. Catch-up URLs built from these programs pointed 30 minutes (or whatever the sub-hour offset was) away from the real program start.

The fix derives the sign directly from the offset string and applies it to the combined hour+minute magnitude, so `-0030` now correctly shifts by −30 minutes while `+0530`, `-0000`, and full-hour offsets keep their previous behavior.

## Changes

- `libs/shared/m3u-utils/src/lib/catchup.utils.ts`: sign-safe XMLTV offset conversion in `getEpgProgramTimestampSeconds`
- `libs/shared/m3u-utils/src/lib/catchup.utils.spec.ts`: regression tests for `-0030` (fails on the old implementation), `+0530`, and `-0000`

## Validation

- `node tools/testing/run-web-esm-lib-tests.mjs libs/shared/m3u-utils` — 3 suites, 55 tests passing
- `pnpm nx lint m3u-utils` — clean