### PR TITLE
test(performance): stabilize Xtream benchmark startup

### DIFF
--- a/apps/electron-backend-e2e/src/performance/xtream-benchmark-iteration-support.ts
+++ b/apps/electron-backend-e2e/src/performance/xtream-benchmark-iteration-support.ts
@@ -50,6 +50,14 @@ export interface SeedXtreamExistingPortalOptions {
 export async function prearmXtreamDatabaseWorker(
     app: LaunchedElectronApp
 ): Promise<void> {
+    // Main owns schema creation but loads the renderer first. Fence that
+    // startup promise before the independent worker opens the fresh database.
+    const downloads = await app.mainWindow.evaluate(() =>
+        window.electron.downloadsGetList()
+    );
+    if (!Array.isArray(downloads)) {
+        throw new Error('xtream-main-database-readiness-invalid');
+    }
     const playlists = await app.mainWindow.evaluate(() =>
         window.electron.dbGetAppPlaylists()
     );

--- a/apps/electron-backend-e2e/src/performance/xtream-iteration-assembler.spec.ts
+++ b/apps/electron-backend-e2e/src/performance/xtream-iteration-assembler.spec.ts
@@ -201,6 +201,32 @@ describe('Xtream raw iteration assembler', () => {
         );
     });
 
+    it('rejects a cancellation terminal that substantially predates the main receipt', () => {
+        const input = createXtreamAssemblerFixture(
+            XTREAM_SCENARIO_ID.CANCEL_IMPORT
+        );
+        const workerTerminal = input.mainCapture.cancelTimeline.find(
+            ({ type }) => type === 'db-cancel-terminal-received'
+        );
+        assert.ok(workerTerminal);
+
+        assert.throws(
+            () =>
+                assembleXtreamRawIteration({
+                    ...input,
+                    rendererCapture: {
+                        ...input.rendererCapture,
+                        probe: {
+                            ...input.rendererCapture.probe,
+                            dbCancellationTerminalEpochMs:
+                                workerTerminal.epochMs - 2,
+                        },
+                    },
+                }),
+            /xtream-iteration-assembly-invalid/
+        );
+    });
+
     it('accepts main observing a network cancel response after the next renderer IPC starts', () => {
         const input = createXtreamAssemblerFixture(
             XTREAM_SCENARIO_ID.CANCEL_IMPORT

--- a/apps/electron-backend-e2e/src/performance/xtream-iteration-assembler.spec.ts
+++ b/apps/electron-backend-e2e/src/performance/xtream-iteration-assembler.spec.ts
@@ -173,6 +173,34 @@ describe('Xtream raw iteration assembler', () => {
         );
     });
 
+    it('accepts sub-millisecond skew between renderer and main cancellation clocks', () => {
+        const input = createXtreamAssemblerFixture(
+            XTREAM_SCENARIO_ID.CANCEL_IMPORT
+        );
+        const workerTerminal = input.mainCapture.cancelTimeline.find(
+            ({ type }) => type === 'db-cancel-terminal-received'
+        );
+        assert.ok(workerTerminal);
+        const rendererTerminalEpochMs = workerTerminal.epochMs - 0.1;
+        assert.ok(
+            rendererTerminalEpochMs >
+                Number(input.rendererCapture.probe.cancellationClickEpochMs)
+        );
+
+        assert.doesNotThrow(() =>
+            assembleXtreamRawIteration({
+                ...input,
+                rendererCapture: {
+                    ...input.rendererCapture,
+                    probe: {
+                        ...input.rendererCapture.probe,
+                        dbCancellationTerminalEpochMs: rendererTerminalEpochMs,
+                    },
+                },
+            })
+        );
+    });
+
     it('accepts main observing a network cancel response after the next renderer IPC starts', () => {
         const input = createXtreamAssemblerFixture(
             XTREAM_SCENARIO_ID.CANCEL_IMPORT

--- a/apps/electron-backend-e2e/src/performance/xtream-iteration-assembly-scenarios.ts
+++ b/apps/electron-backend-e2e/src/performance/xtream-iteration-assembly-scenarios.ts
@@ -26,6 +26,8 @@ import {
     type XtreamUiActionSample,
 } from './xtream-ui-action-probe';
 
+const CANCELLATION_CLOCK_SKEW_TOLERANCE_MS = 1;
+
 export interface XtreamScenarioAssembly {
     readonly backgroundMetrics: {
         readonly actionLatencyMs: number;
@@ -264,8 +266,8 @@ function cancellationEvidence(
     const preload = ipcPair(input.phaseCapture.ipcSpans, 'dbCancelOperation');
     const authoritative = request.responseEpochMs;
     const painted = requireNumber(renderer.uiPaintedEpochMs);
-    // Renderer and main sample independent clocks. Their correlated receipt
-    // timestamps cannot establish cross-process sub-millisecond ordering.
+    // Renderer and main sample independent clocks, so allow their correlated
+    // terminal timestamps to invert only within the known sub-millisecond skew.
     if (
         !dispatch ||
         !receipt ||
@@ -273,6 +275,8 @@ function cancellationEvidence(
         dispatch.type !== 'db-cancel-dispatched' ||
         receipt.type !== 'db-cancel-received' ||
         workerTerminal.type !== 'db-cancel-terminal-received' ||
+        renderer.dbCancellationTerminalEpochMs <
+            workerTerminal.epochMs - CANCELLATION_CLOCK_SKEW_TOLERANCE_MS ||
         renderer.dbCancellationTerminalEpochMs > painted ||
         authoritative > painted
     ) {

--- a/apps/electron-backend-e2e/src/performance/xtream-iteration-assembly-scenarios.ts
+++ b/apps/electron-backend-e2e/src/performance/xtream-iteration-assembly-scenarios.ts
@@ -264,6 +264,8 @@ function cancellationEvidence(
     const preload = ipcPair(input.phaseCapture.ipcSpans, 'dbCancelOperation');
     const authoritative = request.responseEpochMs;
     const painted = requireNumber(renderer.uiPaintedEpochMs);
+    // Renderer and main sample independent clocks. Their correlated receipt
+    // timestamps cannot establish cross-process sub-millisecond ordering.
     if (
         !dispatch ||
         !receipt ||
@@ -271,7 +273,6 @@ function cancellationEvidence(
         dispatch.type !== 'db-cancel-dispatched' ||
         receipt.type !== 'db-cancel-received' ||
         workerTerminal.type !== 'db-cancel-terminal-received' ||
-        renderer.dbCancellationTerminalEpochMs < workerTerminal.epochMs ||
         renderer.dbCancellationTerminalEpochMs > painted ||
         authoritative > painted
     ) {

--- a/apps/electron-backend-e2e/src/performance/xtream-scenario-driver-wiring.spec.ts
+++ b/apps/electron-backend-e2e/src/performance/xtream-scenario-driver-wiring.spec.ts
@@ -145,7 +145,14 @@ describe('Xtream scenario driver source wiring', () => {
             support,
             /export async function prearmXtreamDatabaseWorker/
         );
-        assert.match(support, /window\.electron\.dbGetAppPlaylists\(\)/);
+        const mainDatabaseReady = support.indexOf(
+            'window.electron.downloadsGetList()'
+        );
+        const workerPrearm = support.indexOf(
+            'window.electron.dbGetAppPlaylists()'
+        );
+        assert.ok(mainDatabaseReady >= 0);
+        assert.ok(workerPrearm > mainDatabaseReady);
         assert.ok(install >= 0);
         assert.ok(prearm > install);
         assert.ok(captureOptions > prearm);


### PR DESCRIPTION
## Summary

- wait for the main-process SQLite schema owner before prearming the database worker on each fresh benchmark profile
- allow only the existing 1 ms cross-process clock-skew tolerance for correlated cancellation terminals while rejecting larger causal reversals
- cover the observed fresh-profile schema race, sub-millisecond clock skew, and excessive timestamp inversion

## Evidence

Two formal after suites failed outside production work:

- refresh setup intermittently returned `SqliteError: no such table: playlists` before capture started
- cancel assembly rejected a healthy run where the renderer timestamp preceded the main timestamp by 0.0886 ms

Both failures were reproduced by regression assertions before the harness-only changes. Codex review additionally identified that removing the cancellation lower bound entirely accepted arbitrary inversions; the follow-up regression now accepts -0.1 ms and rejects -2 ms.

## Validation

- `pnpm exec tsx --test src/performance/xtream-iteration-assembler.spec.ts` (17/17)
- `pnpm nx run electron-backend-e2e:test-performance-harness --skip-nx-cache` (475/475)
- `pnpm nx lint electron-backend-e2e --skip-nx-cache` (pass; existing warnings only)
- Xtream E2E smoke: all five scenarios completed warm-up, measured, and diagnostic iterations
- Prettier and `git diff --check` pass

## Release note

Not required: test/performance-harness-only change with no user-visible behavior.