### PR TITLE
fix(epg): await mapping queries so lookups fail soft

### DIFF
--- a/.changes/epg-mapping-lookup-fail-soft.md
+++ b/.changes/epg-mapping-lookup-fail-soft.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: epg
+---
+
+A database error while reading or saving a manual EPG channel mapping no longer
+surfaces as a failed request. Looking up, saving, deleting, and searching
+mappings now fall back quietly, so a transient storage hiccup can no longer take
+down the EPG panel or the "Map EPG channel" dialog.

--- a/apps/electron-backend/src/app/events/epg-mapping.events.spec.ts
+++ b/apps/electron-backend/src/app/events/epg-mapping.events.spec.ts
@@ -1,0 +1,174 @@
+import type EpgEventsType from './epg.events';
+
+const getDatabase = jest.fn();
+const getEpgMapping = jest.fn();
+const getEpgMappingsBatch = jest.fn();
+const setEpgMapping = jest.fn();
+const deleteEpgMapping = jest.fn();
+const searchEpgChannels = jest.fn();
+const ipcHandlers = new Map<
+    string,
+    (event: unknown, args: unknown) => Promise<unknown>
+>();
+
+jest.mock('electron', () => ({
+    app: {
+        isPackaged: false,
+        getAppPath: () => '/mock/app.asar',
+    },
+    BrowserWindow: {
+        getAllWindows: () => [],
+    },
+    ipcMain: {
+        handle: jest.fn(),
+    },
+}));
+
+jest.mock('../database/connection', () => ({
+    getDatabase: (...args: unknown[]) => getDatabase(...args),
+}));
+
+jest.mock('../database/operations/epg-mapping.operations', () => ({
+    getEpgMapping: (...args: unknown[]) => getEpgMapping(...args),
+    getEpgMappingsBatch: (...args: unknown[]) => getEpgMappingsBatch(...args),
+    setEpgMapping: (...args: unknown[]) => setEpgMapping(...args),
+    deleteEpgMapping: (...args: unknown[]) => deleteEpgMapping(...args),
+    searchEpgChannels: (...args: unknown[]) => searchEpgChannels(...args),
+}));
+
+/**
+ * The EPG mapping IPC handlers must fail soft: a mapping lookup is a side
+ * concern of an EPG request and must never take that request down. The
+ * handlers wrap the DB call in try/catch, but a bare `return promise` inside
+ * an async function is *adopted*, not awaited — so the catch block only ever
+ * saw a synchronous `getDatabase()` failure while a rejection from the query
+ * itself escaped to the IPC caller. These tests pin both failure modes.
+ */
+describe('EPG mapping IPC handlers', () => {
+    let EpgEvents: typeof EpgEventsType;
+
+    beforeEach(async () => {
+        jest.resetModules();
+        ipcHandlers.clear();
+        [
+            getDatabase,
+            getEpgMapping,
+            getEpgMappingsBatch,
+            setEpgMapping,
+            deleteEpgMapping,
+            searchEpgChannels,
+        ].forEach((mock) => mock.mockReset());
+
+        getDatabase.mockResolvedValue({});
+
+        ({ default: EpgEvents } = await import('./epg.events'));
+
+        const { ipcMain } = jest.requireMock('electron');
+        (ipcMain.handle as jest.Mock).mockReset();
+        (ipcMain.handle as jest.Mock).mockImplementation(
+            (
+                channel: string,
+                handler: (event: unknown, args: unknown) => Promise<unknown>
+            ) => {
+                ipcHandlers.set(channel, handler);
+            }
+        );
+
+        EpgEvents.bootstrapEpgEvents();
+    });
+
+    function invoke(channel: string, args: unknown): Promise<unknown> {
+        const handler = ipcHandlers.get(channel);
+        if (!handler) {
+            throw new Error(`No IPC handler registered for "${channel}"`);
+        }
+        return handler({}, args);
+    }
+
+    describe.each([
+        {
+            channel: 'EPG_MAPPING_GET',
+            args: { channelKey: 'bbc.one.uk' },
+            operation: () => getEpgMapping,
+            resolved: {
+                id: 1,
+                channelKey: 'bbc.one.uk',
+                epgChannelId: 'BBC.ONE.UK',
+                playlistId: null,
+            },
+            fallback: null,
+        },
+        {
+            channel: 'EPG_MAPPING_SET',
+            args: { channelKey: 'bbc.one.uk', epgChannelId: 'BBC.ONE.UK' },
+            operation: () => setEpgMapping,
+            resolved: { success: true },
+            fallback: { success: false },
+        },
+        {
+            channel: 'EPG_MAPPING_DELETE',
+            args: { channelKey: 'bbc.one.uk' },
+            operation: () => deleteEpgMapping,
+            resolved: { success: true },
+            fallback: { success: false },
+        },
+        {
+            channel: 'EPG_CHANNEL_SEARCH',
+            args: { searchTerm: 'bbc' },
+            operation: () => searchEpgChannels,
+            resolved: [
+                { id: 'BBC.ONE.UK', displayName: 'BBC One', iconUrl: null },
+            ],
+            fallback: [],
+        },
+        {
+            channel: 'EPG_MAPPING_GET_BATCH',
+            args: { channelKeys: ['bbc.one.uk'] },
+            operation: () => getEpgMappingsBatch,
+            resolved: new Map([['bbc.one.uk', 'BBC.ONE.UK']]),
+            fallback: {},
+        },
+    ])('$channel', ({ channel, args, operation, resolved, fallback }) => {
+        it('returns the fallback when the underlying query rejects', async () => {
+            operation().mockRejectedValue(new Error('database is locked'));
+
+            await expect(invoke(channel, args)).resolves.toEqual(fallback);
+        });
+
+        it('returns the fallback when opening the database rejects', async () => {
+            getDatabase.mockRejectedValue(new Error('no such file'));
+
+            await expect(invoke(channel, args)).resolves.toEqual(fallback);
+            expect(operation()).not.toHaveBeenCalled();
+        });
+
+        it('passes the resolved value through on success', async () => {
+            operation().mockResolvedValue(resolved);
+
+            const result = await invoke(channel, args);
+
+            expect(result).toEqual(
+                // The batch handler is the one that reshapes its result.
+                resolved instanceof Map
+                    ? Object.fromEntries(resolved)
+                    : resolved
+            );
+        });
+    });
+
+    it('short-circuits a blank search term without touching the database', async () => {
+        await expect(
+            invoke('EPG_CHANNEL_SEARCH', { searchTerm: '   ' })
+        ).resolves.toEqual([]);
+        expect(getDatabase).not.toHaveBeenCalled();
+        expect(searchEpgChannels).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits an empty batch without touching the database', async () => {
+        await expect(
+            invoke('EPG_MAPPING_GET_BATCH', { channelKeys: [] })
+        ).resolves.toEqual({});
+        expect(getDatabase).not.toHaveBeenCalled();
+        expect(getEpgMappingsBatch).not.toHaveBeenCalled();
+    });
+});

--- a/apps/electron-backend/src/app/events/epg-mapping.service.ts
+++ b/apps/electron-backend/src/app/events/epg-mapping.service.ts
@@ -67,7 +67,7 @@ export async function handleGetEpgMapping(
 ): Promise<EpgMappingRecord | null> {
     try {
         const db = await getDatabase();
-        return getEpgMapping(db, channelKey);
+        return await getEpgMapping(db, channelKey);
     } catch {
         return null;
     }
@@ -96,7 +96,7 @@ export async function handleSetEpgMapping(
 ): Promise<{ success: boolean }> {
     try {
         const db = await getDatabase();
-        return setEpgMapping(db, channelKey, epgChannelId, playlistId);
+        return await setEpgMapping(db, channelKey, epgChannelId, playlistId);
     } catch {
         return { success: false };
     }
@@ -107,7 +107,7 @@ export async function handleDeleteEpgMapping(
 ): Promise<{ success: boolean }> {
     try {
         const db = await getDatabase();
-        return deleteEpgMapping(db, channelKey);
+        return await deleteEpgMapping(db, channelKey);
     } catch {
         return { success: false };
     }
@@ -123,7 +123,7 @@ export async function handleSearchEpgChannels(
 
     try {
         const db = await getDatabase();
-        return searchEpgChannels(db, searchTerm, limit);
+        return await searchEpgChannels(db, searchTerm, limit);
     } catch {
         return [];
     }


### PR DESCRIPTION
## Problem

Four EPG mapping handlers in `apps/electron-backend/src/app/events/epg-mapping.service.ts` wrap their DB call in `try`/`catch` but `return` the promise instead of `await`ing it:

```ts
try {
    const db = await getDatabase();
    return getEpgMapping(db, channelKey);   // adopted, not awaited
} catch {
    return null;
}
```

An `async` function **adopts** a returned promise rather than awaiting it, so the `catch` only ever fired when `getDatabase()` itself threw. A rejection from the underlying query (`getEpgMapping` / `setEpgMapping` / `deleteEpgMapping` / `searchEpgChannels`) propagated straight to the IPC caller instead of returning the intended `null` / `{success: false}` / `[]` fallback.

`handleGetEpgMappingsBatch` and `resolveChannelIds` in the same module already `await`, so they fail soft for both cases. The fallback values and the module's own doc comment — *"Every method fails soft: a mapping lookup must never take down an EPG request"* — show fail-soft is the intended contract throughout. These four just missed it.

Pre-existing, not a regression: the behavior predates the max-lines split in #1278, which carried it over verbatim from `epg.events.ts`.

## Fix

Added the missing `await` to `handleGetEpgMapping`, `handleSetEpgMapping`, `handleDeleteEpgMapping` and `handleSearchEpgChannels`. Four lines.

## Tests

New `apps/electron-backend/src/app/events/epg-mapping.events.spec.ts` (174 lines) drives the **real IPC handlers** captured from a mocked `ipcMain.handle`, so it asserts the contract that actually matters: the caller receives a fallback, not a rejected promise. It covers the `epg.events.ts` → `epg-mapping.service.ts` delegation as well as the handlers themselves.

17 tests — for each of the 5 mapping channels: a rejecting operation, a rejecting `getDatabase()`, and a success passthrough, plus the two short-circuit paths (blank search term, empty batch).

Verified the coverage binds to this bug: reverting the four `await`s produces **exactly 4 failures**, one per fixed handler, while `EPG_MAPPING_GET_BATCH` (which already awaited) stays green.

## Validation

| Command | Result |
| --- | --- |
| `pnpm nx test electron-backend` | 95 suites, 1027 passed |
| `pnpm nx lint electron-backend` | pass |
| `npx eslint` on all three changed files | clean |
| `pnpm run release:notes:validate` | valid |

## Note for the reviewer

Rebased onto `master` after #1278 landed; the fix moved from `epg.events.ts` into the newly extracted `epg-mapping.service.ts`, where the bug had been carried over unchanged.

One unrelated pre-existing issue surfaced while verifying, tracked separately and **not** addressed here: the `lint` target in `apps/electron-backend/project.json` uses an unquoted `apps/electron-backend/**/*.ts`. Nx shells out to `/bin/sh`, where `**` is not recursive, so it expands to just `src/main.ts` — the target lints 1 file of 222 and reports success. The two *quoted* globs in the same command work fine, since eslint then does its own globbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
