### PR TITLE
refactor(styles): move nav-list partial into ui-styles

### DIFF
--- a/.codex/skills/iptvnator-ui-design/SKILL.md
+++ b/.codex/skills/iptvnator-ui-design/SKILL.md
@@ -9,7 +9,7 @@ description: Use when changing user-visible Angular UI in IPTVnator, especially 
 
 - Policy: `docs/architecture/iptvnator-ui-guidelines.md`
 - Theme and navigation: `apps/web/src/m3-theme.scss`,
-  `apps/web/src/nav-list.scss`
+  `libs/ui/styles/_nav-list.scss`
 - Channel row: `libs/ui/components/src/lib/channel-list-container/channel-list-item/`
 - Shared EPG timeline/list: `libs/ui/epg/src/lib/epg-timeline/`,
   `libs/ui/epg/src/lib/epg-list-view/`

--- a/docs/architecture/iptvnator-ui-guidelines.md
+++ b/docs/architecture/iptvnator-ui-guidelines.md
@@ -37,7 +37,7 @@ Use it when changing existing views or introducing new list-based UI in the work
 - Shared EPG list styles:
   `libs/ui/epg/src/lib/epg-list-view/epg-list-view.component.scss`
 - Shared list selection style:
-  `apps/web/src/nav-list.scss`
+  `libs/ui/styles/_nav-list.scss`
 - Theme tokens:
   `apps/web/src/m3-theme.scss`
 - Settings surfaces:

--- a/docs/architecture/nx-workspace-boundaries.md
+++ b/docs/architecture/nx-workspace-boundaries.md
@@ -141,9 +141,11 @@ not enforced here — keep consumers at `type:feature` or `type:ui`, both of whi
 may depend on `type:ui`.
 
 Importing a partial that the consuming **application** owns is a different case
-and needs no declaration: `apps/web/src/nav-list.scss` is already inside
-`web:build`'s own inputs, and declaring a lib → app edge would make the graph
-cyclic. Prefer moving genuinely shared partials into `ui-styles`.
+and needs no declaration, because that partial already sits inside the app's own
+build inputs. It is still the wrong direction, and it is the one case the two
+rules above cannot repair: a lib → app edge would make the graph cyclic, since
+the app already depends on those libraries. Move the partial into `ui-styles`
+instead. No library stylesheet imports from `apps/` today — keep it that way.
 
 `pnpm run styles:inputs:validate` enforces both rules. It resolves every
 relative `@use`/`@forward`/`@import` in the workspace against Nx's own project

--- a/libs/portal/shared/ui/src/lib/components/category-view/category-view.component.scss
+++ b/libs/portal/shared/ui/src/lib/components/category-view/category-view.component.scss
@@ -1,4 +1,4 @@
-@use '../../../../../../../../apps/web/src/nav-list.scss';
+@use '../../../../../../../ui/styles/nav-list';
 
 :host {
     display: block;

--- a/libs/portal/shared/ui/src/lib/navigation/portal-rail-links.component.scss
+++ b/libs/portal/shared/ui/src/lib/navigation/portal-rail-links.component.scss
@@ -1,4 +1,4 @@
-@use '../../../../../../../apps/web/src/nav-list.scss';
+@use '../../../../../../ui/styles/nav-list';
 
 :host {
     display: block;

--- a/libs/ui/components/src/lib/channel-list-container/groups-view/groups-view.component.scss
+++ b/libs/ui/components/src/lib/channel-list-container/groups-view/groups-view.component.scss
@@ -1,7 +1,7 @@
 @use '@angular/material' as mat;
 @use '../../../../../styles/portal-sidebar';
 @use '../../../../../styles/panel-header' as panel;
-@use '../../../../../../../apps/web/src/nav-list.scss';
+@use '../../../../../styles/nav-list';
 
 :host {
     display: flex;

--- a/libs/ui/styles/_index.scss
+++ b/libs/ui/styles/_index.scss
@@ -10,3 +10,4 @@
 @forward 'panel-header';
 @forward 'detail-view';
 @forward 'detail-view-actions';
+@forward 'nav-list';

--- a/libs/ui/styles/_nav-list.scss
+++ b/libs/ui/styles/_nav-list.scss
@@ -1,4 +1,9 @@
 // ─── Shared List Navigation Styles ────────────────────────────────────────────
+// Plain CSS rules (not a mixin) for sidebar and context-panel list items, so no
+// alias is needed. Consumers live in several libraries at different depths;
+// pick the relative @use path from the consuming stylesheet, for example:
+//   @use '../../../../../../ui/styles/nav-list';
+
 .nav-list {
     flex: 1;
     overflow-y: auto;

--- a/libs/workspace/shell/feature/src/lib/workspace-context-panel/components/workspace-context-category-view.component.scss
+++ b/libs/workspace/shell/feature/src/lib/workspace-context-panel/components/workspace-context-category-view.component.scss
@@ -1,4 +1,4 @@
-@use '../../../../../../../../apps/web/src/nav-list.scss';
+@use '../../../nav-list.scss';
 
 :host {
     display: block;

--- a/libs/workspace/shell/feature/src/nav-list.scss
+++ b/libs/workspace/shell/feature/src/nav-list.scss
@@ -1,1 +1,3 @@
-@use '../../../../../apps/web/src/nav-list.scss';
+// Local entry point for this library's context-panel stylesheets.
+// Canonical source: libs/ui/styles/_nav-list.scss
+@use '../../../../ui/styles/nav-list';


### PR DESCRIPTION
Stacked on #1360 — please merge that one first. Base is `claude/infallible-leakey-b1707c`, so this PR shows only its own commit.

## Why

`apps/web/src/nav-list.scss` was imported by relative path from five library stylesheets, inverting the intended lib → app direction. #1360 documents this as the one case its two rules **cannot** repair: the file is already inside `web:build`'s own inputs, so `styles:inputs:validate` stays silent, and a lib → app edge cannot be declared because it would make the graph cyclic (`web` already depends on all three libraries). The only fix is to move the partial.

This is not a caching bug today — it is the structural exception the boundaries doc explicitly says to refactor away.

## What

- `git mv apps/web/src/nav-list.scss` → `libs/ui/styles/_nav-list.scss`, with the same `@use`-convention header the sibling partials carry, and `@forward 'nav-list'` added to the `_index.scss` inventory.
- Repointed all five importers. Four now `@use` the canonical partial directly; `workspace-context-category-view.component.scss` goes through the library's own `src/nav-list.scss` entry point (repointed too) instead of an 8-deep path, matching its two siblings in that project.
- **No new declarations needed.** All three consuming projects already declare `"implicitDependencies": ["ui-styles"]`, and `apps/web` imports nothing from `ui/styles` — its only cross-project stylesheet import is `styles.scss` → `libs/ui/components/.../resizable.scss`, which runs app → lib and is already inside the closure.
- No library stylesheet imports from `apps/` any more.

## Docs

- `docs/architecture/nx-workspace-boundaries.md` — the "Shared Stylesheets and Cache Inputs" exception paragraph named the file this PR moves; rewritten to state the rule generically and record that nothing under `libs/` imports from `apps/`.
- `docs/architecture/iptvnator-ui-guidelines.md` and `.codex/skills/iptvnator-ui-design/SKILL.md` — path references.

## Validation

| Check | Result |
| --- | --- |
| `pnpm run styles:inputs:validate` | green — 42 imports across 133 files |
| `pnpm nx build web` | succeeds (only pre-existing budget/CommonJS warnings) |
| `pnpm run skills:validate` | 8 skills OK |
| `pnpm nx affected -t lint` | 14 projects pass |

**Cache wiring proven at the new location:** appending a comment to `libs/ui/styles/_nav-list.scss` made `web:build` re-run (3 of 4 tasks cached, not 4).

**Styling verified by byte-diff rather than by eye.** I built the pre-move state with `--skip-nx-cache` and diffed the whole `dist/apps/web` output against the post-move build: all 232 files identical except `ngsw.json`'s timestamp. Angular inlines component styles into the JS chunks, so identical chunks prove the nav-list CSS is emitted identically for the M3U sidebar, portal rail links, both category views, and the workspace context panel — no rendered difference is possible.

## Release note

Skipped — pure refactor, no user-visible change; hence the `no-release-note` label. (`.scss` under `libs/**` is not auto-exempt from the gate.)

Prettier flags two of the touched files, but those are pre-existing `color-mix` line wraps unrelated to these edits, so they are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
