### PR TITLE
fix(epg): make manual EPG mapping lookups actually fail soft

### DIFF
--- a/.changes/epg-mapping-fail-soft.md
+++ b/.changes/epg-mapping-fail-soft.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: epg
+---
+
+A database error while looking up manual EPG channel mappings no longer breaks
+the request that triggered it. Searching for a channel in the "Map EPG channel"
+dialog, or saving and removing a mapping, now degrades gracefully instead of
+failing outright.

--- a/apps/electron-backend/src/app/events/epg-mapping.service.spec.ts
+++ b/apps/electron-backend/src/app/events/epg-mapping.service.spec.ts
@@ -1,0 +1,246 @@
+const getDatabase = jest.fn();
+const getEpgMapping = jest.fn();
+const getEpgMappingsBatch = jest.fn();
+const setEpgMapping = jest.fn();
+const deleteEpgMapping = jest.fn();
+const searchEpgChannels = jest.fn();
+
+jest.mock('../database/connection', () => ({
+    getDatabase: (...args: unknown[]) => getDatabase(...args),
+}));
+
+jest.mock('../database/operations/epg-mapping.operations', () => ({
+    getEpgMapping: (...args: unknown[]) => getEpgMapping(...args),
+    getEpgMappingsBatch: (...args: unknown[]) => getEpgMappingsBatch(...args),
+    setEpgMapping: (...args: unknown[]) => setEpgMapping(...args),
+    deleteEpgMapping: (...args: unknown[]) => deleteEpgMapping(...args),
+    searchEpgChannels: (...args: unknown[]) => searchEpgChannels(...args),
+}));
+
+import {
+    handleDeleteEpgMapping,
+    handleGetEpgMapping,
+    handleGetEpgMappingsBatch,
+    handleSearchEpgChannels,
+    handleSetEpgMapping,
+    queryByResolvedChannelIds,
+    resolveChannelIds,
+} from './epg-mapping.service';
+
+const DB_HANDLE = { db: true };
+const DB_ERROR = new Error('getDatabase failed');
+const OP_ERROR = new Error('sqlite operation failed');
+
+describe('epg-mapping.service', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        getDatabase.mockResolvedValue(DB_HANDLE);
+    });
+
+    /**
+     * The fail-soft contract: a mapping lookup must never take down an EPG IPC
+     * request. Each entry is checked against BOTH failure modes — a rejecting
+     * `getDatabase()` and a rejecting database operation.
+     */
+    const failSoftCases: Array<{
+        name: string;
+        operation: jest.Mock;
+        invoke: () => Promise<unknown>;
+        fallback: unknown;
+    }> = [
+        {
+            name: 'resolveChannelIds',
+            operation: getEpgMappingsBatch,
+            invoke: () => resolveChannelIds(['channel-a']),
+            fallback: new Map(),
+        },
+        {
+            name: 'handleGetEpgMapping',
+            operation: getEpgMapping,
+            invoke: () => handleGetEpgMapping('channel-a'),
+            fallback: null,
+        },
+        {
+            name: 'handleGetEpgMappingsBatch',
+            operation: getEpgMappingsBatch,
+            invoke: () => handleGetEpgMappingsBatch(['channel-a']),
+            fallback: {},
+        },
+        {
+            name: 'handleSetEpgMapping',
+            operation: setEpgMapping,
+            invoke: () => handleSetEpgMapping('channel-a', 'epg-a'),
+            fallback: { success: false },
+        },
+        {
+            name: 'handleDeleteEpgMapping',
+            operation: deleteEpgMapping,
+            invoke: () => handleDeleteEpgMapping('channel-a'),
+            fallback: { success: false },
+        },
+        {
+            name: 'handleSearchEpgChannels',
+            operation: searchEpgChannels,
+            invoke: () => handleSearchEpgChannels('bbc'),
+            fallback: [],
+        },
+    ];
+
+    for (const { name, operation, invoke, fallback } of failSoftCases) {
+        describe(`${name} fail-soft`, () => {
+            it('returns the fallback when getDatabase() rejects', async () => {
+                getDatabase.mockRejectedValue(DB_ERROR);
+
+                await expect(invoke()).resolves.toEqual(fallback);
+                expect(operation).not.toHaveBeenCalled();
+            });
+
+            it('returns the fallback when the database operation rejects', async () => {
+                operation.mockRejectedValue(OP_ERROR);
+
+                await expect(invoke()).resolves.toEqual(fallback);
+                expect(operation).toHaveBeenCalled();
+            });
+        });
+    }
+
+    describe('resolveChannelIds', () => {
+        it('returns the mapping batch keyed by original channel id', async () => {
+            const mappings = new Map([['channel-a', 'epg-a']]);
+            getEpgMappingsBatch.mockResolvedValue(mappings);
+
+            await expect(resolveChannelIds(['channel-a'])).resolves.toEqual(
+                mappings
+            );
+            expect(getEpgMappingsBatch).toHaveBeenCalledWith(DB_HANDLE, [
+                'channel-a',
+            ]);
+        });
+    });
+
+    describe('queryByResolvedChannelIds', () => {
+        it('queries mapped ids and remaps results onto the requested ids', async () => {
+            getEpgMappingsBatch.mockResolvedValue(
+                new Map([['channel-a', 'epg-a']])
+            );
+            const query = jest
+                .fn()
+                .mockResolvedValue({ 'epg-a': 'A', 'channel-b': 'B' });
+
+            const result = await queryByResolvedChannelIds(
+                ['channel-a', 'channel-b'],
+                query
+            );
+
+            expect(query).toHaveBeenCalledWith(['epg-a', 'channel-b']);
+            expect(result).toEqual({ 'channel-a': 'A', 'channel-b': 'B' });
+        });
+
+        it('fills missing query results with null', async () => {
+            getEpgMappingsBatch.mockResolvedValue(new Map());
+            const query = jest.fn().mockResolvedValue({});
+
+            await expect(
+                queryByResolvedChannelIds(['channel-a'], query)
+            ).resolves.toEqual({ 'channel-a': null });
+        });
+
+        it('falls back to unmapped ids when the mapping lookup fails', async () => {
+            getEpgMappingsBatch.mockRejectedValue(OP_ERROR);
+            const query = jest.fn().mockResolvedValue({ 'channel-a': 'A' });
+
+            const result = await queryByResolvedChannelIds(
+                ['channel-a'],
+                query
+            );
+
+            expect(query).toHaveBeenCalledWith(['channel-a']);
+            expect(result).toEqual({ 'channel-a': 'A' });
+        });
+    });
+
+    describe('handleGetEpgMappingsBatch', () => {
+        it('converts the mapping batch into a plain record', async () => {
+            getEpgMappingsBatch.mockResolvedValue(
+                new Map([['channel-a', 'epg-a']])
+            );
+
+            await expect(
+                handleGetEpgMappingsBatch(['channel-a'])
+            ).resolves.toEqual({ 'channel-a': 'epg-a' });
+        });
+
+        it.each([
+            ['an empty array', [] as string[]],
+            ['a non-array value', undefined as unknown as string[]],
+        ])(
+            'short-circuits for %s without touching the database',
+            async (_label, channelKeys) => {
+                await expect(
+                    handleGetEpgMappingsBatch(channelKeys)
+                ).resolves.toEqual({});
+                expect(getDatabase).not.toHaveBeenCalled();
+            }
+        );
+    });
+
+    describe('handleSearchEpgChannels', () => {
+        it('forwards the search term and limit to the database', async () => {
+            const matches = [
+                { id: 'epg-a', displayName: 'BBC One', iconUrl: null },
+            ];
+            searchEpgChannels.mockResolvedValue(matches);
+
+            await expect(handleSearchEpgChannels('bbc', 25)).resolves.toEqual(
+                matches
+            );
+            expect(searchEpgChannels).toHaveBeenCalledWith(
+                DB_HANDLE,
+                'bbc',
+                25
+            );
+        });
+
+        it.each([
+            ['an empty term', ''],
+            ['a whitespace-only term', '   '],
+            ['an undefined term', undefined as unknown as string],
+        ])(
+            'short-circuits for %s without touching the database',
+            async (_label, searchTerm) => {
+                await expect(
+                    handleSearchEpgChannels(searchTerm)
+                ).resolves.toEqual([]);
+                expect(getDatabase).not.toHaveBeenCalled();
+            }
+        );
+    });
+
+    describe('mapping writes', () => {
+        it('passes the optional playlist id through to setEpgMapping', async () => {
+            setEpgMapping.mockResolvedValue({ success: true });
+
+            await expect(
+                handleSetEpgMapping('channel-a', 'epg-a', 'playlist-1')
+            ).resolves.toEqual({ success: true });
+            expect(setEpgMapping).toHaveBeenCalledWith(
+                DB_HANDLE,
+                'channel-a',
+                'epg-a',
+                'playlist-1'
+            );
+        });
+
+        it('deletes a mapping by channel key', async () => {
+            deleteEpgMapping.mockResolvedValue({ success: true });
+
+            await expect(handleDeleteEpgMapping('channel-a')).resolves.toEqual({
+                success: true,
+            });
+            expect(deleteEpgMapping).toHaveBeenCalledWith(
+                DB_HANDLE,
+                'channel-a'
+            );
+        });
+    });
+});

--- a/apps/electron-backend/src/app/events/epg-mapping.service.ts
+++ b/apps/electron-backend/src/app/events/epg-mapping.service.ts
@@ -67,7 +67,7 @@ export async function handleGetEpgMapping(
 ): Promise<EpgMappingRecord | null> {
     try {
         const db = await getDatabase();
-        return getEpgMapping(db, channelKey);
+        return await getEpgMapping(db, channelKey);
     } catch {
         return null;
     }
@@ -96,7 +96,7 @@ export async function handleSetEpgMapping(
 ): Promise<{ success: boolean }> {
     try {
         const db = await getDatabase();
-        return setEpgMapping(db, channelKey, epgChannelId, playlistId);
+        return await setEpgMapping(db, channelKey, epgChannelId, playlistId);
     } catch {
         return { success: false };
     }
@@ -107,7 +107,7 @@ export async function handleDeleteEpgMapping(
 ): Promise<{ success: boolean }> {
     try {
         const db = await getDatabase();
-        return deleteEpgMapping(db, channelKey);
+        return await deleteEpgMapping(db, channelKey);
     } catch {
         return { success: false };
     }
@@ -123,7 +123,7 @@ export async function handleSearchEpgChannels(
 
     try {
         const db = await getDatabase();
-        return searchEpgChannels(db, searchTerm, limit);
+        return await searchEpgChannels(db, searchTerm, limit);
     } catch {
         return [];
     }


### PR DESCRIPTION
## What

Four EPG mapping handlers documented a fail-soft contract but only honored half of it. They returned the database operation's promise from inside the `try` block **without awaiting it**, so the rejection escaped the `catch` — the try block exits before the promise settles:

```ts
try {
    const db = await getDatabase();
    return getEpgMapping(db, channelKey);  // rejection escapes the catch
} catch {
    return null;
}
```

A `getDatabase()` failure *was* caught, but a SQLite error inside the operation rejected the `ipcMain.handle` promise, so the renderer call threw instead of receiving `null` / `{success:false}` / `[]`.

User-visible effect: a database error while searching in the **"Map EPG channel"** dialog, or while saving/removing a mapping, failed the request outright instead of degrading to an empty result.

Adding `await` in `handleGetEpgMapping`, `handleSetEpgMapping`, `handleDeleteEpgMapping` and `handleSearchEpgChannels` closes it. `resolveChannelIds` and `handleGetEpgMappingsBatch` already awaited correctly and are unchanged.

## Not a regression

The identical shape predates the `epg.events.ts` split in 636545cb (#1278) — that refactor preserved semantics faithfully and inherited the bug. Confirmed via `git show 636545cb^`.

## Tests

`epg-mapping.service.spec.ts` is new — these handlers had **no coverage at all** before this PR. Table-driven across all six functions × both failure modes (rejecting `getDatabase()` **and** rejecting operation), plus the guard clauses, the `Map`→record conversion, and `queryByResolvedChannelIds` remapping / identity fallback.

Verified the spec actually fails on the old behavior rather than assuming it would: reverting the four `await`s fails **exactly** the four operation-rejection cases (4 failed, 21 passed), then restored.

| Check | Result |
|---|---|
| `pnpm nx test electron-backend` | 95 suites, 1035 tests passed |
| New spec | 25 passed |
| Regression proof (fix reverted) | 4 failed — exactly the expected cases |
| `npx eslint` on changed files | 0 errors, 0 warnings |
| `npx prettier --check` | clean |
| `pnpm run release:notes:validate` | 33 notes valid |

## Docs

No update needed — CLAUDE.md's `epg.events.ts` entry already names `epg-mapping.service.ts` as the home for manual channel-mapping resolution and CRUD, and that is still accurate. Release note added at `.changes/epg-mapping-fail-soft.md` (`type: fix`, area `epg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)