### PR TITLE
fix(workspace): restore playlist info entry in header playlist dropdown

### DIFF
--- a/.changes/workspace-playlist-info-menu-item.md
+++ b/.changes/workspace-playlist-info-menu-item.md
@@ -1,0 +1,8 @@
+---
+type: fix
+area: workspace
+---
+
+The playlist dropdown in the header shows a "Playlist info" entry for the
+active playlist again, next to "Account info" and "Add playlist" — it had
+disappeared when playlist actions moved into the per-row menu.

--- a/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.html
+++ b/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.html
@@ -202,16 +202,16 @@
         }
     </div>
 
-    @if (showAddPlaylist() || showAccountInfo()) {
+    @if (showAddPlaylist() || showAccountInfo() || showPlaylistInfo()) {
         <div class="context-actions-section">
-            @if (showAddPlaylist()) {
+            @if (showPlaylistInfo()) {
                 <button
                     class="context-action-item"
-                    (click)="requestAddPlaylist()"
+                    (click)="requestPlaylistInfo()"
                 >
-                    <mat-icon>add</mat-icon>
+                    <mat-icon>info</mat-icon>
                     <span>{{
-                        'WORKSPACE.SHELL.ADD_PLAYLIST' | translate
+                        'WORKSPACE.SHELL.PLAYLIST_INFO' | translate
                     }}</span>
                 </button>
             }
@@ -223,6 +223,17 @@
                     <mat-icon>person</mat-icon>
                     <span>{{
                         'WORKSPACE.SHELL.ACCOUNT_INFO' | translate
+                    }}</span>
+                </button>
+            }
+            @if (showAddPlaylist()) {
+                <button
+                    class="context-action-item"
+                    (click)="requestAddPlaylist()"
+                >
+                    <mat-icon>add</mat-icon>
+                    <span>{{
+                        'WORKSPACE.SHELL.ADD_PLAYLIST' | translate
                     }}</span>
                 </button>
             }

--- a/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-switcher/playlist-switcher.component.spec.ts
@@ -295,6 +295,38 @@ describe('PlaylistSwitcherComponent', () => {
         expect(accountInfoSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('renders playlist info, account info, and add playlist context actions in the menu', async () => {
+        await createComponent();
+        fixture.componentRef.setInput('showPlaylistInfo', true);
+        fixture.componentRef.setInput('showAccountInfo', true);
+        fixture.componentRef.setInput('showAddPlaylist', true);
+        fixture.detectChanges();
+
+        const playlistInfoSpy = jest.fn();
+        component.playlistInfoRequested.subscribe(playlistInfoSpy);
+
+        component.menuTrigger().openMenu();
+        fixture.detectChanges();
+
+        const actionButtons = Array.from(
+            document.querySelectorAll<HTMLButtonElement>(
+                '.context-actions-section .context-action-item'
+            )
+        );
+        const labels = actionButtons.map((button) =>
+            button.textContent?.trim()
+        );
+
+        expect(labels).toEqual([
+            expect.stringContaining('PLAYLIST_INFO'),
+            expect.stringContaining('ACCOUNT_INFO'),
+            expect.stringContaining('ADD_PLAYLIST'),
+        ]);
+
+        actionButtons[0].click();
+        expect(playlistInfoSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('opens the menu, syncs overlay width, and checks portal statuses for Xtream playlists', fakeAsync(async () => {
         await createComponent();
 


### PR DESCRIPTION
## Summary

The bottom context-actions section of the header playlist switcher lost its **Playlist info** button when playlist actions moved into the per-row ⋮ menu (156c12c51). The `showPlaylistInfo` input, the `playlistInfoRequested` output and the entire shell wiring (header component bindings, facade, header service) stayed alive — but no template rendered the entry, so the active playlist's info dialog was only reachable by locating the playlist's own row in the dropdown list.

This restores the button in the bottom section, gated on the existing `showPlaylistInfo` input, ordered as: Playlist info → Account info → Add playlist.

## Test impact

- Added a DOM-level regression test that opens the menu and asserts all three context actions render and that clicking Playlist info emits `playlistInfoRequested`. Verified it fails against the old template and passes with the fix.
- `pnpm nx test playlist-shared-ui` (switcher scope): 51/51 green; `pnpm nx lint playlist-shared-ui` clean.

## Release note

`.changes/workspace-playlist-info-menu-item.md` (type: fix, area: workspace).

## Docs

No doc updates needed — restores documented behavior, no architecture change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)