### PR TITLE
perf(stalker): skip wasted series-seasons request for non-series items

### DIFF
--- a/docs/architecture/stalker-portal.md
+++ b/docs/architecture/stalker-portal.md
@@ -271,10 +271,14 @@ Stalker has multiple real-world data shapes. The current implementation supports
 
 - Seasons come from API resource (`serialSeasonsResource`).
 - Episodes are derived from season payload.
-- This is the only shape that sets `selectedSerialId`, which is what drives
-  `serialSeasonsResource`. Modes 2 and 3 below carry their episodes elsewhere,
-  so selecting them must leave the id unset — otherwise every detail open
-  fires a `get_ordered_list&type=series` request whose result is discarded.
+- This is the only mode that sets `selectedSerialId`, which is what drives
+  `serialSeasonsResource`. It is set purely from `selectedContentType ===
+'series'` — the `series` detail branch renders `<app-stalker-series-view />`
+  with no `vodWithSeries` input, so the API resource is its only episode
+  source and the fetch must never be gated on item shape.
+- Modes 2 and 3 below are always opened under the `vod` content type, which
+  leaves the id unset — otherwise every VOD detail open would fire a
+  `get_ordered_list&type=series` request whose result is discarded.
 
 2. VOD with Embedded `series[]`:
 

--- a/docs/architecture/stalker-portal.md
+++ b/docs/architecture/stalker-portal.md
@@ -271,6 +271,10 @@ Stalker has multiple real-world data shapes. The current implementation supports
 
 - Seasons come from API resource (`serialSeasonsResource`).
 - Episodes are derived from season payload.
+- This is the only shape that sets `selectedSerialId`, which is what drives
+  `serialSeasonsResource`. Modes 2 and 3 below carry their episodes elsewhere,
+  so selecting them must leave the id unset — otherwise every detail open
+  fires a `get_ordered_list&type=series` request whose result is discarded.
 
 2. VOD with Embedded `series[]`:
 

--- a/docs/architecture/stalker-store-api-baseline.md
+++ b/docs/architecture/stalker-store-api-baseline.md
@@ -123,7 +123,12 @@ Consumer directories sampled:
 
 ## Invariants to Preserve During Refactor
 
-- Selection IDs (`selectedVodId`, `selectedSerialId`, `selectedItvId`) are synchronized in `setSelectedItem`.
+- Selection IDs (`selectedVodId`, `selectedItvId`) are synchronized in `setSelectedItem`.
+- `selectedSerialId` is set only for a regular-series selection — content type
+  `series` and an item without embedded `series[]` episodes or the Ministra
+  `is_series` flag. Every other selection clears it, because
+  `serialSeasonsResource` fires a `get_ordered_list&type=series` portal request
+  on each change and the other shapes resolve their episodes elsewhere.
 - `setSelectedCategory(...)` resets `page` to `0`.
 - `getPaginatedContent()` and `getCategoryResource()` always return arrays,
   even when the underlying request fails.

--- a/docs/architecture/stalker-store-api-baseline.md
+++ b/docs/architecture/stalker-store-api-baseline.md
@@ -124,11 +124,14 @@ Consumer directories sampled:
 ## Invariants to Preserve During Refactor
 
 - Selection IDs (`selectedVodId`, `selectedItvId`) are synchronized in `setSelectedItem`.
-- `selectedSerialId` is set only for a regular-series selection — content type
-  `series` and an item without embedded `series[]` episodes or the Ministra
-  `is_series` flag. Every other selection clears it, because
-  `serialSeasonsResource` fires a `get_ordered_list&type=series` portal request
-  on each change and the other shapes resolve their episodes elsewhere.
+- `selectedSerialId` is set only when `selectedContentType` is `series`, and is
+  cleared for every other content type. `serialSeasonsResource` fires a
+  `get_ordered_list&type=series` portal request on each change of that id, and
+  it is the only episode source for a `series` selection — while VOD-context
+  shapes (embedded `series[]`, Ministra `is_series`) resolve their episodes
+  elsewhere, so carrying the id there only wastes a request. The gate must stay
+  on content type alone: gating it on item shape would leave a series-section
+  item that happens to carry `is_series`/`series[]` with an empty episode list.
 - `setSelectedCategory(...)` resets `page` to `0`.
 - `getPaginatedContent()` and `getCategoryResource()` always return arrays,
   even when the underlying request fails.

--- a/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-selection.feature.spec.ts
+++ b/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-selection.feature.spec.ts
@@ -49,7 +49,65 @@ describe('withStalkerSelection', () => {
         });
 
         expect(store.selectedVodId()).toBe('55');
-        expect(store.selectedSerialId()).toBe('55');
         expect(store.selectedItvId()).toBe('55');
+    });
+
+    it('sets the serial id for a regular series selection', () => {
+        store.setSelectedContentType('series');
+
+        store.setSelectedItem({
+            id: '55',
+            name: 'Regular series',
+        });
+
+        expect(store.selectedSerialId()).toBe('55');
+    });
+
+    it('does not set the serial id for a plain VOD selection', () => {
+        store.setSelectedContentType('vod');
+
+        store.setSelectedItem({
+            id: '55',
+            name: 'Plain movie',
+        });
+
+        expect(store.selectedSerialId()).toBeUndefined();
+        expect(store.selectedVodId()).toBe('55');
+    });
+
+    it('does not set the serial id for items with embedded series episodes', () => {
+        store.setSelectedContentType('series');
+
+        store.setSelectedItem({
+            id: '55',
+            name: 'Embedded series',
+            series: [1, 2, 3],
+        });
+
+        expect(store.selectedSerialId()).toBeUndefined();
+    });
+
+    it('does not set the serial id for Ministra VOD-series items', () => {
+        store.setSelectedContentType('vod');
+
+        store.setSelectedItem({
+            id: '55',
+            name: 'VOD series',
+            is_series: '1',
+        });
+
+        expect(store.selectedSerialId()).toBeUndefined();
+    });
+
+    it('clears a stale serial id when a non-series item is selected', () => {
+        store.setSelectedContentType('series');
+        store.setSelectedItem({ id: '55', name: 'Regular series' });
+        expect(store.selectedSerialId()).toBe('55');
+
+        store.setSelectedContentType('vod');
+        store.setSelectedItem({ id: '77', name: 'Plain movie' });
+
+        expect(store.selectedSerialId()).toBeUndefined();
+        expect(store.selectedVodId()).toBe('77');
     });
 });

--- a/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-selection.feature.spec.ts
+++ b/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-selection.feature.spec.ts
@@ -76,7 +76,9 @@ describe('withStalkerSelection', () => {
     });
 
     it('does not set the serial id for items with embedded series episodes', () => {
-        store.setSelectedContentType('series');
+        // vclub items carry their episodes inline and are always opened
+        // under the VOD content type.
+        store.setSelectedContentType('vod');
 
         store.setSelectedItem({
             id: '55',
@@ -85,6 +87,32 @@ describe('withStalkerSelection', () => {
         });
 
         expect(store.selectedSerialId()).toBeUndefined();
+    });
+
+    it('still sets the serial id for a series selection carrying is_series', () => {
+        // Under the `series` content type the seasons API is the only
+        // episode source, so the fetch must not be gated on item shape.
+        store.setSelectedContentType('series');
+
+        store.setSelectedItem({
+            id: '55',
+            name: 'Series flagged is_series',
+            is_series: '1',
+        });
+
+        expect(store.selectedSerialId()).toBe('55');
+    });
+
+    it('still sets the serial id for a series selection carrying series[]', () => {
+        store.setSelectedContentType('series');
+
+        store.setSelectedItem({
+            id: '55',
+            name: 'Series carrying series[]',
+            series: [1, 2, 3],
+        });
+
+        expect(store.selectedSerialId()).toBe('55');
     });
 
     it('does not set the serial id for Ministra VOD-series items', () => {

--- a/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-selection.feature.ts
+++ b/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-selection.feature.ts
@@ -7,7 +7,10 @@ import {
 } from '@ngrx/signals';
 import { TmdbEnrichmentService } from '@iptvnator/services';
 import { StalkerVodSource } from '../../models';
-import { normalizeStalkerEntityId } from '../../stalker-vod.utils';
+import {
+    isStalkerSeriesItem,
+    normalizeStalkerEntityId,
+} from '../../stalker-vod.utils';
 import {
     enrichStalkerSelectionWithTmdb,
     stalkerSelectionMediaType,
@@ -102,9 +105,21 @@ export function withStalkerSelection() {
                     selectedIdRaw !== undefined
                         ? normalizeStalkerEntityId(selectedIdRaw)
                         : undefined;
+                // serialSeasonsResource fetches regular-series seasons
+                // (get_ordered_list&type=series) whenever selectedSerialId
+                // changes. Items with embedded series[] episodes or the
+                // Ministra is_series flag resolve their episodes elsewhere,
+                // so only a plain type=series selection may carry the id —
+                // anything else would fire a wasted portal request on every
+                // detail open.
+                const contentType = store.selectedContentType();
+                const isRegularSeries =
+                    contentType === 'series' &&
+                    !!selectedItem &&
+                    !isStalkerSeriesItem(selectedItem);
                 patchState(store, {
                     selectedVodId: selectedId,
-                    selectedSerialId: selectedId,
+                    selectedSerialId: isRegularSeries ? selectedId : undefined,
                     selectedItvId: selectedId,
                     selectedItem,
                 });
@@ -112,7 +127,6 @@ export function withStalkerSelection() {
                 // Async, best-effort TMDB enrichment for VOD/series detail
                 // selections. Applies via patchState (not setSelectedItem)
                 // so the hook cannot recurse; live/radio items are skipped.
-                const contentType = store.selectedContentType();
                 if (
                     selectedItem &&
                     (contentType === 'vod' || contentType === 'series')

--- a/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-selection.feature.ts
+++ b/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-selection.feature.ts
@@ -7,10 +7,7 @@ import {
 } from '@ngrx/signals';
 import { TmdbEnrichmentService } from '@iptvnator/services';
 import { StalkerVodSource } from '../../models';
-import {
-    isStalkerSeriesItem,
-    normalizeStalkerEntityId,
-} from '../../stalker-vod.utils';
+import { normalizeStalkerEntityId } from '../../stalker-vod.utils';
 import {
     enrichStalkerSelectionWithTmdb,
     stalkerSelectionMediaType,
@@ -106,20 +103,17 @@ export function withStalkerSelection() {
                         ? normalizeStalkerEntityId(selectedIdRaw)
                         : undefined;
                 // serialSeasonsResource fetches regular-series seasons
-                // (get_ordered_list&type=series) whenever selectedSerialId
-                // changes. Items with embedded series[] episodes or the
-                // Ministra is_series flag resolve their episodes elsewhere,
-                // so only a plain type=series selection may carry the id —
-                // anything else would fire a wasted portal request on every
-                // detail open.
+                // (get_ordered_list&type=series) on every selectedSerialId
+                // change, and it is the only episode source for a `series`
+                // selection. Every other content type resolves episodes
+                // elsewhere — embedded series[] and Ministra is_series items
+                // are always opened as `vod` — so carrying the id there only
+                // fires a portal request whose result is discarded.
                 const contentType = store.selectedContentType();
-                const isRegularSeries =
-                    contentType === 'series' &&
-                    !!selectedItem &&
-                    !isStalkerSeriesItem(selectedItem);
                 patchState(store, {
                     selectedVodId: selectedId,
-                    selectedSerialId: isRegularSeries ? selectedId : undefined,
+                    selectedSerialId:
+                        contentType === 'series' ? selectedId : undefined,
                     selectedItvId: selectedId,
                     selectedItem,
                 });

--- a/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-series.feature.spec.ts
+++ b/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-series.feature.spec.ts
@@ -145,7 +145,10 @@ describe('withStalkerSeries serialSeasonsResource gating', () => {
     });
 
     it('does not fire a series request for an item with embedded series episodes', async () => {
-        store.setSelectedContentType('series');
+        // vclub items carry their episodes inline and are always opened
+        // under the VOD content type, where the seasons API is not the
+        // episode source.
+        store.setSelectedContentType('vod');
         store.setSelectedItem({
             id: '9',
             name: 'Embedded series',
@@ -156,6 +159,32 @@ describe('withStalkerSeries serialSeasonsResource gating', () => {
         await flushResources();
 
         expect(dataService.sendIpcEvent).not.toHaveBeenCalled();
+    });
+
+    it('still fetches seasons for a series selection carrying is_series', async () => {
+        // Regression guard: under the `series` content type the detail view
+        // renders <app-stalker-series-view /> without a vodWithSeries input,
+        // so serialSeasonsResource is the only episode source. Gating the
+        // fetch on item shape would render an empty episode list.
+        store.setSelectedContentType('series');
+        store.setSelectedItem({
+            id: '42',
+            name: 'Series flagged is_series',
+            is_series: '1',
+        });
+
+        await waitForCondition(
+            () => seriesRequestCalls(dataService.sendIpcEvent).length > 0
+        );
+
+        expect(
+            seriesRequestCalls(dataService.sendIpcEvent)[0][1]
+        ).toMatchObject({
+            params: expect.objectContaining({
+                type: 'series',
+                movie_id: '42',
+            }),
+        });
     });
 
     it('does not fire a series request for a Ministra VOD-series item', async () => {

--- a/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-series.feature.spec.ts
+++ b/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-series.feature.spec.ts
@@ -1,0 +1,195 @@
+import { TestBed } from '@angular/core/testing';
+import { patchState, signalStore, withMethods, withState } from '@ngrx/signals';
+import { DataService, TmdbEnrichmentService } from '@iptvnator/services';
+import { PlaylistMeta, StalkerPortalActions } from '@iptvnator/shared/interfaces';
+import { StalkerSessionService } from '../../stalker-session.service';
+import { withStalkerSelection } from './with-stalker-selection.feature';
+import { withStalkerSeries } from './with-stalker-series.feature';
+
+jest.mock('@iptvnator/portal/shared/util', () => ({
+    createLogger: () => ({
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    }),
+}));
+
+const PLAYLIST = {
+    _id: 'playlist-1',
+    title: 'Demo Stalker',
+    count: 0,
+    autoRefresh: false,
+    importDate: '2026-04-14T00:00:00.000Z',
+    portalUrl: 'http://demo.example/stalker_portal/server/load.php',
+    macAddress: '00:1A:79:00:00:01',
+    isFullStalkerPortal: false,
+} as PlaylistMeta;
+
+const TestSeriesStore = signalStore(
+    withState({
+        currentPlaylist: undefined as PlaylistMeta | undefined,
+    }),
+    withMethods((store) => ({
+        setCurrentPlaylist(playlist: PlaylistMeta | undefined) {
+            patchState(store, { currentPlaylist: playlist });
+        },
+    })),
+    withStalkerSelection(),
+    withStalkerSeries()
+);
+
+async function flushResources(): Promise<void> {
+    TestBed.flushEffects();
+    await Promise.resolve();
+    await Promise.resolve();
+    TestBed.flushEffects();
+    await Promise.resolve();
+}
+
+async function waitForCondition(
+    predicate: () => boolean,
+    attempts = 20
+): Promise<void> {
+    for (let index = 0; index < attempts; index += 1) {
+        if (predicate()) {
+            return;
+        }
+
+        await flushResources();
+    }
+
+    throw new Error('Timed out waiting for resource activity');
+}
+
+function seriesRequestCalls(
+    sendIpcEvent: jest.Mock<Promise<unknown>, unknown[]>
+) {
+    return sendIpcEvent.mock.calls.filter(
+        ([, payload]) =>
+            (payload as { params?: { type?: string } })?.params?.type ===
+            'series'
+    );
+}
+
+describe('withStalkerSeries serialSeasonsResource gating', () => {
+    let store: InstanceType<typeof TestSeriesStore>;
+    let dataService: {
+        sendIpcEvent: jest.Mock<Promise<unknown>, unknown[]>;
+    };
+
+    beforeEach(() => {
+        dataService = {
+            sendIpcEvent: jest.fn().mockResolvedValue({ js: [] }),
+        };
+
+        TestBed.configureTestingModule({
+            providers: [
+                TestSeriesStore,
+                { provide: DataService, useValue: dataService },
+                {
+                    provide: StalkerSessionService,
+                    useValue: {
+                        makeAuthenticatedRequest: jest.fn(),
+                    },
+                },
+                {
+                    provide: TmdbEnrichmentService,
+                    useValue: {
+                        isEnabled: () => false,
+                    },
+                },
+            ],
+        });
+
+        store = TestBed.inject(TestSeriesStore);
+        store.setCurrentPlaylist(PLAYLIST);
+        void store.isSerialSeasonsLoading();
+        void store.isVodSeriesSeasonsLoading();
+    });
+
+    it('fetches seasons for a regular series selection', async () => {
+        dataService.sendIpcEvent.mockResolvedValue({
+            js: [{ id: '42:1', name: 'Season 1', series: [1, 2] }],
+        });
+
+        store.setSelectedContentType('series');
+        store.setSelectedItem({ id: '42', name: 'Regular series' });
+
+        await waitForCondition(
+            () => seriesRequestCalls(dataService.sendIpcEvent).length > 0
+        );
+
+        expect(dataService.sendIpcEvent).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                url: PLAYLIST.portalUrl,
+                macAddress: PLAYLIST.macAddress,
+                params: expect.objectContaining({
+                    action: StalkerPortalActions.GetOrderedList,
+                    type: 'series',
+                    movie_id: '42',
+                }),
+            })
+        );
+    });
+
+    it('does not fire a series request for a plain VOD selection', async () => {
+        store.setSelectedContentType('vod');
+        store.setSelectedItem({ id: '7', name: 'Plain movie' });
+
+        await flushResources();
+        await flushResources();
+
+        expect(dataService.sendIpcEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a series request for an item with embedded series episodes', async () => {
+        store.setSelectedContentType('series');
+        store.setSelectedItem({
+            id: '9',
+            name: 'Embedded series',
+            series: [1, 2, 3],
+        });
+
+        await flushResources();
+        await flushResources();
+
+        expect(dataService.sendIpcEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not fire a series request for a Ministra VOD-series item', async () => {
+        store.setSelectedContentType('vod');
+        store.setSelectedItem({
+            id: '11',
+            name: 'VOD series',
+            is_series: '1',
+        });
+
+        // The legit vod-series season request (type=vod) may fire; the
+        // wasted regular-series request (type=series) must not.
+        await waitForCondition(
+            () => dataService.sendIpcEvent.mock.calls.length > 0
+        );
+        await flushResources();
+
+        expect(seriesRequestCalls(dataService.sendIpcEvent)).toHaveLength(0);
+    });
+
+    it('does not refetch seasons when a VOD item is selected after a series', async () => {
+        store.setSelectedContentType('series');
+        store.setSelectedItem({ id: '42', name: 'Regular series' });
+
+        await waitForCondition(
+            () => seriesRequestCalls(dataService.sendIpcEvent).length === 1
+        );
+
+        store.setSelectedContentType('vod');
+        store.setSelectedItem({ id: '7', name: 'Plain movie' });
+
+        await flushResources();
+        await flushResources();
+
+        expect(seriesRequestCalls(dataService.sendIpcEvent)).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Problem

`setSelectedItem` ([with-stalker-selection.feature.ts](https://github.com/4gray/iptvnator/blob/master/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-selection.feature.ts)) mirrored **every** selection's id into `selectedSerialId`, and `serialSeasonsResource` ([with-stalker-series.feature.ts](https://github.com/4gray/iptvnator/blob/master/libs/portal/stalker/data-access/src/lib/stores/features/with-stalker-series.feature.ts)) only gates on `selectedSerialId` + `currentPlaylist`.

So opening *any* Stalker detail page fired a pointless portal request:

```
get_ordered_list&type=series&movie_id=<id>
```

This happened for:

- plain VOD movies (no series data at all),
- vclub items with embedded `series[]` — the response is fetched and then **discarded** by `mapRegularSeriesSeasons`, which prefers the embedded episodes,
- Ministra `is_series` VOD items, which resolve seasons through the separate `type=vod` path,
- ITV channel selections in the live layout.

…on every entry path: browse, favorites, recent, dashboard and search.

## Fix

Set `selectedSerialId` only when `selectedContentType === 'series'`; every other content type clears it. That also prevents a stale serial id from lingering when a VOD item is opened right after a series.

**The gate is deliberately on content type alone, not item shape.** Under the `series` content type `serialSeasonsResource` is the *only* episode source — the detail templates render `<app-stalker-series-view />` with no `vodWithSeries` input ([stalker-catalog-detail.component.html:26-28](https://github.com/4gray/iptvnator/blob/master/libs/portal/stalker/feature/src/lib/stalker-catalog-detail/stalker-catalog-detail.component.html#L26-L28)), and `isVodSeries()` requires content type `vod`. Additionally gating on `is_series`/`series[]` would leave a series-section item that happens to carry either field with a silently empty episode list (no spinner, no error). It would also buy nothing: every embedded-series and Ministra item is opened under content type `vod` (`resolveDetailMode`, the search filter, the route section), so the content-type check alone already suppresses 100% of the wasted requests.

The first commit had that unnecessary conjunct; the third commit removes it after self-review. The resource loader already early-returns `[]` on an empty id without issuing a request, so it needed no change.

## Tests

- `with-stalker-selection.feature.spec.ts` — serial id set for a regular series; not set for plain VOD, embedded-`series[]` and Ministra `is_series` items (each paired with the VOD content type they actually occur under); cleared when a non-series item follows a series; **and still set** for a `series` selection carrying `is_series` or `series[]`.
- `with-stalker-series.feature.spec.ts` (new) — composes the real selection + series features with a mocked `DataService` and asserts at the **request level**: exactly one `type=series` fetch for a regular series, zero portal calls for plain VOD and embedded-series selections, no `type=series` call for a Ministra item (its legitimate `type=vod` season request is still allowed), no refetch when a VOD selection follows a series, and a regression guard that a `series` selection carrying `is_series` still fetches.

Regression check: with the fix reverted to the `origin/master` implementation, the new tests fail (8 failures); with it applied, all 107 pass.

## Validation

| Command | Result |
| --- | --- |
| `pnpm nx test portal-stalker-data-access` | 17 suites, 107 tests passed |
| `pnpm nx test portal-stalker-feature` | 9 suites, 77 tests passed |
| `pnpm nx lint portal-stalker-data-access` | clean |

## Docs

`docs/architecture/stalker-store-api-baseline.md` claimed all three selection ids are synchronized in `setSelectedItem`, which is no longer true. Both that file and the VOD/Series modes section of `docs/architecture/stalker-portal.md` now record the actual invariant and why the gate must stay on content type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)