### PR TITLE
test(performance): deflake the real-timer event-loop delay spec

### DIFF
--- a/apps/electron-backend/src/app/workers/worker-performance-capture.concurrency.spec.ts
+++ b/apps/electron-backend/src/app/workers/worker-performance-capture.concurrency.spec.ts
@@ -1,35 +1,47 @@
 import {
     WORKER_PERFORMANCE_INVALID_REASON,
-    WORKER_PERFORMANCE_UNAVAILABLE_REASON,
     armWorkerPerformanceCapture,
     executeWithWorkerPerformanceCapture,
     registerDatabaseWorkerPerformanceCapture,
     releaseDatabaseWorkerPerformanceCapture,
     startWorkerPerformanceCapture,
     type WorkerPerformanceCapture,
-    type WorkerPerformanceCaptureResult,
+    type WorkerPerformanceCaptureRuntime,
 } from './worker-performance-capture';
+import { DEFAULT_WORKER_PERFORMANCE_RUNTIME } from './worker-performance-capture.runtime';
 import { createFakeRuntime } from './worker-performance-capture.test-harness';
 
 const PROFILING_ENV = 'IPTVNATOR_PERF_WORKER_PROFILING';
+
+const BLOCK_DURATION_MS = 20;
+const REAL_TIMER_TEST_TIMEOUT_MS = 30_000;
 
 /**
  * `monitorEventLoopDelay()` records nothing on its first internal timer tick —
  * that tick only seeds the previous timestamp, so the first delay sample lands
  * on the second tick. Condition-based arming therefore needs two event-loop
- * turns inside its fixed 50ms budget. A machine running the full Jest suite in
- * parallel can stretch a single turn past 25ms, which makes a lost arming race
- * an environmental outcome rather than a defect. Retry within a wall-clock
- * budget so the real measurement is asserted whenever the machine allows it.
+ * turns, and it budgets for them with a 50ms deadline read from
+ * `readMonotonicMs()`. A machine running the full Jest suite in parallel can
+ * stretch a single turn past 20ms, so that deadline expires against the
+ * scheduler rather than against any defect in the capture code.
+ *
+ * Slowing only that deadline clock leaves the wait bounded by its other limit,
+ * the 50-poll ceiling, which is ~25x the two turns arming actually needs.
+ * Everything else stays production code: the real `monitorEventLoopDelay()`
+ * histogram, real `setTimeout()` polling, and real epoch/CPU/ELU boundaries.
+ * The scaled clock reaches nothing but the wait budgets — its only other
+ * consumer records phase events, and this spec records none.
  */
-const REAL_TIMER_ARMING_BUDGET_MS = 5_000;
-const REAL_TIMER_TEST_TIMEOUT_MS = 30_000;
-const BLOCK_DURATION_MS = 20;
+const WAIT_DEADLINE_CLOCK_SCALE = 50;
 
-const DOCUMENTED_DELAY_TIMEOUTS = [
-    WORKER_PERFORMANCE_UNAVAILABLE_REASON.EVENT_LOOP_DELAY_ARM_TIMEOUT,
-    WORKER_PERFORMANCE_UNAVAILABLE_REASON.EVENT_LOOP_DELAY_FLUSH_TIMEOUT,
-];
+function createRuntimeWithScaledWaitDeadline(): WorkerPerformanceCaptureRuntime {
+    return {
+        ...DEFAULT_WORKER_PERFORMANCE_RUNTIME,
+        readMonotonicMs: () =>
+            DEFAULT_WORKER_PERFORMANCE_RUNTIME.readMonotonicMs() /
+            WAIT_DEADLINE_CLOCK_SCALE,
+    };
+}
 
 describe('worker performance capture concurrency and real timers', () => {
     const originalProfilingValue = process.env[PROFILING_ENV];
@@ -91,69 +103,42 @@ describe('worker performance capture concurrency and real timers', () => {
     });
 
     it(
-        'observes a real 20ms event-loop block once condition-based arming wins its budget',
+        'measures a real 20ms event-loop block through condition-based arming',
         async () => {
             process.env[PROFILING_ENV] = '1';
 
-            const startedAt = performance.now();
-            let attempts = 0;
-            let measured: WorkerPerformanceCaptureResult | undefined;
+            // No `enabled` override: the env variable is the opt-in under test.
+            const capture = startWorkerPerformanceCapture({
+                runtime: createRuntimeWithScaledWaitDeadline(),
+            });
 
-            while (
-                performance.now() - startedAt <
-                REAL_TIMER_ARMING_BUDGET_MS
-            ) {
-                attempts += 1;
-                const capture = startWorkerPerformanceCapture();
-                await armWorkerPerformanceCapture(capture);
-                const execution = await executeWithWorkerPerformanceCapture(
-                    capture,
-                    async () => {
-                        const blockStartedAt = performance.now();
-                        while (
-                            performance.now() - blockStartedAt <
-                            BLOCK_DURATION_MS
-                        ) {
-                            // This deliberate block is the behavior under measurement.
-                        }
+            expect(capture).not.toBeNull();
+
+            await armWorkerPerformanceCapture(capture);
+            const execution = await executeWithWorkerPerformanceCapture(
+                capture,
+                async () => {
+                    const blockStartedAt = performance.now();
+                    while (
+                        performance.now() - blockStartedAt <
+                        BLOCK_DURATION_MS
+                    ) {
+                        // This deliberate block is the behavior under measurement.
                     }
-                );
-
-                // Whether or not arming won its race, instrumentation must never
-                // break the work it wraps.
-                expect(execution.success).toBe(true);
-                expect(execution.performance?.invalidReason).toBeNull();
-
-                if (execution.performance?.eventLoopDelay) {
-                    measured = execution.performance;
-                    break;
                 }
+            );
 
-                // A lost race is only ever a documented timeout, never a silent null.
-                expect(DOCUMENTED_DELAY_TIMEOUTS).toContain(
-                    execution.performance?.eventLoopDelayUnavailableReason
-                );
-                expect(
-                    execution.performance?.histogramFlushedEpochMs
-                ).toBeNull();
-
-                // Let the loop breathe before contending for two more turns.
-                await new Promise<void>((resolve) => setTimeout(resolve, 0));
-            }
-
-            if (measured === undefined) {
-                console.warn(
-                    `Event-loop delay arming lost every one of ${attempts} races within ` +
-                        `${REAL_TIMER_ARMING_BUDGET_MS}ms; this machine never granted two ` +
-                        'event-loop turns inside the 50ms arming budget. The documented ' +
-                        'timeout contract was asserted on every attempt instead.'
-                );
-                return;
-            }
-
-            expect(measured.eventLoopDelayUnavailableReason).toBeNull();
-            expect(measured.histogramFlushedEpochMs).not.toBeNull();
-            expect(measured.eventLoopDelay?.maxMs).toBeGreaterThan(10);
+            expect(execution.success).toBe(true);
+            expect(execution.performance?.invalidReason).toBeNull();
+            expect(
+                execution.performance?.eventLoopDelayUnavailableReason
+            ).toBeNull();
+            expect(
+                execution.performance?.histogramFlushedEpochMs
+            ).not.toBeNull();
+            expect(
+                execution.performance?.eventLoopDelay?.maxMs
+            ).toBeGreaterThan(10);
         },
         REAL_TIMER_TEST_TIMEOUT_MS
     );

--- a/apps/electron-backend/src/app/workers/worker-performance-capture.concurrency.spec.ts
+++ b/apps/electron-backend/src/app/workers/worker-performance-capture.concurrency.spec.ts
@@ -1,15 +1,35 @@
 import {
     WORKER_PERFORMANCE_INVALID_REASON,
+    WORKER_PERFORMANCE_UNAVAILABLE_REASON,
     armWorkerPerformanceCapture,
     executeWithWorkerPerformanceCapture,
     registerDatabaseWorkerPerformanceCapture,
     releaseDatabaseWorkerPerformanceCapture,
     startWorkerPerformanceCapture,
     type WorkerPerformanceCapture,
+    type WorkerPerformanceCaptureResult,
 } from './worker-performance-capture';
 import { createFakeRuntime } from './worker-performance-capture.test-harness';
 
 const PROFILING_ENV = 'IPTVNATOR_PERF_WORKER_PROFILING';
+
+/**
+ * `monitorEventLoopDelay()` records nothing on its first internal timer tick —
+ * that tick only seeds the previous timestamp, so the first delay sample lands
+ * on the second tick. Condition-based arming therefore needs two event-loop
+ * turns inside its fixed 50ms budget. A machine running the full Jest suite in
+ * parallel can stretch a single turn past 25ms, which makes a lost arming race
+ * an environmental outcome rather than a defect. Retry within a wall-clock
+ * budget so the real measurement is asserted whenever the machine allows it.
+ */
+const REAL_TIMER_ARMING_BUDGET_MS = 5_000;
+const REAL_TIMER_TEST_TIMEOUT_MS = 30_000;
+const BLOCK_DURATION_MS = 20;
+
+const DOCUMENTED_DELAY_TIMEOUTS = [
+    WORKER_PERFORMANCE_UNAVAILABLE_REASON.EVENT_LOOP_DELAY_ARM_TIMEOUT,
+    WORKER_PERFORMANCE_UNAVAILABLE_REASON.EVENT_LOOP_DELAY_FLUSH_TIMEOUT,
+];
 
 describe('worker performance capture concurrency and real timers', () => {
     const originalProfilingValue = process.env[PROFILING_ENV];
@@ -70,26 +90,71 @@ describe('worker performance capture concurrency and real timers', () => {
         expect(activeCaptures.size).toBe(0);
     });
 
-    it('reliably observes a real 20ms event-loop block after condition-based arming', async () => {
-        process.env[PROFILING_ENV] = '1';
+    it(
+        'observes a real 20ms event-loop block once condition-based arming wins its budget',
+        async () => {
+            process.env[PROFILING_ENV] = '1';
 
-        const capture = startWorkerPerformanceCapture();
-        await armWorkerPerformanceCapture(capture);
-        const execution = await executeWithWorkerPerformanceCapture(
-            capture,
-            async () => {
-                const blockStartedAt = performance.now();
-                while (performance.now() - blockStartedAt < 20) {
-                    // This deliberate block is the behavior under measurement.
+            const startedAt = performance.now();
+            let attempts = 0;
+            let measured: WorkerPerformanceCaptureResult | undefined;
+
+            while (
+                performance.now() - startedAt <
+                REAL_TIMER_ARMING_BUDGET_MS
+            ) {
+                attempts += 1;
+                const capture = startWorkerPerformanceCapture();
+                await armWorkerPerformanceCapture(capture);
+                const execution = await executeWithWorkerPerformanceCapture(
+                    capture,
+                    async () => {
+                        const blockStartedAt = performance.now();
+                        while (
+                            performance.now() - blockStartedAt <
+                            BLOCK_DURATION_MS
+                        ) {
+                            // This deliberate block is the behavior under measurement.
+                        }
+                    }
+                );
+
+                // Whether or not arming won its race, instrumentation must never
+                // break the work it wraps.
+                expect(execution.success).toBe(true);
+                expect(execution.performance?.invalidReason).toBeNull();
+
+                if (execution.performance?.eventLoopDelay) {
+                    measured = execution.performance;
+                    break;
                 }
-            }
-        );
 
-        expect(execution.success).toBe(true);
-        expect(execution.performance?.eventLoopDelay).not.toBeNull();
-        expect(execution.performance?.eventLoopDelay?.maxMs).toBeGreaterThan(
-            10
-        );
-        expect(execution.performance?.histogramFlushedEpochMs).not.toBeNull();
-    });
+                // A lost race is only ever a documented timeout, never a silent null.
+                expect(DOCUMENTED_DELAY_TIMEOUTS).toContain(
+                    execution.performance?.eventLoopDelayUnavailableReason
+                );
+                expect(
+                    execution.performance?.histogramFlushedEpochMs
+                ).toBeNull();
+
+                // Let the loop breathe before contending for two more turns.
+                await new Promise<void>((resolve) => setTimeout(resolve, 0));
+            }
+
+            if (measured === undefined) {
+                console.warn(
+                    `Event-loop delay arming lost every one of ${attempts} races within ` +
+                        `${REAL_TIMER_ARMING_BUDGET_MS}ms; this machine never granted two ` +
+                        'event-loop turns inside the 50ms arming budget. The documented ' +
+                        'timeout contract was asserted on every attempt instead.'
+                );
+                return;
+            }
+
+            expect(measured.eventLoopDelayUnavailableReason).toBeNull();
+            expect(measured.histogramFlushedEpochMs).not.toBeNull();
+            expect(measured.eventLoopDelay?.maxMs).toBeGreaterThan(10);
+        },
+        REAL_TIMER_TEST_TIMEOUT_MS
+    );
 });


### PR DESCRIPTION
## The flake

`worker-performance-capture.concurrency.spec.ts` → *"reliably observes a real 20ms event-loop block after condition-based arming"* failed on **4/4** full-suite runs (`pnpm nx test electron-backend --skip-nx-cache`) on a clean master at 24f0dee6, while passing when the file ran alone. Introduced in da3b6572.

```
expect(execution.performance?.eventLoopDelay).not.toBeNull();
Received: null
```

## Root cause

The null was never silent — it was a documented `event-loop-delay-arm-timeout`. Instrumenting the failing run confirmed it:

```
DIAG {"delay":null,"delayReason":"event-loop-delay-arm-timeout","flushed":null,"invalid":null}
```

The reason is a property of `monitorEventLoopDelay()`: its **first internal timer tick records nothing** — it only seeds the previous timestamp, so the first delay sample lands on the *second* tick. Verified directly on Node v22.14.0:

```
turn 1 at 1.26ms count=0
turn 2 at 4.10ms count=1
```

`armWorkerPerformanceCapture()` waits for `histogram.count > 0` under two limits in `waitForHistogramCondition()`: a 50ms deadline read from `readMonotonicMs()`, and a 50-poll ceiling. Arming structurally needs two event-loop turns, and under full-suite parallelism (10 Jest workers on 10 cores) a single turn stretches well past 25ms — an instrumented run caught the first turn landing at **20.6ms**. So the *deadline* expired against the scheduler, arming was marked unavailable, the histogram was disabled, and `readWorkerEventLoopDelay()` returned null.

**Production code is behaving correctly here** — this is exactly the graceful-degradation path the reason enum exists for. The spec asserted the happy path of that wall-clock race, so a loaded machine turned an environmental outcome into a red build.

## The fix

Test-only; no production code touched.

The deadline is read through the injectable `readMonotonicMs()`, so the spec supplies the production runtime with only that one clock scaled:

```ts
return {
    ...DEFAULT_WORKER_PERFORMANCE_RUNTIME,
    readMonotonicMs: () =>
        DEFAULT_WORKER_PERFORMANCE_RUNTIME.readMonotonicMs() /
        WAIT_DEADLINE_CLOCK_SCALE,
};
```

That leaves the wait bounded by its *other* limit — the 50-poll ceiling — which is ~25x the two event-loop turns arming actually needs, so the race against the scheduler is gone rather than merely made unlikely. Everything else stays production code: the real `monitorEventLoopDelay()` histogram, real `setTimeout()` polling, and real epoch/CPU/ELU boundaries. The scaled clock reaches nothing but the wait budgets — its only other consumer records phase events, and this spec records none. The env-var opt-in stays under test (no `enabled` override).

The 50ms deadline itself remains covered deterministically by the fake-runtime specs (`times out arming after a monotonic 50ms...`, `times out flushing after a monotonic 50ms...`), so nothing is lost by not racing it here.

## Validation

Mutation-tested, since a test like this is only worth what it fails on:

| Mutation | Result |
|---|---|
| Force arming to never arm | **fails** |
| Drop the deliberate 20ms block | **fails** at `maxMs 3.825663` vs the 10ms floor |

| Check | Result |
|---|---|
| Full suite, baseline master | **failed** (`arm-timeout`, reproduced) |
| Full suite × 5, after fix | 1045 passed |
| Full suite × 2 at load average 34.5 on 10 cores (3.4x oversubscribed) | 1045 passed |
| `nx lint electron-backend` + prettier | clean |

## Review history

The first iteration used a bounded retry loop that tolerated budget exhaustion with a warning. [Codex correctly flagged](https://github.com/4gray/iptvnator/pull/1293#discussion_r3659790053) that this made the test pass even if arming or flushing regressed on every attempt, removing the only assertion backed by the real histogram. Rather than picking between its two suggestions (fail, or skip), 50fdb559 removed the condition that made exhaustion possible at all — the retry loop, the warning, and the early `return` are gone, and the test now asserts a real measurement unconditionally.

## Notes

- **No release note**: test-only change, and `.spec.ts` is auto-exempt in `tools/release/check-release-note-gate.mjs:31`. No `no-release-note` label needed.
- **No docs update**: isolated test-only change with no behavior change, per the CLAUDE.md policy.
- **Not done (deliberate scope call)**: the 50ms arming deadline is arguably tight for a loaded machine, so real DB-worker requests on a busy system will occasionally ship without an event-loop-delay metric. That is a graceful, well-labelled degradation rather than a bug — but if those metrics ever look sparser than expected in practice, `HISTOGRAM_WAIT_CAP_MS` is where to look. Sibling specs assert the 50ms value by name, so changing it should be a deliberate decision, not a tweak bundled into a flake fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)