### PR TITLE
ci(deps): bump checkout/upload-artifact/download-artifact majors

### DIFF
--- a/.github/workflows/build-and-make.yaml
+++ b/.github/workflows/build-and-make.yaml
@@ -56,7 +56,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -322,7 +322,7 @@ jobs:
                   test -s "${RUNTIME_ROOT}/source-archive-binding.json"
 
             - name: Upload staged Linux runtime
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: linux-embedded-mpv-runtime
                   path: vendor/embedded-mpv/linux-x64
@@ -330,7 +330,7 @@ jobs:
                   retention-days: 7
 
             - name: Upload Linux runtime source compliance
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: linux-frame-copy-runtime-sources
                   path: dist/compliance/linux-frame-copy-runtime-sources.tar.xz
@@ -370,7 +370,7 @@ jobs:
 
         steps: &electron-build-steps
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
@@ -424,7 +424,7 @@ jobs:
 
             - name: Download pinned Linux Embedded MPV runtime
               if: matrix.os == 'linux'
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: linux-embedded-mpv-runtime
                   path: vendor/embedded-mpv/linux-x64
@@ -1187,7 +1187,7 @@ jobs:
 
             - name: Upload artifacts (macOS)
               if: matrix.os == 'macos'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: macos-${{ matrix.arch }}-artifacts
                   path: |
@@ -1199,7 +1199,7 @@ jobs:
 
             - name: Upload system-runtime Linux artifacts
               if: matrix.os == 'linux' && matrix.linux_profile == 'system'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: linux-system-artifacts
                   path: |
@@ -1211,7 +1211,7 @@ jobs:
 
             - name: Upload portable-runtime Linux artifacts
               if: matrix.os == 'linux' && matrix.linux_profile == 'portable'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: linux-portable-artifacts
                   path: |
@@ -1223,7 +1223,7 @@ jobs:
 
             - name: Upload Flatpak-runtime Linux artifacts
               if: matrix.os == 'linux' && matrix.linux_profile == 'flatpak'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: linux-flatpak-artifacts
                   path: |
@@ -1232,7 +1232,7 @@ jobs:
 
             - name: Upload artifacts (Windows)
               if: matrix.os == 'windows'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: windows-artifacts
                   path: |
@@ -1294,10 +1294,10 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download all artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   path: artifacts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             # Image pinned by digest (tag 1.7.12). False positives are
             # suppressed in .github/actionlint.yaml; shellcheck runs at
@@ -53,7 +53,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             # The gate scripts are dependency-free Node, so this job skips
             # pnpm install entirely and stays cheap.
@@ -92,7 +92,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   # nx affected needs the merge-base with the PR target branch.
                   fetch-depth: 0
@@ -133,7 +133,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
@@ -167,7 +167,7 @@ jobs:
 
             - name: Upload unit coverage artifact
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: unit-coverage
                   path: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning. PR runs analyze the merge
     # commit checked out above (the modern default); JavaScript is

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
 
             - name: Prepare Docker metadata
               id: docker-meta

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -49,7 +49,7 @@ jobs:
                 os: [ubuntu-latest, macos-latest, windows-latest]
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
@@ -87,7 +87,7 @@ jobs:
 
             - name: Upload Electron Test Results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report-electron-${{ matrix.os }}
                   path: |
@@ -103,7 +103,7 @@ jobs:
             NX_SKIP_NX_CACHE: true
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
@@ -131,7 +131,7 @@ jobs:
 
             - name: Upload Web Test Results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report-web-ubuntu
                   path: |

--- a/.github/workflows/publish-snap.yaml
+++ b/.github/workflows/publish-snap.yaml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout released tooling
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
               with:
                   ref: ${{ github.event.release.tag_name }}
                   persist-credentials: false
@@ -121,7 +121,7 @@ jobs:
                   printf 'receipt-sha256=%s\n' "${RECEIPT_SHA256}" >> "${GITHUB_OUTPUT}"
 
             - name: Transfer verified release assets
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
               with:
                   name: verified-snap-release-assets
                   path: /var/lib/iptvnator-snap-release/assets
@@ -139,7 +139,7 @@ jobs:
 
         steps:
             - name: Download verified release assets
-              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
               with:
                   name: verified-snap-release-assets
                   path: ${{ runner.temp }}/verified-snap-release-assets

--- a/tools/packaging/publish-snap-workflow.test.mjs
+++ b/tools/packaging/publish-snap-workflow.test.mjs
@@ -174,13 +174,13 @@ test('isolates released verification from the fresh credentialed upload runner',
     assert.deepEqual(
         verifyJob.steps.filter((step) => step.uses).map((step) => step.uses),
         [
-            'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5',
-            'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02',
+            'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1',
+            'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
         ]
     );
     assert.deepEqual(
         publishJob.steps.filter((step) => step.uses).map((step) => step.uses),
-        ['actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093']
+        ['actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c']
     );
 
     const bindingStep = verifyJob.steps.find(

--- a/tools/packaging/release-snap-assets.test.mjs
+++ b/tools/packaging/release-snap-assets.test.mjs
@@ -1563,7 +1563,7 @@ test('publish workflow installs the source verifier and binds the release tag re
     );
     assert.equal(
         checkoutStep.uses,
-        'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5'
+        'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
     );
     assert.equal(snapcraftStep.uses, undefined);
     assert.match(
@@ -1594,11 +1594,11 @@ test('publish workflow installs the source verifier and binds the release tag re
     );
     assert.equal(
         transferStep.uses,
-        'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02'
+        'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'
     );
     assert.equal(
         artifactDownloadStep.uses,
-        'actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093'
+        'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c'
     );
     assert.ok(
         publishJob.steps.indexOf(artifactDownloadStep) <

--- a/tools/packaging/snap-workflow-policy.test-helpers.mjs
+++ b/tools/packaging/snap-workflow-policy.test-helpers.mjs
@@ -2,11 +2,11 @@ import assert from 'node:assert/strict';
 import { parse } from 'yaml';
 
 const PINNED_CHECKOUT_ACTION =
-    'actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5';
+    'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1';
 const PINNED_UPLOAD_ARTIFACT_ACTION =
-    'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02';
+    'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a';
 const PINNED_DOWNLOAD_ARTIFACT_ACTION =
-    'actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093';
+    'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c';
 const PUBLISH_ACTION_ALLOWLIST = Object.freeze([
     PINNED_CHECKOUT_ACTION,
     PINNED_DOWNLOAD_ARTIFACT_ACTION,
@@ -16,10 +16,10 @@ const BUILD_ACTION_ALLOWLIST = Object.freeze([
     'actions/cache/restore@v4',
     'actions/cache/save@v4',
     'actions/cache@v4',
-    'actions/checkout@v4',
-    'actions/download-artifact@v4',
+    'actions/checkout@v7',
+    'actions/download-artifact@v8',
     'actions/setup-node@v4',
-    'actions/upload-artifact@v4',
+    'actions/upload-artifact@v7',
     'pnpm/action-setup@v4',
     'softprops/action-gh-release@v2',
 ]);


### PR DESCRIPTION
Replaces #1249, #1245 and #1247 with one commit, because all three rewrite the full-commit pins in `publish-snap.yaml` and the same SHAs are asserted in three packaging test files — merged separately, each one leaves the tests red (`# fail 4` on the Dependabot runs).

## What changed

- `actions/checkout` v4 → v7 (and v6 → v7 in `docker.yml`)
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- new pins in `publish-snap.yaml` plus the constants that assert them in `snap-workflow-policy.test-helpers.mjs`, `publish-snap-workflow.test.mjs`, `release-snap-assets.test.mjs`
- `BUILD_ACTION_ALLOWLIST` follows the unpinned bumps in `build-and-make.yaml`

## Pin verification

Each new SHA was resolved against the upstream tag refs before use:

| action | pin | tags |
| --- | --- | --- |
| checkout | `3d3c42e5…` | `v7`, `v7.0.1` |
| upload-artifact | `043fb46d…` | `v7`, `v7.0.1` |
| download-artifact | `3e5f45b2…` | `v8`, `v8.0.1` |

## Breaking changes reviewed

**download-artifact v8** changes two things that touch the Snap publish path, both in our favour:

- an artifact digest mismatch now **fails** the run (`digest-mismatch: error` by default) instead of logging a warning
- the action no longer unzips unconditionally — it checks `Content-Type` first. Our publish job downloads a regular `upload-artifact` artifact by name, so it is still a zip and decompression is unchanged. The job also re-verifies the receipt digest itself.

**download-artifact v5** changed path behaviour for downloads *by ID*; every call site here uses `name:` or no filter, so it is unaffected.

**checkout v7** blocks checking out fork PRs under `pull_request_target` / `workflow_run`. Neither trigger exists in this repo.

## Validation

`node --test` over the full packaging suite (the CI `tools/packaging` target): **247 passed, 0 failed** — the four `publish-snap-workflow` / `release-snap-assets` assertions that fail on the Dependabot branches are green here.

No release note: the diff touches only `.github/` and `tools/`, so the gate's `apps/`/`libs/` trigger does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)