### PR TITLE
fix(ci): classify release-tools in the coverage policy

### DIFF
--- a/tools/coverage/coverage-policy.json
+++ b/tools/coverage/coverage-policy.json
@@ -234,6 +234,12 @@
                 "reason": "Node package identity checks validate generated packaging metadata."
             },
             {
+                "name": "release-tools",
+                "root": "tools/release",
+                "validationCommand": "pnpm nx test release-tools",
+                "reason": "Node tests validate release-note parsing, rendering and gate policy; the scripts are release tooling, not shipped source."
+            },
+            {
                 "name": "remote-control-web",
                 "root": "apps/remote-control-web",
                 "validationCommand": "pnpm nx build remote-control-web",


### PR DESCRIPTION
## Why

Master is red and blocking every PR rebased onto it.

#1256 added the `release-tools` Nx project with a `test` target but did not list it in `tools/coverage/coverage-policy.json`. The policy check enumerates projects with a test target and fails on any it does not know:

```
Coverage policy is missing projects that have a test target:
  - release-tools
```

Master has failed `Unit Tests and Typechecks` since that merge (`270350c2`), and again on `6bdd6fd8`. My breakage from #1256 — apologies for the blast radius.

(The earlier failure on `9885178f` was unrelated: the `Workflow lint` job could not pull the pinned actionlint image.)

## What

One entry, Tier B, mirroring the sibling `packaging` tools project. The tests validate release-note parsing, rendering and gate policy, but these scripts are release tooling rather than shipped source, so a percentage-coverage baseline would measure nothing useful — exactly the rationale Tier B exists for.

## Verification

- `node tools/coverage/check-coverage-policy.mjs` → `Coverage policy OK: 36 test projects classified (30 Tier A, 6 Tier B, 6 Tier C)`
- `node tools/coverage/check-coverage-policy.mjs --run-non-tier-a` → exit 0, release-tools suite runs green
- Diff is 6 added lines; no reformatting of the surrounding file

No release note: CI configuration with no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)