### PR TITLE
docs(release): backfill 0.23 notes for embedded MPV scaling and dock-menu fixes

### DIFF
--- a/.changes/embedded-mpv-dock-menus.md
+++ b/.changes/embedded-mpv-dock-menus.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: embedded-mpv
+issues: [1139]
+---
+
+Opening the volume, audio, subtitle, speed or aspect menu in the Embedded MPV
+player no longer makes the video jump or leave a black bar above the controls:
+the menus now unfold inside the control bar instead of floating over the video.

--- a/.changes/embedded-mpv-scaled-displays.md
+++ b/.changes/embedded-mpv-scaled-displays.md
@@ -1,0 +1,11 @@
+---
+type: fix
+area: embedded-mpv
+issues: [1139, 1145]
+---
+
+On Windows and Linux displays scaled above 100%, the Embedded MPV video was
+drawn toward the top-left corner at a fraction of its size, in windowed and
+fullscreen mode alike. The video now fills the player area correctly at any
+display scale and page zoom, with no need for a high-DPI compatibility
+workaround.


### PR DESCRIPTION
## Summary

Adds two missing `.changes/` release notes for user-visible embedded MPV fixes that were merged before the release-notes pipeline existed and were not covered by the 0.23.0 backfill (#1263):

- `embedded-mpv-scaled-displays.md` — #1206: native view drawn misplaced/undersized on Windows/Linux displays scaled above 100% (issues #1139, #1145)
- `embedded-mpv-dock-menus.md` — #1207: video jump / black bar when opening the control menus (issue #1139)

## Validation

- `node tools/release/build-release-notes.mjs --validate` → 60 note(s) valid
- Markdown-only change; no runtime code touched, so no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)