### PR TITLE
feat(ui): programme details in the live channel context menu

### DIFF
--- a/.changes/ui-program-details-context-menu.md
+++ b/.changes/ui-program-details-context-menu.md
@@ -1,0 +1,9 @@
+---
+type: feature
+area: ui
+---
+
+Right-clicking a live channel now offers "Show program details" in the
+context menu — in the Xtream and Stalker channel sidebars and in the
+favorites and recently-viewed lists — whenever the channel has current
+programme information.

--- a/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.html
+++ b/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.html
@@ -62,6 +62,18 @@
 ></div>
 
 <mat-menu #channelContextMenu="matMenu">
+    @if (contextMenuChannel()?.currentEpgProgram) {
+        <button
+            mat-menu-item
+            data-test-id="program-details-menu-item"
+            (click)="openProgramDetails()"
+        >
+            <mat-icon>event_note</mat-icon>
+            <span>{{
+                'EPG.PROGRAM_DIALOG.SHOW_PROGRAM_DETAILS' | translate
+            }}</span>
+        </button>
+    }
     @if (supportsEpgMapping) {
         <button mat-menu-item (click)="openEpgMapping()">
             <mat-icon>settings_remote</mat-icon>

--- a/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.spec.ts
+++ b/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.spec.ts
@@ -4,6 +4,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateModule } from '@ngx-translate/core';
 import { ChannelDetailsDialogComponent } from '@iptvnator/ui/components';
+import { EpgItemDescriptionComponent } from '@iptvnator/ui/epg';
 import { UnifiedFavoriteChannel } from '@iptvnator/portal/shared/util';
 import { Channel } from '@iptvnator/shared/interfaces';
 import { SettingsStore } from '@iptvnator/services';
@@ -156,6 +157,46 @@ describe('GlobalFavoritesListComponent', () => {
                 width: 'calc(100vw - 32px)',
             })
         );
+    });
+
+    it('opens programme details from the context menu when the row has a current program', async () => {
+        const program = {
+            title: 'Current Show',
+            desc: 'Current description',
+            channel: 'chan-1',
+            start: '2026-04-05 05:30:00',
+            stop: '2026-04-05 06:00:00',
+            category: null,
+        };
+        const row = buildChannel('a', 'Alpha', { tvgId: 'chan-1' });
+        fixture.componentRef.setInput('channels', [row]);
+        fixture.componentRef.setInput(
+            'epgMap',
+            new Map([['chan-1', program as never]])
+        );
+        fixture.detectChanges();
+
+        const enriched = fixture.componentInstance.enrichedChannels()[0];
+        expect(enriched.currentEpgProgram).toBe(program);
+        expect(
+            fixture.componentInstance.hasChannelContextMenu(enriched)
+        ).toBe(true);
+
+        jest.spyOn(
+            fixture.componentInstance.contextMenuTrigger(),
+            'openMenu'
+        ).mockImplementation();
+        fixture.componentInstance.onChannelContextMenu(enriched, {
+            clientX: 24,
+            clientY: 32,
+        } as MouseEvent);
+        await Promise.resolve();
+
+        fixture.componentInstance.openProgramDetails();
+
+        expect(dialog.open).toHaveBeenCalledWith(EpgItemDescriptionComponent, {
+            data: program,
+        });
     });
 
     it('emits recent row removal from the context menu', async () => {

--- a/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.ts
+++ b/libs/portal/shared/ui/src/lib/components/global-favorites-list/global-favorites-list.component.ts
@@ -31,6 +31,7 @@ import {
 } from '@iptvnator/shared/interfaces';
 import { resolveChannelEpgLookupKey } from '@iptvnator/m3u-state';
 import { EpgMappingDialogComponent } from '@iptvnator/ui/components';
+import { EpgItemDescriptionComponent } from '@iptvnator/ui/epg';
 import { EpgRuntimeBridgeService } from '@iptvnator/epg/data-access';
 import {
     DEFAULT_FAVORITES_CHANNEL_SORT_MODE,
@@ -178,14 +179,29 @@ export class GlobalFavoritesListComponent {
         });
     }
 
-    hasChannelContextMenu(channel: UnifiedFavoriteChannel): boolean {
+    hasChannelContextMenu(
+        channel: UnifiedFavoriteChannel & {
+            currentEpgProgram?: EpgProgram | null;
+        }
+    ): boolean {
         return (
             Boolean(channel.m3uChannel) ||
             this.mode() === 'recent' ||
+            Boolean(channel.currentEpgProgram) ||
             (this.supportsEpgMapping &&
                 (channel.xtreamId != null ||
                     Boolean(this.stalkerItemId(channel))))
         );
+    }
+
+    openProgramDetails(): void {
+        const program = this.contextMenuChannel()?.currentEpgProgram;
+        if (!program) {
+            return;
+        }
+
+        this.contextMenuTrigger().closeMenu();
+        this.dialog.open(EpgItemDescriptionComponent, { data: program });
     }
 
     openEpgMapping(): void {

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.html
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.html
@@ -115,7 +115,7 @@
                         [showFavoriteButton]="true"
                         [showProgramInfoButton]="false"
                         [showDetailsContextMenu]="
-                            supportsEpgMapping && !isRadioMode()
+                            hasChannelContextMenu(item) && !isRadioMode()
                         "
                         [isFavorite]="
                             favorites.get(normalizeStalkerEntityId(item.id)) ??
@@ -278,8 +278,22 @@
 ></div>
 
 <mat-menu #channelContextMenu="matMenu">
-    <button mat-menu-item (click)="openEpgMapping()">
-        <mat-icon>settings_remote</mat-icon>
-        <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
-    </button>
+    @if (contextMenuProgram()) {
+        <button
+            mat-menu-item
+            data-test-id="program-details-menu-item"
+            (click)="openProgramDetails()"
+        >
+            <mat-icon>event_note</mat-icon>
+            <span>{{
+                'EPG.PROGRAM_DIALOG.SHOW_PROGRAM_DETAILS' | translate
+            }}</span>
+        </button>
+    }
+    @if (supportsEpgMapping) {
+        <button mat-menu-item (click)="openEpgMapping()">
+            <mat-icon>settings_remote</mat-icon>
+            <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
+        </button>
+    }
 </mat-menu>

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.spec.ts
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.spec.ts
@@ -17,7 +17,11 @@ import {
     ResizableDirective,
 } from '@iptvnator/portal/shared/util';
 import { StalkerStore } from '@iptvnator/portal/stalker/data-access';
-import { EpgListViewComponent, EpgTimelineComponent } from '@iptvnator/ui/epg';
+import {
+    EpgItemDescriptionComponent,
+    EpgListViewComponent,
+    EpgTimelineComponent,
+} from '@iptvnator/ui/epg';
 import {
     AudioPlayerComponent,
     type PlaybackFallbackRequest,
@@ -457,6 +461,35 @@ describe('StalkerLiveStreamLayoutComponent', () => {
         fixture?.destroy();
         localStorage.removeItem(LIVE_EPG_PANEL_STATE_STORAGE_KEY);
         window.electron = originalElectron;
+    });
+
+    it('offers programme details from the row context menu when a preview program exists', () => {
+        fixture.detectChanges();
+
+        const program = {
+            title: 'Current Show',
+            desc: 'Current description',
+            channel: 'stalker-10',
+            start: '2026-04-05 05:30:00',
+            stop: '2026-04-05 06:00:00',
+            category: null,
+        } as never;
+        component.epgPreviewPrograms.set('10', program);
+
+        const rowWithProgram = { id: '10', name: 'Chan 10' } as never;
+        expect(component.hasChannelContextMenu(rowWithProgram)).toBe(true);
+
+        component.contextMenuChannel.set(rowWithProgram);
+        expect(component.contextMenuProgram()).toBe(program);
+
+        component.openProgramDetails();
+
+        const dialog = TestBed.inject(MatDialog) as unknown as {
+            open: jest.Mock;
+        };
+        expect(dialog.open).toHaveBeenCalledWith(EpgItemDescriptionComponent, {
+            data: program,
+        });
     });
 
     it('renders the controlled epg list and removes the load-more button', () => {

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.spec.ts
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.spec.ts
@@ -17,11 +17,7 @@ import {
     ResizableDirective,
 } from '@iptvnator/portal/shared/util';
 import { StalkerStore } from '@iptvnator/portal/stalker/data-access';
-import {
-    EpgItemDescriptionComponent,
-    EpgListViewComponent,
-    EpgTimelineComponent,
-} from '@iptvnator/ui/epg';
+import { EpgListViewComponent, EpgTimelineComponent } from '@iptvnator/ui/epg';
 import {
     AudioPlayerComponent,
     type PlaybackFallbackRequest,
@@ -461,35 +457,6 @@ describe('StalkerLiveStreamLayoutComponent', () => {
         fixture?.destroy();
         localStorage.removeItem(LIVE_EPG_PANEL_STATE_STORAGE_KEY);
         window.electron = originalElectron;
-    });
-
-    it('offers programme details from the row context menu when a preview program exists', () => {
-        fixture.detectChanges();
-
-        const program = {
-            title: 'Current Show',
-            desc: 'Current description',
-            channel: 'stalker-10',
-            start: '2026-04-05 05:30:00',
-            stop: '2026-04-05 06:00:00',
-            category: null,
-        } as never;
-        component.epgPreviewPrograms.set('10', program);
-
-        const rowWithProgram = { id: '10', name: 'Chan 10' } as never;
-        expect(component.hasChannelContextMenu(rowWithProgram)).toBe(true);
-
-        component.contextMenuChannel.set(rowWithProgram);
-        expect(component.contextMenuProgram()).toBe(program);
-
-        component.openProgramDetails();
-
-        const dialog = TestBed.inject(MatDialog) as unknown as {
-            open: jest.Mock;
-        };
-        expect(dialog.open).toHaveBeenCalledWith(EpgItemDescriptionComponent, {
-            data: program,
-        });
     });
 
     it('renders the controlled epg list and removes the load-more button', () => {

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.ts
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.ts
@@ -44,6 +44,7 @@ import {
 } from '@iptvnator/shared/interfaces';
 import {
     EpgDateNavigationDirection,
+    EpgItemDescriptionComponent,
     EpgListViewComponent,
     EpgTimelineComponent,
     getTodayEpgDateKey,
@@ -857,6 +858,37 @@ export class StalkerLiveStreamLayoutComponent implements OnDestroy {
         queueMicrotask(() => {
             this.contextMenuTrigger().openMenu();
         });
+    }
+
+    /** Current preview programme of the row under the context menu. */
+    contextMenuProgram(): EpgProgram | null {
+        const channel = this.contextMenuChannel();
+        if (!channel) {
+            return null;
+        }
+
+        return (
+            this.epgPreviewPrograms.get(normalizeStalkerEntityId(channel.id)) ??
+            null
+        );
+    }
+
+    /** Whether right-click has anything to offer for this row. */
+    hasChannelContextMenu(item: StalkerItvChannel): boolean {
+        return (
+            this.supportsEpgMapping ||
+            this.epgPreviewPrograms.has(normalizeStalkerEntityId(item.id))
+        );
+    }
+
+    openProgramDetails(): void {
+        const program = this.contextMenuProgram();
+        if (!program) {
+            return;
+        }
+
+        this.contextMenuTrigger().closeMenu();
+        this.dialog.open(EpgItemDescriptionComponent, { data: program });
     }
 
     async openEpgMapping(): Promise<void> {

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.ts
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.component.ts
@@ -873,7 +873,12 @@ export class StalkerLiveStreamLayoutComponent implements OnDestroy {
         );
     }
 
-    /** Whether right-click has anything to offer for this row. */
+    /**
+     * Whether right-click has anything to offer for this row. Keys on data
+     * presence rather than runtime capability — but note EPG previews are
+     * currently populated only where `supportsEpg` (Electron), so in the PWA
+     * this stays false until portal EPG previews exist there.
+     */
     hasChannelContextMenu(item: StalkerItvChannel): boolean {
         return (
             this.supportsEpgMapping ||

--- a/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.context-menu.spec.ts
+++ b/libs/portal/stalker/feature/src/lib/stalker-live-stream-layout/stalker-live-stream-layout.context-menu.spec.ts
@@ -1,0 +1,163 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { EpgRuntimeBridgeService } from '@iptvnator/epg/data-access';
+import {
+    LiveLayoutSidebarStateService,
+    PORTAL_PLAYER,
+} from '@iptvnator/portal/shared/util';
+import { StalkerStore } from '@iptvnator/portal/stalker/data-access';
+import {
+    PlaylistsService,
+    RuntimeCapabilitiesService,
+    SettingsStore,
+} from '@iptvnator/services';
+import { EpgItemDescriptionComponent } from '@iptvnator/ui/epg';
+import { ElectronStreamHeadersService } from '@iptvnator/ui/playback';
+import { StalkerLiveStreamLayoutComponent } from './stalker-live-stream-layout.component';
+
+describe('StalkerLiveStreamLayoutComponent row context menu', () => {
+    let fixture: ComponentFixture<StalkerLiveStreamLayoutComponent>;
+    let component: StalkerLiveStreamLayoutComponent;
+    const playlist = signal({ _id: 'playlist-one', title: 'Portal One' });
+    const channels = [
+        {
+            id: '10',
+            cmd: 'ffrt4://itv/10',
+            name: 'Chan 10',
+            o_name: 'Chan 10',
+            logo: 'ten.png',
+        },
+    ];
+    const store = {
+        getSelectedCategoryName: signal('All'),
+        currentPlaylist: playlist,
+        selectedContentType: signal<'itv' | 'radio'>('itv'),
+        selectedCategoryId: signal<string | null>('all'),
+        selectedItvId: signal<string | undefined>(channels[0].id),
+        selectedItem: signal<(typeof channels)[number] | null>(null),
+        itvChannels: signal(channels),
+        radioChannels: signal([]),
+        searchPhrase: signal(''),
+        hasMoreChannels: signal(false),
+        itvFullListActive: signal(false),
+        itvSelectedCategoryFromCache: signal(false),
+        itvFullListLoading: signal(false),
+        itvFullListProgress: signal(null),
+        itvFullChannelList: signal([]),
+        isPaginatedContentLoading: signal(false),
+        selectedItvEpgPrograms: signal([]),
+        bulkItvEpgByChannel: signal({}),
+        isLoadingBulkItvEpg: signal(false),
+        setItvChannels: jest.fn(),
+        setRadioChannels: jest.fn(),
+        setPage: jest.fn(),
+        preloadItvChannels: jest.fn(),
+        applyMappedItvEpg: jest.fn(),
+        clearBulkItvEpgCache: jest.fn(),
+        ensureBulkItvEpg: jest.fn(),
+        fetchChannelEpg: jest.fn(),
+        resolveItvPlayback: jest.fn(),
+        resolveRadioPlayback: jest.fn(),
+        addToFavorites: jest.fn(),
+        removeFromFavorites: jest.fn(),
+        setSelectedItem: jest.fn(),
+    };
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [StalkerLiveStreamLayoutComponent],
+            providers: [
+                { provide: StalkerStore, useValue: store },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: {
+                        supportsEpg: false,
+                        isElectron: false,
+                        supportsEpgMapping: false,
+                    },
+                },
+                {
+                    provide: PlaylistsService,
+                    useValue: { getPortalFavorites: () => of([]) },
+                },
+                {
+                    provide: SettingsStore,
+                    useValue: { openStreamOnDoubleClick: signal(false) },
+                },
+                {
+                    provide: PORTAL_PLAYER,
+                    useValue: {
+                        isEmbeddedPlayer: () => true,
+                        openResolvedPlayback: jest.fn(),
+                    },
+                },
+                {
+                    provide: ElectronStreamHeadersService,
+                    useValue: { apply: jest.fn(), clear: jest.fn() },
+                },
+                {
+                    provide: LiveLayoutSidebarStateService,
+                    useValue: { isCollapsed: signal(false), toggle: jest.fn() },
+                },
+                { provide: EpgRuntimeBridgeService, useValue: {} },
+                { provide: MatDialog, useValue: { open: jest.fn() } },
+                { provide: MatSnackBar, useValue: { open: jest.fn() } },
+                {
+                    provide: TranslateService,
+                    useValue: { instant: (key: string) => key },
+                },
+            ],
+        })
+            .overrideComponent(StalkerLiveStreamLayoutComponent, {
+                set: { template: '' },
+            })
+            .compileComponents();
+        fixture = TestBed.createComponent(StalkerLiveStreamLayoutComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    afterEach(() => fixture.destroy());
+
+    it('offers programme details exactly for rows with a preview program', () => {
+        const program = {
+            title: 'Current Show',
+            desc: 'Current description',
+            channel: 'stalker-10',
+            start: '2026-04-05 05:30:00',
+            stop: '2026-04-05 06:00:00',
+            category: null,
+        } as never;
+        component.epgPreviewPrograms.set('10', program);
+
+        const rowWithProgram = { id: '10', name: 'Chan 10' } as never;
+        const rowWithoutProgram = { id: '11', name: 'Chan 11' } as never;
+        // supportsEpgMapping is false in this harness, so the programme is
+        // the only thing that can justify a context menu.
+        expect(component.hasChannelContextMenu(rowWithProgram)).toBe(true);
+        expect(component.hasChannelContextMenu(rowWithoutProgram)).toBe(false);
+
+        component.contextMenuChannel.set(rowWithProgram);
+        expect(component.contextMenuProgram()).toBe(program);
+
+        // The empty test template renders no menu trigger — stub it so the
+        // action can close the menu it was invoked from.
+        const closeMenu = jest.fn();
+        Object.defineProperty(component, 'contextMenuTrigger', {
+            value: () => ({ closeMenu }),
+        });
+        component.openProgramDetails();
+
+        expect(closeMenu).toHaveBeenCalled();
+        const dialog = TestBed.inject(MatDialog) as unknown as {
+            open: jest.Mock;
+        };
+        expect(dialog.open).toHaveBeenCalledWith(EpgItemDescriptionComponent, {
+            data: program,
+        });
+    });
+});

--- a/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.html
+++ b/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.html
@@ -44,7 +44,7 @@
                 [showEpg]="supportsEpg"
                 [showFavoriteButton]="true"
                 [showProgramInfoButton]="false"
-                [showDetailsContextMenu]="supportsEpgMapping"
+                [showDetailsContextMenu]="hasChannelContextMenu(item)"
                 [isFavorite]="favorites.get(favoriteKeyFor(item)) ?? false"
                 (clicked)="playClicked.emit(item)"
                 (activated)="playbackRequested.emit(item)"
@@ -63,10 +63,24 @@
         ></div>
 
         <mat-menu #channelContextMenu="matMenu">
-            <button mat-menu-item (click)="openEpgMapping()">
-                <mat-icon>settings_remote</mat-icon>
-                <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
-            </button>
+            @if (contextMenuProgram()) {
+                <button
+                    mat-menu-item
+                    data-test-id="program-details-menu-item"
+                    (click)="openProgramDetails()"
+                >
+                    <mat-icon>event_note</mat-icon>
+                    <span>{{
+                        'EPG.PROGRAM_DIALOG.SHOW_PROGRAM_DETAILS' | translate
+                    }}</span>
+                </button>
+            }
+            @if (supportsEpgMapping) {
+                <button mat-menu-item (click)="openEpgMapping()">
+                    <mat-icon>settings_remote</mat-icon>
+                    <span>{{ 'CHANNELS.MAP_EPG' | translate }}</span>
+                </button>
+            }
         </mat-menu>
     } @else {
         <div class="empty-search-state">

--- a/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.spec.ts
+++ b/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.spec.ts
@@ -12,8 +12,10 @@ import {
     FavoritesService,
     XtreamStore,
 } from '@iptvnator/portal/xtream/data-access';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import { ChannelListItemComponent } from '@iptvnator/ui/components';
+import { EpgItemDescriptionComponent } from '@iptvnator/ui/epg';
 import { PortalChannelsListComponent } from './portal-channels-list.component';
 
 function buildEpgItem(params: {
@@ -458,5 +460,47 @@ describe('PortalChannelsListComponent', () => {
             'live'
         );
         expect(fixture.componentInstance.favorites.get('live:253')).toBe(true);
+    });
+
+    it('offers programme details from the row context menu when a preview program exists', () => {
+        const component = fixture.componentInstance;
+        selectedTypeContentLoading.set(false);
+        selectedChannels.set([{ title: 'Cartoon Network', xtream_id: 50 }]);
+        fixture.detectChanges();
+
+        const program = {
+            title: 'Current Show',
+            desc: 'Current description',
+            channel: 'channel-50',
+            start: '2026-04-05 05:30:00',
+            stop: '2026-04-05 06:00:00',
+            category: null,
+        } as never;
+        component.epgPrograms.set(50, program);
+
+        // Without a program (and without EPG-mapping support in this
+        // harness) the row offers no context menu at all.
+        expect(
+            component.hasChannelContextMenu({ xtream_id: 51 })
+        ).toBe(false);
+        expect(
+            component.hasChannelContextMenu({ xtream_id: 50 })
+        ).toBe(true);
+
+        component.contextMenuChannel.set({
+            title: 'Cartoon Network',
+            xtream_id: 50,
+        });
+        expect(component.contextMenuProgram()).toBe(program);
+
+        const dialog = TestBed.inject(MatDialog);
+        const openSpy = jest
+            .spyOn(dialog, 'open')
+            .mockReturnValue({} as MatDialogRef<unknown>);
+        component.openProgramDetails();
+
+        expect(openSpy).toHaveBeenCalledWith(EpgItemDescriptionComponent, {
+            data: program,
+        });
     });
 });

--- a/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.ts
+++ b/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.ts
@@ -37,6 +37,7 @@ import {
     ChannelListSkeletonComponent,
     EpgMappingDialogComponent,
 } from '@iptvnator/ui/components';
+import { EpgItemDescriptionComponent } from '@iptvnator/ui/epg';
 import {
     PortalChannelSortMode,
     sortPortalChannelItems,
@@ -499,6 +500,31 @@ export class PortalChannelsListComponent implements AfterViewInit, OnDestroy {
         queueMicrotask(() => {
             this.contextMenuTrigger().openMenu();
         });
+    }
+
+    /** Current preview programme of the row under the context menu. */
+    contextMenuProgram(): EpgProgram | null {
+        const channel = this.contextMenuChannel();
+        if (!channel) {
+            return null;
+        }
+
+        return this.epgPrograms.get(channel.xtream_id) ?? null;
+    }
+
+    /** Whether right-click has anything to offer for this row. */
+    hasChannelContextMenu(item: XtreamChannelListItem): boolean {
+        return this.supportsEpgMapping || this.epgPrograms.has(item.xtream_id);
+    }
+
+    openProgramDetails(): void {
+        const program = this.contextMenuProgram();
+        if (!program) {
+            return;
+        }
+
+        this.contextMenuTrigger().closeMenu();
+        this.dialog.open(EpgItemDescriptionComponent, { data: program });
     }
 
     openEpgMapping(): void {

--- a/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.ts
+++ b/libs/portal/xtream/feature/src/lib/portal-channels-list/portal-channels-list.component.ts
@@ -512,7 +512,12 @@ export class PortalChannelsListComponent implements AfterViewInit, OnDestroy {
         return this.epgPrograms.get(channel.xtream_id) ?? null;
     }
 
-    /** Whether right-click has anything to offer for this row. */
+    /**
+     * Whether right-click has anything to offer for this row. Keys on data
+     * presence rather than runtime capability — but note EPG previews are
+     * currently populated only where `supportsEpg` (Electron), so in the PWA
+     * this stays false until portal EPG previews exist there.
+     */
     hasChannelContextMenu(item: XtreamChannelListItem): boolean {
         return this.supportsEpgMapping || this.epgPrograms.has(item.xtream_id);
     }


### PR DESCRIPTION
Follow-up to the discussion in #1341: the Xtream and Stalker live sidebars intentionally have no per-row (i) button (the current programme is already shown inline), but that left no way to read a programme description without switching channels. Instead of adding a third button to every row, the programme details are now reachable through the row context menu, consistently across live lists.

## What changed

- **Xtream live sidebar** (`portal-channels-list`) and **Stalker ITV sidebar** (`stalker-live-stream-layout`): right-click now offers **"Show program details"** (opens the existing `EpgItemDescriptionComponent` dialog) whenever the row has a current preview programme.
- **Favorites / recently-viewed lists** (`global-favorites-list`, used by the portal favorites/recent tabs and global favorites): the same item appears when the row has a current programme.
- The context-menu availability gate now keys on what the menu can actually offer (mapping support **or** a current programme) instead of EPG-mapping support alone. Note this is future-proofing, not PWA support: EPG previews are currently populated only where `supportsEpg` (Electron), so in the PWA the maps stay empty and the item does not appear — behavior there is unchanged. If portal EPG previews ever land in the PWA, the menu lights up automatically. "Map EPG" itself stays Electron-gated.
- Reuses the existing `EPG.PROGRAM_DIALOG.SHOW_PROGRAM_DETAILS` key — no new translations needed. Icon is `event_note` to avoid clashing with the M3U "Show details" (channel metadata) item that already uses `info` in the favorites menu.

## Rationale

The sidebar row already shows the programme title, time, and progress inline, and selecting a channel opens the full EPG timeline — a third per-row button would add action density to a high-frequency zapping surface and appear/disappear per row depending on EPG coverage. The context menu gives consistent access everywhere with zero visual noise.

## Tests

- `portal-channels-list` spec: menu offered only when a programme exists (no mapping support in harness), programme lookup, dialog open.
- `stalker-live-stream-layout` spec: programme lookup and dialog open via the preview-programme map.
- `global-favorites-list` spec: enriched-row programme flows into the menu and opens the dialog.
- All three suites green; lint clean; `nx build web` (template typecheck) passes; release note added (`release:notes:validate` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)