### PR TITLE
docs(release): backfill curated 0.23.0 release notes, fix the notes CLI `--` trap

### DIFF
--- a/.changes/README.md
+++ b/.changes/README.md
@@ -69,16 +69,15 @@ node tools/release/build-release-notes.mjs --consume
 ```
 
 The release version comes from the root `package.json` — bump it first, then
-generate. `--version 0.24.0` overrides it to preview a release before the bump,
-and is appended straight to the script, with no `--` separator:
+generate. `--version 0.24.0` overrides it to preview a release before the bump:
 
 ```bash
 pnpm run release:notes:github --version 0.24.0
 ```
 
-pnpm passes a bare `--` through to the script instead of swallowing it the way
-npm does, so the reflexive `pnpm run release:notes:github -- --version 0.24.0`
-dies with `unknown argument: --`.
+A bare `--` separator is accepted and ignored, so the npm habit of
+`pnpm run release:notes:github -- --version 0.24.0` works too: pnpm forwards
+that separator to the script rather than consuming it the way npm does.
 
 `--validate` and `--format github` only read and print. `--format changelog`
 and `--format blog` write their target file (rerunning `changelog` for the same

--- a/.changes/README.md
+++ b/.changes/README.md
@@ -69,9 +69,21 @@ node tools/release/build-release-notes.mjs --consume
 ```
 
 The release version comes from the root `package.json` — bump it first, then
-generate. `--version 0.24.0` overrides it for a dry run before the bump.
+generate. `--version 0.24.0` overrides it to preview a release before the bump,
+and is appended straight to the script, with no `--` separator:
 
-Only `--consume` deletes anything; every other mode is a safe dry run.
+```bash
+pnpm run release:notes:github --version 0.24.0
+```
+
+pnpm passes a bare `--` through to the script instead of swallowing it the way
+npm does, so the reflexive `pnpm run release:notes:github -- --version 0.24.0`
+dies with `unknown argument: --`.
+
+`--validate` and `--format github` only read and print. `--format changelog`
+and `--format blog` write their target file (rerunning `changelog` for the same
+version replaces that section rather than duplicating it). Only `--consume`
+deletes anything.
 
 The release sequence is: bump the version → `release:notes:changelog` →
 `release:notes:blog` → `--consume` → commit → tag → push. The tag build then

--- a/.changes/backup-hidden-categories.md
+++ b/.changes/backup-hidden-categories.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: backup
+issues: [1017]
+---
+
+Backups carry hidden Xtream categories correctly. An export used to lose which
+categories you had hidden, and restoring such a backup then hid every category
+of that kind.

--- a/.changes/downloads-pause-resume.md
+++ b/.changes/downloads-pause-resume.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: downloads
+---
+
+Downloads can be paused and picked up later. A paused transfer keeps what it
+already fetched and continues from that point instead of starting over, and
+downloads cut short by a crash or a closed app come back as paused rather than
+lost.

--- a/.changes/embedded-mpv-frame-copy.md
+++ b/.changes/embedded-mpv-frame-copy.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: embedded-mpv
+---
+
+Experimental Embedded MPV can draw video inside the app window instead of into a
+separate layer pinned on top of it, so menus, dialogs and the player controls
+stop being swallowed by the picture. Available on macOS (Apple Silicon), Windows
+and Linux; switching it on needs a restart.

--- a/.changes/embedded-mpv-frame-copy.md
+++ b/.changes/embedded-mpv-frame-copy.md
@@ -6,4 +6,4 @@ area: embedded-mpv
 Experimental Embedded MPV can draw video inside the app window instead of into a
 separate layer pinned on top of it, so menus, dialogs and the player controls
 stop being swallowed by the picture. Available on macOS (Apple Silicon), Windows
-and Linux; switching it on needs a restart.
+and Linux x64; switching it on needs a restart.

--- a/.changes/epg-manual-channel-mapping.md
+++ b/.changes/epg-manual-channel-mapping.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: epg
+---
+
+Channels whose guide never matched can be mapped by hand: right-click a channel
+in any list and pick "Map EPG channel" to attach it to a channel from your
+uploaded XMLTV guide. The mapping is remembered and used everywhere the guide is
+read — M3U playlists, Xtream and Stalker portals alike.

--- a/.changes/favorites-lost-updates.md
+++ b/.changes/favorites-lost-updates.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: favorites
+issues: [1137]
+---
+
+Favorites stop losing changes. The custom drag-and-drop order of an Xtream
+playlist's own favorites is saved again, and two favorites or history entries
+added at almost the same moment no longer quietly overwrite each other.

--- a/.changes/i18n-hungarian.md
+++ b/.changes/i18n-hungarian.md
@@ -1,0 +1,7 @@
+---
+type: feature
+area: i18n
+issues: [1192]
+---
+
+IPTVnator speaks Hungarian, its 19th language — contributed by @htibcsike.

--- a/.changes/m3u-dash-clearkey.md
+++ b/.changes/m3u-dash-clearkey.md
@@ -1,0 +1,10 @@
+---
+type: feature
+area: m3u
+issues: [86, 614, 656, 733, 752]
+---
+
+MPEG-DASH channels play in the built-in player, ClearKey-encrypted ones
+included — the keys are read from the playlist's #KODIPROP lines, whether they
+sit above or below the channel entry. Streams locked with Widevine or PlayReady
+still cannot be played, but they now say so instead of failing silently.

--- a/.changes/m3u-long-stream-urls.md
+++ b/.changes/m3u-long-stream-urls.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: m3u
+issues: [1189]
+---
+
+Playlists with very long stream URLs — Pluto TV style lists that carry a session
+token in every link — import in full again instead of collapsing into a single
+channel.

--- a/.changes/playback-shared-player-controls.md
+++ b/.changes/playback-shared-player-controls.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: playback
+---
+
+An optional new set of player controls that looks and behaves the same in every
+built-in player, with picture-in-picture and, in fullscreen, the name of what you
+are watching. Enable it in Settings → Playback; left off, each player keeps its
+own controls exactly as before.

--- a/.changes/playback-shared-player-controls.md
+++ b/.changes/playback-shared-player-controls.md
@@ -3,7 +3,7 @@ type: feature
 area: playback
 ---
 
-An optional new set of player controls that looks and behaves the same in every
-built-in player, with picture-in-picture and, in fullscreen, the name of what you
-are watching. Enable it in Settings → Playback; left off, each player keeps its
-own controls exactly as before.
+An optional new set of player controls that looks and behaves the same in the
+HTML5, Video.js and ArtPlayer players, with picture-in-picture and, in
+fullscreen, the name of what you are watching. Enable it in Settings → Playback;
+left off, each of the three keeps its own controls exactly as before.

--- a/.changes/playback-theater-stage.md
+++ b/.changes/playback-theater-stage.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: playback
+---
+
+The inline player on movie and series pages fills the whole content area like a
+theater: the video sits centered in black instead of leaving a strip of app
+background beside it. Ambient mode, off by default, fills that space with a
+blurred, dimmed copy of the poster.

--- a/.changes/playback-theater-stage.md
+++ b/.changes/playback-theater-stage.md
@@ -5,5 +5,5 @@ area: playback
 
 The inline player on movie and series pages fills the whole content area like a
 theater: the video sits centered in black instead of leaving a strip of app
-background beside it. Ambient mode, off by default, fills that space with a
-blurred, dimmed copy of the poster.
+background beside it. In the built-in web players, an optional ambient mode
+fills that space with a blurred, dimmed copy of the poster.

--- a/.changes/playback-up-next-rail.md
+++ b/.changes/playback-up-next-rail.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: playback
+---
+
+A series playing inline on a wide window shows an "Up Next" rail beside the
+video: the rest of the season and the start of the next one, the current episode
+highlighted, watch progress on every card. Click one to jump straight to it, or
+switch the rail off in Settings → Playback.

--- a/.changes/playback-up-next-rail.md
+++ b/.changes/playback-up-next-rail.md
@@ -5,5 +5,5 @@ area: playback
 
 A series playing inline on a wide window shows an "Up Next" rail beside the
 video: the rest of the season and the start of the next one, the current episode
-highlighted, watch progress on every card. Click one to jump straight to it, or
-switch the rail off in Settings → Playback.
+highlighted, watch progress on every card. Click one to jump straight to it.
+Built-in web players only; switch the rail off in Settings → Playback.

--- a/.changes/playlists-auto-refresh.md
+++ b/.changes/playlists-auto-refresh.md
@@ -1,0 +1,10 @@
+---
+type: fix
+area: playlists
+issues: [931]
+---
+
+One unreachable playlist no longer holds up the rest. Refreshes give up after 30
+seconds and run a few at a time, so your other playlists still update, and the
+message on startup names how many actually failed instead of always claiming
+success.

--- a/.changes/search-punctuation-words.md
+++ b/.changes/search-punctuation-words.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: search
+issues: [1161]
+---
+
+Searching for names that carry punctuation inside them — "A&E", "X-Men",
+"L'Equipe" — finds them anywhere in a title, including channels the provider
+prefixes, like "US: A&E".

--- a/.changes/settings-strip-country-prefix.md
+++ b/.changes/settings-strip-country-prefix.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: settings
+---
+
+A new setting drops the country prefix from live channel names, turning
+"UK - BBC One" into "BBC One" in lists, the guide and the player. Movie and
+series titles are left alone, and names that only look like a prefix — "Sky -
+Sports F1" — stay intact.

--- a/.changes/stalker-detail-requests.md
+++ b/.changes/stalker-detail-requests.md
@@ -3,6 +3,7 @@ type: perf
 area: stalker
 ---
 
-Detail pages open faster: a movie, channel or series no longer triggers an extra
-episode-list request before it can show anything — whether you got there from
-browsing, search, Favorites, Recent or the dashboard.
+Detail pages for anything that is not a series — a movie, a live channel, a VOD
+item that only looks like a series — no longer fire an episode-list request
+before they can show anything, so they open faster on every route in, from
+browsing and search to Favorites, Recent and the dashboard.

--- a/.changes/stalker-detail-requests.md
+++ b/.changes/stalker-detail-requests.md
@@ -1,0 +1,8 @@
+---
+type: perf
+area: stalker
+---
+
+Detail pages open faster: a movie, channel or series no longer triggers an extra
+episode-list request before it can show anything — whether you got there from
+browsing, search, Favorites, Recent or the dashboard.

--- a/.changes/stalker-embedded-series-episodes.md
+++ b/.changes/stalker-embedded-series-episodes.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: stalker
+---
+
+Series opened from Favorites, Recent or the dashboard show their current
+episodes. One saved back when a single episode existed used to keep showing that
+one episode forever; the list is refreshed from the portal in the background
+instead.

--- a/.changes/stalker-live-tv-channel-list.md
+++ b/.changes/stalker-live-tv-channel-list.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: stalker
+---
+
+The Live TV section loads its full channel list up front: search covers every
+channel instead of only the page you are on, genres show how many channels they
+hold, and Live TV opens on a grid of all channels. Guide data for the visible
+rows loads in bulk, so it shows up without playing a channel first.

--- a/.changes/tmdb-detail-page-extras.md
+++ b/.changes/tmdb-detail-page-extras.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: tmdb
+---
+
+Series pages show whether a show has ended or is still returning, so you know
+before committing to it. Directors and creators became clickable avatar chips
+like the cast — they open the person's page, where directing credits now sit
+alongside acting ones.

--- a/.changes/tmdb-title-matching.md
+++ b/.changes/tmdb-title-matching.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: tmdb
+---
+
+Titles that providers dress up with language or quality tags — "|ALB| Fallout",
+"4K-DE - The Pitt (2025)", "Breaking Bad-eng" — now match against TMDB, so they
+get artwork, plot and cast like the rest of the catalog. Shows split into one
+entry per season also pull the season that entry really contains.

--- a/.changes/xtream-catchup-collections.md
+++ b/.changes/xtream-catchup-collections.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: xtream
+issues: [1138]
+---
+
+Catch-up is available from Favorites and Recent, not just Live TV, so an
+archived programme is reachable wherever the channel is. The programme currently
+on air can also be restarted from the beginning.

--- a/.changes/xtream-portal-connection.md
+++ b/.changes/xtream-portal-connection.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: xtream
+---
+
+Portals sitting behind Cloudflare or a similar firewall connect again. Those
+setups answered the app with a challenge page instead of data, so "Test
+connection" failed on portals that worked fine in every other player; requests
+now identify themselves the way an ordinary IPTV player does.

--- a/.changes/xtream-series-resume.md
+++ b/.changes/xtream-series-resume.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: xtream
+---
+
+Continue Watching resumes a series where you left it: opening one from the
+dashboard starts the exact episode at its saved position, and the series page
+offers "Play episode N" instead of always starting at the first one. Episodes
+launched in MPV or VLC count towards this too.

--- a/tools/release/build-release-notes.mjs
+++ b/tools/release/build-release-notes.mjs
@@ -90,6 +90,13 @@ function parseArgs(argv) {
             case '--force':
                 options.force = true;
                 break;
+            // npm needs `--` to forward arguments past the script name; pnpm
+            // hands it to the script verbatim. Ignore it so the habitual
+            // `pnpm run release:notes:github -- --version 0.24.0` works
+            // instead of dying on its own separator. There are no positional
+            // arguments for it to delimit.
+            case '--':
+                break;
             default:
                 throw new Error(`unknown argument: ${arg}`);
         }

--- a/tools/release/build-release-notes.test.mjs
+++ b/tools/release/build-release-notes.test.mjs
@@ -1,0 +1,119 @@
+/**
+ * CLI-level tests for build-release-notes.mjs.
+ *
+ * The script parses its arguments and runs on import, so these drive the real
+ * entry point in a subprocess rather than importing parseArgs directly.
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { after, describe, it } from 'node:test';
+
+const workspaceRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../..'
+);
+const CLI = path.join(workspaceRoot, 'tools/release/build-release-notes.mjs');
+const tempDirs = [];
+
+/** A notes directory holding one valid note, so runs have something to render. */
+function makeNotesDir() {
+    const directory = mkdtempSync(path.join(tmpdir(), 'release-cli-'));
+    tempDirs.push(directory);
+
+    writeFileSync(
+        path.join(directory, 'playback-example.md'),
+        '---\ntype: feature\narea: playback\n---\n\nAn example note.\n',
+        'utf8'
+    );
+
+    return directory;
+}
+
+/**
+ * @returns {{ status: number, stdout: string, stderr: string }}
+ */
+function runCli(args) {
+    try {
+        const stdout = execFileSync(process.execPath, [CLI, ...args], {
+            cwd: workspaceRoot,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+
+        return { status: 0, stdout, stderr: '' };
+    } catch (error) {
+        return {
+            status: error.status ?? 1,
+            stdout: error.stdout ?? '',
+            stderr: error.stderr ?? '',
+        };
+    }
+}
+
+after(() => {
+    for (const directory of tempDirs) {
+        rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+describe('build-release-notes CLI arguments', () => {
+    it('validates a notes directory', () => {
+        const result = runCli(['--validate', '--dir', makeNotesDir()]);
+
+        assert.equal(result.status, 0);
+        assert.match(result.stdout, /1 release note\(s\) valid\./);
+    });
+
+    it('ignores a bare `--` separator', () => {
+        // pnpm forwards `--` to the script instead of consuming it, so the
+        // npm-style `pnpm run release:notes:validate -- --dir x` reaches us
+        // with the separator still attached.
+        const result = runCli(['--validate', '--', '--dir', makeNotesDir()]);
+
+        assert.equal(result.status, 0);
+        assert.match(result.stdout, /1 release note\(s\) valid\./);
+    });
+
+    it('ignores a leading `--` separator', () => {
+        const result = runCli(['--', '--validate', '--dir', makeNotesDir()]);
+
+        assert.equal(result.status, 0);
+        assert.match(result.stdout, /1 release note\(s\) valid\./);
+    });
+
+    it('renders the github body with a version passed after `--`', () => {
+        const result = runCli([
+            '--format',
+            'github',
+            '--',
+            '--version',
+            '0.24.0',
+            '--dir',
+            makeNotesDir(),
+        ]);
+
+        assert.equal(result.status, 0);
+        assert.match(result.stdout, /## Features/);
+        assert.match(result.stdout, /\*\*playback\*\* — An example note\./);
+    });
+
+    it('still rejects a genuinely unknown argument', () => {
+        const result = runCli(['--validate', '--nope']);
+
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /unknown argument: --nope/);
+    });
+
+    it('still rejects a flag whose value is missing', () => {
+        const result = runCli(['--format']);
+
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /--format requires a value/);
+    });
+});

--- a/tools/release/project.json
+++ b/tools/release/project.json
@@ -12,14 +12,16 @@
                 "{workspaceRoot}/tools/release/release-notes-render.mjs",
                 "{workspaceRoot}/tools/release/extract-changelog-section.mjs",
                 "{workspaceRoot}/tools/release/check-release-note-gate.mjs",
+                "{workspaceRoot}/tools/release/build-release-notes.mjs",
                 "{workspaceRoot}/tools/release/screenshot-guards.mjs",
                 "{workspaceRoot}/tools/release/screenshots.manifest.json",
                 "{workspaceRoot}/tools/release/release-notes.test.mjs",
                 "{workspaceRoot}/tools/release/release-note-gate.test.mjs",
+                "{workspaceRoot}/tools/release/build-release-notes.test.mjs",
                 "{workspaceRoot}/tools/release/screenshot-guards.test.mjs"
             ],
             "options": {
-                "command": "node --test tools/release/release-notes.test.mjs tools/release/release-note-gate.test.mjs tools/release/screenshot-guards.test.mjs",
+                "command": "node --test tools/release/release-notes.test.mjs tools/release/release-note-gate.test.mjs tools/release/build-release-notes.test.mjs tools/release/screenshot-guards.test.mjs",
                 "cwd": "{workspaceRoot}"
             }
         },


### PR DESCRIPTION
## Why

The `.changes/` pipeline (#1256, #1257, #1261) landed *after* most of the 0.23.0 work was merged. `package.json` is already at `0.23.0` and there is no `v0.23.0` tag, so everything since `v0.22.0` belongs to this release — but only 4 notes existed for 79 commits. Without a backfill the authored section of the 0.23.0 release body would be nearly empty.

## What

22 authored notes, bringing `.changes/` to **26** (14 features, 11 fixes, 1 perf).

**Curated, not exhaustive.** The GitHub release body renders these *above* GitHub's own auto-generated list of every merged PR, so replaying all 61 feat/fix/perf commits would just duplicate that list. Related PRs are folded into one note per user-facing story:

| Note | Folds |
| --- | --- |
| `playback-shared-player-controls` | #1148, #1193, #1194, #1195, #1196, #1198, #1199, #1228 |
| `embedded-mpv-frame-copy` | #1169, #1171, #1175, #1200 |
| `epg-manual-channel-mapping` | #1165, #1173, #1214 |
| `m3u-dash-clearkey` | #1225, #1234 |
| `playlists-auto-refresh` | #1233, #1235 |
| `tmdb-title-matching` | #1211, #1229 |
| `tmdb-detail-page-extras` | #1227, #1240 |
| `favorites-lost-updates` | #1143, #1255 |
| `stalker-embedded-series-episodes` | #1218, #1253 |

Tooling-only scopes (`ci`, `release`, `packaging`, `website`, `docs`, `refactor`) get no note. Deliberately left out as too minor for the authored section — GitHub's auto list still covers them: theme-aware scrollbars (#1179), embedded-MPV native-view placement (#1206, #1207), MKV source routing (#1210), in-portal search back button (#1142), build commit in About (#1208), catalog type badges (#1217), XMLTV sub-hour offsets (#1216), trailer language fallback (#1136), log redaction (#1182).

Issue links are carried in `issues:` frontmatter where a PR genuinely closed one — including the five long-standing DASH requests (#86, #614, #656, #733, #752) closed by #1225.

## No screenshots

None of the five slugs in `tools/release/screenshots.manifest.json` depicts a 0.23 headline feature (Up Next rail, theater stage, frame-copy, DASH), and the capture run asserts TMDB enrichment stays disabled, so no TMDB note could carry one either. Attaching a mismatched shot would be worse than none — adding manifest entries is a release-time call.

## Known limitation of any backfill

The generator resolves each note's PR link from the commit that added the file, so all 22 backfilled entries will link to **this** PR rather than the original ones. Real attribution stays intact via GitHub's auto-generated PR list below the authored section.

## Two tooling fixes found on the way

Both came out of writing the notes above, in `.changes/README.md` and the CLI it documents.

**1. `pnpm run release:notes:github -- --version 0.24.0` died with `unknown argument: --`.** npm needs `--` to forward arguments past the script name; pnpm hands it to the script verbatim. So the separator you type to make forwarding work was itself the thing that broke it. `parseArgs` now ignores a bare `--` wherever it appears — there are no positional arguments for it to delimit, and unknown flags / missing values still fail exactly as before.

New `tools/release/build-release-notes.test.mjs` drives the real CLI in a subprocess (the script parses and runs on import, so `parseArgs` cannot be imported directly). Six cases: the three `--` forms **fail on the old code and pass now**, plus two guards proving genuine argument errors are still rejected. Wired into the `release-tools` test target and its cache inputs.

**2. "every other mode is a safe dry run" was wrong.** `--format changelog` writes `CHANGELOG.md` and `--format blog` writes the post scaffold. Only `--validate` and `--format github` read without writing — worth being exact about three lines above a "preview a release" instruction.

## Verification

```
pnpm nx test release-tools    # 93 passed
pnpm nx lint release-tools    # clean
node tools/release/build-release-notes.mjs --validate    # 26 release note(s) valid
```

Both invocation forms now render: `pnpm run release:notes:github --version 0.24.0` and the `--` variant. The `--format github` dry run was read end to end and revised for tone — repeated "Settings → Playback" endings, trailing-"now" constructions, and `**stalker** — Stalker…` area-label redundancy were edited out.

No app or lib code, no version bump, no `--consume`, no `CHANGELOG.md` or website changes. Those stay owned by `release-cut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)