### PR TITLE
fix(electron-backend): lint the whole project, not one file

### DIFF
--- a/.changes/electron-backend-lint-coverage.md
+++ b/.changes/electron-backend-lint-coverage.md
@@ -1,0 +1,9 @@
+---
+type: internal
+area: electron-backend
+---
+
+Lint now covers the whole Electron backend instead of a single file, and two
+teardown paths that silently discarded their failure reason — closing an
+external player session and disposing an embedded mpv session — now report it.
+Both still finish the teardown exactly as before.

--- a/apps/electron-backend/project.json
+++ b/apps/electron-backend/project.json
@@ -241,7 +241,7 @@
                 "{workspaceRoot}/tools/embedded-mpv/runtime-probe-contract.cjs",
                 "{workspaceRoot}/tools/embedded-mpv/runtime-probe-contract.d.cts"
             ],
-            "command": "eslint apps/electron-backend/**/*.ts \"apps/electron-backend/src/app/services/embedded-mpv-frame-copy-runtime.ts\" \"apps/electron-backend/src/app/services/embedded-mpv-frame-copy-runtime/**/*.ts\""
+            "command": "eslint \"apps/electron-backend/**/*.ts\""
         },
         "test": {
             "executor": "@nx/jest:jest",

--- a/apps/electron-backend/src/app/events/epg-worker.service.ts
+++ b/apps/electron-backend/src/app/events/epg-worker.service.ts
@@ -422,7 +422,6 @@ export class EpgWorkerService {
             }
 
             let settled = false;
-            let timeoutId: ReturnType<typeof setTimeout>;
             const settle = (fn: () => void) => {
                 if (settled) return;
                 settled = true;
@@ -430,7 +429,7 @@ export class EpgWorkerService {
                 fn();
             };
 
-            timeoutId = setTimeout(() => {
+            const timeoutId = setTimeout(() => {
                 const errorMessage = `${options.timeoutLabel} timed out after ${
                     this.fetchTimeoutMs / 1000
                 }s`;

--- a/apps/electron-backend/src/app/events/external-player-session-registry.spec.ts
+++ b/apps/electron-backend/src/app/events/external-player-session-registry.spec.ts
@@ -47,6 +47,32 @@ describe('ExternalPlayerSessionRegistry', () => {
         expect(registry.getActiveSessionId()).toBeNull();
     });
 
+    it('still closes the session when the player fails to close', async () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation();
+        const failure = new Error('player already exited');
+        const close = jest.fn().mockRejectedValue(failure);
+        const session = registry.beginSession({
+            player: 'mpv',
+            title: 'Example',
+            streamUrl: 'https://example.com/video.m3u8',
+        });
+
+        registry.attachCloser(session.id, close);
+
+        const closed = await registry.closeSession(session.id);
+
+        expect(closed?.status).toBe('closed');
+        expect(closed?.canClose).toBe(false);
+        expect(registry.getActiveSessionId()).toBeNull();
+        // The reason must survive: the old `return` inside `finally` dropped it.
+        expect(warn).toHaveBeenCalledWith(
+            `Failed to close external player session ${session.id}:`,
+            failure
+        );
+
+        warn.mockRestore();
+    });
+
     it('marks runtime failures as errors without clearing the active id', () => {
         const session = registry.beginSession({
             player: 'mpv',

--- a/apps/electron-backend/src/app/events/external-player-session-registry.ts
+++ b/apps/electron-backend/src/app/events/external-player-session-registry.ts
@@ -128,10 +128,18 @@ export class ExternalPlayerSessionRegistry {
             return null;
         }
 
+        // The session must end up closed even if the player is already gone,
+        // but a `return` inside `finally` would also swallow the reason — so
+        // catch it explicitly and surface it.
         try {
             await runtime.close?.();
-        } finally {
-            return this.markClosed(id);
+        } catch (error) {
+            console.warn(
+                `Failed to close external player session ${id}:`,
+                error
+            );
         }
+
+        return this.markClosed(id);
     }
 }

--- a/apps/electron-backend/src/app/services/embedded-mpv-native.service.spec.ts
+++ b/apps/electron-backend/src/app/services/embedded-mpv-native.service.spec.ts
@@ -493,7 +493,11 @@ describe('EmbeddedMpvNativeService power blocker', () => {
             addon.createSession.mockReturnValueOnce('s-zoom');
             addon.getSessionSnapshot.mockReturnValue(snapshot('loading'));
 
-            service.createSession({ x: 0, y: 0, width: 100, height: 100 }, '', 1);
+            service.createSession(
+                { x: 0, y: 0, width: 100, height: 100 },
+                '',
+                1
+            );
 
             expect(addon.createSession).toHaveBeenCalledWith(
                 expect.any(Buffer),
@@ -1111,5 +1115,34 @@ describe('EmbeddedMpvNativeService power blocker', () => {
                 },
             })
         );
+    });
+
+    it('completes teardown when the native dispose throws', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation();
+        const failure = new Error('native session already gone');
+        startSession('s-throws', snapshot('playing'));
+        addon.disposeSession.mockImplementationOnce(() => {
+            throw failure;
+        });
+
+        // A `return` inside `finally` used to swallow this, so `shutdown()`
+        // could not tell a failed dispose from a clean one.
+        const disposed = service.disposeSession('s-throws');
+
+        expect(disposed?.id).toBe('s-throws');
+        expect(disposed?.status).toBe('closed');
+        expect(mainWindowSendMock).toHaveBeenLastCalledWith(
+            'EMBEDDED_MPV_SESSION_UPDATE',
+            expect.objectContaining({ id: 's-throws', status: 'closed' })
+        );
+        expect(warn).toHaveBeenCalledWith(
+            'Failed to dispose embedded mpv session s-throws:',
+            failure
+        );
+
+        // The session is gone, so a second dispose finds nothing.
+        expect(service.disposeSession('s-throws')).toBeNull();
+
+        warn.mockRestore();
     });
 });

--- a/apps/electron-backend/src/app/services/embedded-mpv-native.service.ts
+++ b/apps/electron-backend/src/app/services/embedded-mpv-native.service.ts
@@ -663,32 +663,41 @@ export class EmbeddedMpvNativeService {
                 lastRecording = undefined;
             }
             addon.disposeSession(sessionId);
-        } finally {
-            this.sessions.delete(sessionId);
-            this.pollFailuresLogged.delete(sessionId);
-            const payload: EmbeddedMpvSession = {
-                id: session.id,
-                title: session.title,
-                streamUrl: session.streamUrl,
-                status: 'closed',
-                positionSeconds: 0,
-                durationSeconds: null,
-                volume: 1,
-                audioTracks: [],
-                selectedAudioTrackId: null,
-                subtitleTracks: [],
-                selectedSubtitleTrackId: null,
-                playbackSpeed: 1,
-                aspectOverride: 'no',
-                recording: this.createClosedRecordingState(lastRecording),
-                startedAt: session.startedAt,
-                updatedAt: new Date().toISOString(),
-            };
-            this.sendSessionUpdate(payload);
-            this.stopPollingIfIdle();
-            this.updatePowerBlocker();
-            return payload;
+        } catch (error) {
+            // Teardown below must run even when the native session is already
+            // gone — `shutdown()` disposes every session in turn and must not
+            // stop at the first failure. A `return` inside `finally` achieved
+            // that but also swallowed the reason, so log it instead.
+            console.warn(
+                `Failed to dispose embedded mpv session ${sessionId}:`,
+                error
+            );
         }
+
+        this.sessions.delete(sessionId);
+        this.pollFailuresLogged.delete(sessionId);
+        const payload: EmbeddedMpvSession = {
+            id: session.id,
+            title: session.title,
+            streamUrl: session.streamUrl,
+            status: 'closed',
+            positionSeconds: 0,
+            durationSeconds: null,
+            volume: 1,
+            audioTracks: [],
+            selectedAudioTrackId: null,
+            subtitleTracks: [],
+            selectedSubtitleTrackId: null,
+            playbackSpeed: 1,
+            aspectOverride: 'no',
+            recording: this.createClosedRecordingState(lastRecording),
+            startedAt: session.startedAt,
+            updatedAt: new Date().toISOString(),
+        };
+        this.sendSessionUpdate(payload);
+        this.stopPollingIfIdle();
+        this.updatePowerBlocker();
+        return payload;
     }
 
     shutdown(): void {
@@ -979,6 +988,9 @@ export class EmbeddedMpvNativeService {
 
     private sanitizeRecordingFileName(title: string): string {
         const normalized = title
+            // Stripping control characters is precisely what a filename
+            // sanitizer must do, so the rule does not apply here.
+            // eslint-disable-next-line no-control-regex
             .replace(/[<>:"/\\|?*\u0000-\u001f]/g, '_')
             .replace(/\s+/g, ' ')
             .trim();

--- a/apps/electron-backend/src/app/workers/database.worker-connection.ts
+++ b/apps/electron-backend/src/app/workers/database.worker-connection.ts
@@ -15,17 +15,14 @@ import {
     trace,
 } from '../services/debug-trace';
 
-let Database: typeof BetterSqlite3;
 let drizzleFactory:
-    | (typeof import('drizzle-orm/better-sqlite3'))['drizzle']
-    | undefined;
+    (typeof import('drizzle-orm/better-sqlite3'))['drizzle'] | undefined;
 
 const nativeModuleSearchPaths = [
     ...getWorkerDataNativeModuleSearchPaths(workerData),
     ...getNativeModuleSearchPaths({
-        resourcesPath: (
-            process as NodeJS.Process & { resourcesPath?: string }
-        ).resourcesPath,
+        resourcesPath: (process as NodeJS.Process & { resourcesPath?: string })
+            .resourcesPath,
     }),
 ];
 
@@ -50,14 +47,13 @@ function getDrizzleFactory(): (typeof import('drizzle-orm/better-sqlite3'))['dri
     // Require drizzle only after native lookup paths have been registered.
     // Its better-sqlite3 driver resolves the native package at module load time.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    drizzleFactory = require('drizzle-orm/better-sqlite3').drizzle as (
-        typeof import('drizzle-orm/better-sqlite3')
-    )['drizzle'];
+    drizzleFactory = require('drizzle-orm/better-sqlite3')
+        .drizzle as (typeof import('drizzle-orm/better-sqlite3'))['drizzle'];
 
     return drizzleFactory;
 }
 
-Database = loadBetterSqlite3();
+const Database: typeof BetterSqlite3 = loadBetterSqlite3();
 
 let db: AppDatabase | null = null;
 let sqlite: BetterSqlite3.Database | null = null;


### PR DESCRIPTION
## The glob

```jsonc
// apps/electron-backend/project.json
"command": "eslint apps/electron-backend/**/*.ts \"...frame-copy-runtime.ts\" \"...frame-copy-runtime/**/*.ts\""
```

The first pattern is unquoted. Nx runs commands through `/bin/sh`, which has no `globstar`, so `**` collapses to `*` and **the shell** expands it — matching **1 file out of 247**. Quoting hands the pattern to eslint, which expands it recursively.

The two sibling patterns were already quoted: the breakage had been worked around per-file instead of fixed. They are now redundant, so all three collapse into one — verified rather than assumed: the quoted glob alone resolves to the byte-identical 247-file list (`diff` empty), including all 24 `frame-copy-runtime` files.

This is the hole that let the 519-line `epg.events.ts` sit over the `max-lines` cap unnoticed.

## What it was hiding

Five errors, now fixed:

**`no-unsafe-finally` × 2 — real bugs.** Both `closeSession` and `disposeSession` did:

```ts
try { await runtime.close?.(); } finally { return this.markClosed(id); }
```

A `return` inside `finally` discards an in-flight exception, so a failing close/dispose was indistinguishable from a clean one. Both *intentionally* always complete teardown — `shutdown()` disposes every session in turn and must not stop at the first failure — so the fix preserves that guarantee with an explicit `catch` and logs the reason instead of dropping it. Same silent-failure class as #1291.

**`prefer-const` × 2.** A write-once `timeoutId` and the module-level `Database`. The *other* `timeoutId` in the same file is genuinely reassigned (`= undefined` on clear) and correctly stays `let`.

**`no-control-regex` × 1.** The recording-filename sanitizer strips control characters on purpose — disabled inline with that rationale rather than reworked.

Three `max-lines` violations would also have surfaced, but #1288 already split those specs, so nothing needed the baseline.

## Tests

Regression coverage for both teardown paths, each **verified to fail against the old code** (reverted the fix, watched the new test go red, restored):

| Spec | Against old code |
|---|---|
| `external-player-session-registry.spec.ts` | 1 failed, 3 passed |
| `embedded-mpv-native.service.spec.ts` | 1 failed, 47 passed |

| Check | Result |
|---|---|
| `pnpm nx lint electron-backend` | **0 errors** (was: 5, hidden), 247 files, 61 pre-existing warnings |
| Full `electron-backend` suite | 105 suites, 1073 tests passed |
| `npx prettier --check` on every changed file | clean |
| `pnpm run release:notes:validate` | 36 notes valid |

## Note on the warnings

61 warnings remain and are left alone: they are pre-existing, `--max-warnings` is not set anywhere, so they do not gate CI. Cleaning them is separate work.

Release note is `type: internal` — teardown finishes exactly as before, only the previously-discarded reason now gets logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)