### PR TITLE
fix(playback): keep Video.js controls on the live MPEG-TS path

### DIFF
--- a/.changes/playback-vjs-live-controls.md
+++ b/.changes/playback-vjs-live-controls.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: playback
+---
+
+Video.js now shows its own control bar (play/pause, seek, volume, quality,
+fullscreen) on Live TV channels. Previously live streams played with no visible
+controls at all, because switching to a live source rebuilt the video element
+and the controls never came back.

--- a/libs/ui/playback/src/lib/vjs-player/vjs-player-setup.spec.ts
+++ b/libs/ui/playback/src/lib/vjs-player/vjs-player-setup.spec.ts
@@ -19,7 +19,27 @@ describe('Video.js player setup', () => {
         expect(createVjsPlayerOptions(options, false, false)).toEqual({
             ...options,
             autoplay: true,
+            controls: true,
         });
+    });
+
+    it('keeps Video.js controls enabled on the raw MPEG-TS legacy path', () => {
+        // player.reset() replaces the tech <video>, so the control bar must
+        // come from the constructor option — a template binding on the
+        // original element cannot survive the swap.
+        expect(
+            createVjsPlayerOptions(
+                { sources: [{ src: 'https://example.test/live.ts' }] },
+                true,
+                false
+            )
+        ).toEqual(
+            expect.objectContaining({
+                sources: [],
+                autoplay: false,
+                controls: true,
+            })
+        );
     });
 
     it('removes duplicate Video.js interaction ownership for shared controls', () => {

--- a/libs/ui/playback/src/lib/vjs-player/vjs-player-setup.ts
+++ b/libs/ui/playback/src/lib/vjs-player/vjs-player-setup.ts
@@ -13,7 +13,12 @@ export function createVjsPlayerOptions(
         ? { ...options, sources: [], autoplay: false }
         : { ...options, autoplay: true };
     if (!sharedControls) {
-        return baseOptions;
+        // Controls must be enabled through the constructor, not a `[controls]`
+        // template binding: `player.reset()` (raw MPEG-TS/live path) replaces
+        // the tech <video> element, and a binding to the original element can
+        // never reach the replacement — Video.js's own control bar lives
+        // outside the tech element and survives the swap.
+        return { ...baseOptions, controls: true };
     }
     return {
         ...baseOptions,

--- a/libs/ui/playback/src/lib/vjs-player/vjs-player.component.html
+++ b/libs/ui/playback/src/lib/vjs-player/vjs-player.component.html
@@ -2,7 +2,6 @@
     <video
         #target
         class="video-js"
-        [controls]="!sharedControls"
         muted
         playsinline
         preload="none"

--- a/libs/ui/playback/src/lib/vjs-player/vjs-player.component.spec.ts
+++ b/libs/ui/playback/src/lib/vjs-player/vjs-player.component.spec.ts
@@ -78,13 +78,16 @@ describe('VjsPlayerComponent', () => {
             expect.any(Element),
             expect.objectContaining({
                 autoplay: true,
+                controls: true,
                 userActions: { hotkeys: true },
                 spatialNavigation: { enabled: true },
             }),
             expect.any(Function)
         );
+        // Native controls stay off: Video.js owns the control bar, and the
+        // bar has to survive the tech-element swap in player.reset().
         expect(fixture.nativeElement.querySelector('video').controls).toBe(
-            true
+            false
         );
         expect(
             fixture.nativeElement.querySelector('app-player-controls')


### PR DESCRIPTION
## Problem

With Video.js selected as the player, Live TV playback (Stalker `itv`, Xtream `live`) showed **no controls at all** — no play/pause, no seek bar, no fullscreen. VOD/series, favorites and recently viewed were fine; ArtPlayer was fine everywhere.

## Root cause

Two parts, both required:

1. `videoJs(...)` runs in `ngOnInit`, **before** Angular applies the `[controls]="!sharedControls"` template binding, and `createVjsPlayerOptions` never passed `controls: true`. Video.js therefore initialized with controls disabled (`vjs-controls-disabled` → `display: none !important` on its control bar) — everywhere. What users actually saw in VOD was the **browser-native** `<video controls>` chrome that the binding enabled one tick later.
2. Live sources take the raw MPEG-TS path, which calls `player.reset()` instead of `player.src()`. `reset()` **replaces the tech `<video>` element**; the Angular binding still points at the disposed original and never re-evaluates, so the replacement element has no native controls either. Result: zero control affordances on live.

## Fix

Enable controls through the Video.js **constructor options** in legacy (non-shared-controls) mode and drop the template binding. The Video.js control bar is a player-level DOM child that survives `loadTech_`, so it persists across resets. Bonus: the `qualitySelectorHls` and `aspectRatioPanel` plugin buttons — which live in that control bar and were invisible until now — become reachable.

Shared-controls mode is unchanged (`controls: false` + `app-player-controls` as before).

## Tests

- `vjs-player-setup.spec.ts`: legacy options now assert `controls: true`; new regression case for the raw MPEG-TS legacy path (fails on the old code).
- `vjs-player.component.spec.ts`: asserts the constructor receives `controls: true` and the tech element keeps native controls off (Video.js owns the bar).
- `pnpm nx test ui-playback` — 92 suites / 902 tests green; `pnpm nx lint ui-playback` green; `pnpm run release:notes:validate` green.

Release note added: `.changes/playback-vjs-live-controls.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)