### PR TITLE
fix(playback): escape commas in mpv http header fields

### DIFF
--- a/.changes/stalker-mpv-header-comma-escape.md
+++ b/.changes/stalker-mpv-header-comma-escape.md
@@ -3,9 +3,8 @@ type: fix
 area: playback
 ---
 
-Stalker live TV channels play again in the embedded MPV player. The MAG250
-user agent sent to portals contains a comma (`... (KHTML, like Gecko) MAG250`),
-and MPV splits its `--http-header-fields` list on commas, so the `X-User-Agent`
-header was truncated and strict portals rejected the stream with HTTP 400.
-Commas and backslashes in header values are now escaped before MPV parses them,
-on the Windows/Linux and macOS embedded-MPV paths.
+Stalker live TV plays again in the embedded MPV player. The MAG250 user agent
+contains a comma (`KHTML, like Gecko`), which MPV splits in its comma-separated
+`--http-header-fields` list, truncating `X-User-Agent` so strict portals reject
+the stream with HTTP 400. Commas and backslashes in header values are now
+escaped on the Windows/Linux and macOS embedded-MPV paths.

--- a/.changes/stalker-mpv-header-comma-escape.md
+++ b/.changes/stalker-mpv-header-comma-escape.md
@@ -1,0 +1,11 @@
+---
+type: fix
+area: playback
+---
+
+Stalker live TV channels play again in the embedded MPV player. The MAG250
+user agent sent to portals contains a comma (`... (KHTML, like Gecko) MAG250`),
+and MPV splits its `--http-header-fields` list on commas, so the `X-User-Agent`
+header was truncated and strict portals rejected the stream with HTTP 400.
+Commas and backslashes in header values are now escaped before MPV parses them,
+on the Windows/Linux and macOS embedded-MPV paths.

--- a/apps/electron-backend/native/src/embedded_mpv.mm
+++ b/apps/electron-backend/native/src/embedded_mpv.mm
@@ -766,6 +766,19 @@ void onRenderContextUpdate(void* context)
     }
 }
 
+void replaceAllInPlace(std::string& value, const std::string& from, const std::string& to)
+{
+    if (from.empty()) {
+        return;
+    }
+
+    size_t position = 0;
+    while ((position = value.find(from, position)) != std::string::npos) {
+        value.replace(position, from.length(), to);
+        position += to.length();
+    }
+}
+
 std::string joinHeaderFields(const Napi::Object& headers)
 {
     const Napi::Array propertyNames = headers.GetPropertyNames();
@@ -788,6 +801,15 @@ std::string joinHeaderFields(const Napi::Object& headers)
         if (key.empty() || value.empty()) {
             continue;
         }
+
+        // mpv's `--http-header-fields` option is a comma-separated list
+        // (OPT_STRINGLIST). Header values that themselves contain commas
+        // (e.g. the Stalker MAG250 user agent "...(KHTML, like Gecko) MAG250")
+        // must be escaped so mpv does not split them into bogus fields and
+        // the server rejects the request with HTTP 400. mpv strips the
+        // backslash and keeps the comma inside the header value.
+        replaceAllInPlace(value, "\\", "\\\\");
+        replaceAllInPlace(value, ",", "\\,");
 
         fields.push_back(key + ": " + value);
     }

--- a/apps/electron-backend/native/src/embedded_mpv_wid_common.h
+++ b/apps/electron-backend/native/src/embedded_mpv_wid_common.h
@@ -289,6 +289,19 @@ std::string normalizeEnvValue(const char* value)
     return result;
 }
 
+void replaceAllInPlace(std::string& value, const std::string& from, const std::string& to)
+{
+    if (from.empty()) {
+        return;
+    }
+
+    size_t position = 0;
+    while ((position = value.find(from, position)) != std::string::npos) {
+        value.replace(position, from.length(), to);
+        position += to.length();
+    }
+}
+
 std::string joinHeaderFields(const Napi::Object& headers)
 {
     const Napi::Array propertyNames = headers.GetPropertyNames();
@@ -311,6 +324,15 @@ std::string joinHeaderFields(const Napi::Object& headers)
         if (key.empty() || value.empty()) {
             continue;
         }
+
+        // mpv's `--http-header-fields` option is a comma-separated list
+        // (OPT_STRINGLIST). Header values that themselves contain commas
+        // (e.g. the Stalker MAG250 user agent "...(KHTML, like Gecko) MAG250")
+        // must be escaped so mpv does not split them into bogus fields and
+        // the server rejects the request with HTTP 400. mpv strips the
+        // backslash and keeps the comma inside the header value.
+        replaceAllInPlace(value, "\\", "\\\\");
+        replaceAllInPlace(value, ",", "\\,");
 
         fields.push_back(key + ": " + value);
     }


### PR DESCRIPTION
Fixes #910

## Problem

Stalker live TV fails to play in the embedded mpv player (only works in VLC / external players).

`mpv --http-header-fields` is parsed as a **comma-separated list** (`OPT_STRINGLIST`). Stalker portals require the MAG250 user agent, which contains a comma:

```
Mozilla/5.0 (QtEmbedded; U; Linux; C) AppleWebKit/533.3 (KHTML, like Gecko) MAG250
```

Because the value is split on commas, the `X-User-Agent` header was truncated to `... (KHTML`. The portal then rejects the stream request with `HTTP 400 Bad Request` — while VOD (`movie.php`) still works because it does not validate this header.

## Fix

Escape backslashes and commas inside header values (`\,`). mpv's stringlist parser strips the backslash and keeps the comma as part of the header value, so the full MAG250 user agent is sent to the portal.

## Verification

- `curl` against the live portal: intact `X-User-Agent` → `HTTP 302` (accepted); truncated header → `HTTP 400`/`462` (rejected)
- After the fix, the spawned mpv process receives the escaped header and the live channel plays