### PR TITLE
test(playlist): fix flaky refresh-preparation worker-event spec

### DIFF
--- a/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts
+++ b/libs/playlist/shared/ui/src/lib/playlist-refresh-action.service.spec.ts
@@ -60,10 +60,6 @@ function createAbortError(): Error {
     return error;
 }
 
-async function waitForRefreshPreparationPaint(): Promise<void> {
-    await new Promise<void>((resolve) => setTimeout(resolve, 160));
-}
-
 function createPlaylistMeta(
     overrides: Partial<PlaylistMeta> = {}
 ): PlaylistMeta {
@@ -559,6 +555,13 @@ describe('PlaylistRefreshActionService', () => {
             hiddenCategories: [];
         }>();
         let confirmPromise: Promise<void> | undefined;
+        // The service awaits its internal paint delay (rAF + setTimeout)
+        // before it calls deleteXtreamPlaylistContent, so a fixed sleep here
+        // races against real timers under parallel jest load. The mock fires
+        // onEvent synchronously and the service applies it to the signal
+        // synchronously, so resolving this deferred inside the mock is a
+        // deterministic "worker event has been applied" signal.
+        const workerEventDelivered = createDeferred<void>();
 
         databaseService.deleteXtreamPlaylistContent.mockImplementation(
             (
@@ -576,6 +579,7 @@ describe('PlaylistRefreshActionService', () => {
                     current: 50,
                     total: 100,
                 });
+                workerEventDelivered.resolve();
 
                 return refresh.promise;
             }
@@ -587,7 +591,7 @@ describe('PlaylistRefreshActionService', () => {
         );
 
         service.refresh(item);
-        await waitForRefreshPreparationPaint();
+        await workerEventDelivered.promise;
 
         expect(service.refreshPreparation()).toEqual({
             playlistId: item._id,


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `PlaylistRefreshActionService › updates refresh-preparation phase and progress from worker events` under parallel jest load (`nx affected --target=test --parallel=3`): expected phase `deleting-content` with `current`/`total`, received `collecting-user-data` without progress fields.

## Root cause

`refreshXtream` sets `collecting-user-data` and then awaits its internal paint delay — a `requestAnimationFrame` plus a 120ms real `setTimeout` — **before** calling `deleteXtreamPlaylistContent`, whose mock emits the `deleting-content` worker event. The spec raced that chain with an independent fixed 160ms sleep. In isolation the sleep always loses the race safely; under parallel load, timer callbacks are delayed unevenly across worker processes, so the spec's timer could fire first — before the mock was ever invoked — and the assertion saw the initial state. No sleep duration fixes that; it only shifts the odds (same trap as d2fd27b5).

## Fix

The test now awaits a deferred that the `deleteXtreamPlaylistContent` mock resolves immediately after firing `onEvent`. The mock fires the event synchronously and the service applies it to the signal synchronously, so the deferred is a deterministic "worker event has been applied" signal — the assertion is causally ordered after the state update instead of racing wall-clock timers. The assertion itself is unchanged (full `toEqual` including `current: 50` / `total: 100`); if the event were never delivered, jest's own timeout fails the test. The unused 160ms spec helper is deleted; production code is untouched.

## Validation

- `pnpm nx test playlist-shared-ui` — 50/50 pass
- 5 consecutive uncached runs with 8 concurrent CPU-burner processes simulating parallel-jest contention — all green

Test-only change: no release note required (test paths are auto-exempt from the release note gate), no doc updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)