### PR TITLE
fix(pwa): tolerate broken IPv6 routes and surface provider error codes

### DIFF
--- a/.changes/pwa-ipv6-ipv4-fallback.md
+++ b/.changes/pwa-ipv6-ipv4-fallback.md
@@ -1,0 +1,11 @@
+---
+type: fix
+area: pwa
+issues: [1400]
+---
+
+The self-hosted web backend now gives each provider connection attempt enough
+time to fall back from an unreachable IPv6 route to working IPv4 — common
+behind VPN containers like Gluetun — instead of failing with a bare
+"Bad Gateway". Provider errors now name the underlying network code (for
+example ETIMEDOUT) in the app and in the container logs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,7 @@ This is an Nx monorepo with the following structure:
 
 - **apps/web** - Angular application (frontend, shared by Electron and PWA)
 - **apps/electron-backend** - Electron main process
-- **apps/web-backend** - HTTP backend for the self-hosted PWA (`/parse`, `/parse-xml`, `/xtream`, `/stalker` CORS proxy endpoints)
+- **apps/web-backend** - HTTP backend for the self-hosted PWA (`/parse`, `/parse-xml`, `/xtream`, `/stalker` CORS proxy endpoints). At startup it raises Node's happy-eyeballs per-attempt connection timeout to 2500 ms (`network-family-autoselection.ts`) so dual-stack provider hostnames fall back to IPv4 behind IPv6-less VPN/Docker networks; an explicit `--network-family-autoselection-attempt-timeout` passed via `NODE_OPTIONS`/CLI always wins. Outbound provider failures are logged hostname-only with the underlying Node error codes and return the primary code in the error body (`provider-error.ts`) — the proxied URL query carries credentials and must never be logged
 - **apps/remote-control-web** - Mobile remote-control web app served by the Electron backend
 - **apps/web-e2e** - Playwright E2E tests against the web app
 - **apps/electron-backend-e2e** - Playwright E2E tests against the Electron app

--- a/apps/web-backend/src/app/network-family-autoselection.spec.ts
+++ b/apps/web-backend/src/app/network-family-autoselection.spec.ts
@@ -1,0 +1,107 @@
+import net from 'node:net';
+import {
+    applyDefaultAutoSelectFamilyAttemptTimeout,
+    AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG,
+    DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS,
+    hasExplicitAttemptTimeoutFlag,
+} from './network-family-autoselection';
+
+describe('network family autoselection tuning', () => {
+    it('raises the attempt timeout when the operator set nothing', () => {
+        const setAttemptTimeout = jest.fn();
+
+        const applied = applyDefaultAutoSelectFamilyAttemptTimeout({
+            execArgv: [],
+            nodeOptions: '',
+            setAttemptTimeout,
+        });
+
+        expect(applied).toBe(DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS);
+        expect(setAttemptTimeout).toHaveBeenCalledWith(
+            DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS
+        );
+    });
+
+    it('keeps an explicit --network-family-autoselection-attempt-timeout=<ms> flag', () => {
+        const setAttemptTimeout = jest.fn();
+
+        const applied = applyDefaultAutoSelectFamilyAttemptTimeout({
+            execArgv: [`${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG}=1000`],
+            nodeOptions: '',
+            setAttemptTimeout,
+        });
+
+        expect(applied).toBeNull();
+        expect(setAttemptTimeout).not.toHaveBeenCalled();
+    });
+
+    it('keeps the flag when it is passed as a separate argument', () => {
+        const setAttemptTimeout = jest.fn();
+
+        const applied = applyDefaultAutoSelectFamilyAttemptTimeout({
+            execArgv: [AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG, '1000'],
+            nodeOptions: '',
+            setAttemptTimeout,
+        });
+
+        expect(applied).toBeNull();
+        expect(setAttemptTimeout).not.toHaveBeenCalled();
+    });
+
+    it('keeps the flag when it arrives through NODE_OPTIONS', () => {
+        const setAttemptTimeout = jest.fn();
+
+        const applied = applyDefaultAutoSelectFamilyAttemptTimeout({
+            execArgv: [],
+            nodeOptions: `--dns-result-order=ipv4first ${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG}=500`,
+            setAttemptTimeout,
+        });
+
+        expect(applied).toBeNull();
+        expect(setAttemptTimeout).not.toHaveBeenCalled();
+    });
+
+    it('detects the flag in both argv shapes and NODE_OPTIONS', () => {
+        expect(
+            hasExplicitAttemptTimeoutFlag(
+                [`${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG}=250`],
+                ''
+            )
+        ).toBe(true);
+        expect(
+            hasExplicitAttemptTimeoutFlag(
+                [AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG],
+                ''
+            )
+        ).toBe(true);
+        expect(
+            hasExplicitAttemptTimeoutFlag(
+                [],
+                `${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG} 250`
+            )
+        ).toBe(true);
+        expect(
+            hasExplicitAttemptTimeoutFlag(
+                ['--no-network-family-autoselection'],
+                '--dns-result-order=ipv4first'
+            )
+        ).toBe(false);
+    });
+
+    it('applies the timeout to the real net default when nothing is injected', () => {
+        const original = net.getDefaultAutoSelectFamilyAttemptTimeout();
+        try {
+            const applied = applyDefaultAutoSelectFamilyAttemptTimeout({
+                execArgv: [],
+                nodeOptions: '',
+            });
+
+            expect(applied).toBe(DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS);
+            expect(net.getDefaultAutoSelectFamilyAttemptTimeout()).toBe(
+                DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS
+            );
+        } finally {
+            net.setDefaultAutoSelectFamilyAttemptTimeout(original);
+        }
+    });
+});

--- a/apps/web-backend/src/app/network-family-autoselection.spec.ts
+++ b/apps/web-backend/src/app/network-family-autoselection.spec.ts
@@ -113,6 +113,32 @@ describe('network family autoselection tuning', () => {
         ).toBe(false);
     });
 
+    it('ignores the flag text embedded in another option value or name', () => {
+        const setAttemptTimeout = jest.fn();
+
+        // The flag string inside another option's VALUE is not the option.
+        const applied = applyDefaultAutoSelectFamilyAttemptTimeout({
+            execArgv: [],
+            nodeOptions:
+                '--title=--network-family-autoselection-attempt-timeout-worker',
+            setAttemptTimeout,
+        });
+
+        expect(applied).toBe(DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS);
+        expect(setAttemptTimeout).toHaveBeenCalledWith(
+            DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS
+        );
+
+        // A longer option NAME that merely starts with the flag text is a
+        // different option.
+        expect(
+            hasExplicitAttemptTimeoutFlag(
+                ['--network-family-autoselection-attempt-timeout-worker=5'],
+                ''
+            )
+        ).toBe(false);
+    });
+
     it('applies the timeout to the real net default when nothing is injected', () => {
         const original = net.getDefaultAutoSelectFamilyAttemptTimeout();
         try {

--- a/apps/web-backend/src/app/network-family-autoselection.spec.ts
+++ b/apps/web-backend/src/app/network-family-autoselection.spec.ts
@@ -61,6 +61,25 @@ describe('network family autoselection tuning', () => {
         expect(setAttemptTimeout).not.toHaveBeenCalled();
     });
 
+    it('keeps the underscore spelling Node also accepts', () => {
+        const setAttemptTimeout = jest.fn();
+
+        const viaArgv = applyDefaultAutoSelectFamilyAttemptTimeout({
+            execArgv: ['--network_family_autoselection_attempt_timeout=500'],
+            nodeOptions: '',
+            setAttemptTimeout,
+        });
+        const viaNodeOptions = applyDefaultAutoSelectFamilyAttemptTimeout({
+            execArgv: [],
+            nodeOptions: '--network_family_autoselection_attempt_timeout=700',
+            setAttemptTimeout,
+        });
+
+        expect(viaArgv).toBeNull();
+        expect(viaNodeOptions).toBeNull();
+        expect(setAttemptTimeout).not.toHaveBeenCalled();
+    });
+
     it('detects the flag in both argv shapes and NODE_OPTIONS', () => {
         expect(
             hasExplicitAttemptTimeoutFlag(
@@ -71,6 +90,12 @@ describe('network family autoselection tuning', () => {
         expect(
             hasExplicitAttemptTimeoutFlag(
                 [AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG],
+                ''
+            )
+        ).toBe(true);
+        expect(
+            hasExplicitAttemptTimeoutFlag(
+                ['--network_family-autoselection_attempt-timeout=250'],
                 ''
             )
         ).toBe(true);

--- a/apps/web-backend/src/app/network-family-autoselection.ts
+++ b/apps/web-backend/src/app/network-family-autoselection.ts
@@ -23,6 +23,16 @@ export interface ApplyAutoSelectFamilyAttemptTimeoutOptions {
 }
 
 /**
+ * Node accepts underscores interchangeably with dashes in flag names
+ * (`process.allowedNodeEnvironmentFlags` semantics), so
+ * `--network_family_autoselection_attempt_timeout=500` is just as explicit
+ * as the canonical spelling and must be honored too.
+ */
+function normalizeFlagSpelling(value: string): string {
+    return value.replace(/_/g, '-');
+}
+
+/**
  * An operator who tunes the timeout through Node's own CLI flag (directly or
  * via `NODE_OPTIONS`) must keep the final word: the flag is applied before
  * user code runs, so overwriting it here would silently undo their setting.
@@ -32,11 +42,18 @@ export function hasExplicitAttemptTimeoutFlag(
     nodeOptions: string
 ): boolean {
     return (
-        execArgv.some(
-            (arg) =>
-                arg === AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG ||
-                arg.startsWith(`${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG}=`)
-        ) || nodeOptions.includes(AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG)
+        execArgv.some((arg) => {
+            const normalized = normalizeFlagSpelling(arg);
+            return (
+                normalized === AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG ||
+                normalized.startsWith(
+                    `${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG}=`
+                )
+            );
+        }) ||
+        normalizeFlagSpelling(nodeOptions).includes(
+            AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG
+        )
     );
 }
 

--- a/apps/web-backend/src/app/network-family-autoselection.ts
+++ b/apps/web-backend/src/app/network-family-autoselection.ts
@@ -33,6 +33,20 @@ function normalizeFlagSpelling(value: string): string {
 }
 
 /**
+ * The flag must match as a complete option token — a raw substring search
+ * would also fire on the flag text embedded in another option's value
+ * (e.g. `--title=--network-family-autoselection-attempt-timeout-worker`)
+ * and silently skip the 2500 ms default.
+ */
+function matchesAttemptTimeoutFlag(token: string): boolean {
+    const normalized = normalizeFlagSpelling(token);
+    return (
+        normalized === AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG ||
+        normalized.startsWith(`${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG}=`)
+    );
+}
+
+/**
  * An operator who tunes the timeout through Node's own CLI flag (directly or
  * via `NODE_OPTIONS`) must keep the final word: the flag is applied before
  * user code runs, so overwriting it here would silently undo their setting.
@@ -42,18 +56,8 @@ export function hasExplicitAttemptTimeoutFlag(
     nodeOptions: string
 ): boolean {
     return (
-        execArgv.some((arg) => {
-            const normalized = normalizeFlagSpelling(arg);
-            return (
-                normalized === AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG ||
-                normalized.startsWith(
-                    `${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG}=`
-                )
-            );
-        }) ||
-        normalizeFlagSpelling(nodeOptions).includes(
-            AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG
-        )
+        execArgv.some(matchesAttemptTimeoutFlag) ||
+        nodeOptions.split(/\s+/).some(matchesAttemptTimeoutFlag)
     );
 }
 

--- a/apps/web-backend/src/app/network-family-autoselection.ts
+++ b/apps/web-backend/src/app/network-family-autoselection.ts
@@ -1,0 +1,67 @@
+import net from 'node:net';
+
+/**
+ * Node enables "Happy Eyeballs" connection racing (`autoSelectFamily`) by
+ * default and gives every address attempt only 250 ms before moving on to
+ * the next one. Behind VPN or Docker networks a perfectly working IPv4
+ * handshake routinely needs more than that, so a dual-stack provider
+ * hostname with an unreachable IPv6 route exhausts all attempts
+ * (`ENETUNREACH` on IPv6, `ETIMEDOUT` on IPv4) and surfaces as a bare
+ * 502 (#1400). Raising the per-attempt budget keeps the IPv6→IPv4 fallback
+ * intact — unlike `--no-network-family-autoselection`, which would break
+ * IPv6-only deployments — while tolerating slow links.
+ */
+export const DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 2500;
+
+export const AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG =
+    '--network-family-autoselection-attempt-timeout';
+
+export interface ApplyAutoSelectFamilyAttemptTimeoutOptions {
+    readonly execArgv?: readonly string[];
+    readonly nodeOptions?: string;
+    readonly setAttemptTimeout?: (timeoutMs: number) => void;
+}
+
+/**
+ * An operator who tunes the timeout through Node's own CLI flag (directly or
+ * via `NODE_OPTIONS`) must keep the final word: the flag is applied before
+ * user code runs, so overwriting it here would silently undo their setting.
+ */
+export function hasExplicitAttemptTimeoutFlag(
+    execArgv: readonly string[],
+    nodeOptions: string
+): boolean {
+    return (
+        execArgv.some(
+            (arg) =>
+                arg === AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG ||
+                arg.startsWith(`${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG}=`)
+        ) || nodeOptions.includes(AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG)
+    );
+}
+
+/**
+ * Raises the process-wide happy-eyeballs attempt timeout unless the operator
+ * already set one explicitly. Returns the applied value, or `null` when the
+ * explicit flag won (or the running Node build lacks the setter).
+ */
+export function applyDefaultAutoSelectFamilyAttemptTimeout(
+    options: ApplyAutoSelectFamilyAttemptTimeoutOptions = {}
+): number | null {
+    const execArgv = options.execArgv ?? process.execArgv;
+    const nodeOptions =
+        options.nodeOptions ?? process.env['NODE_OPTIONS'] ?? '';
+    if (hasExplicitAttemptTimeoutFlag(execArgv, nodeOptions)) {
+        return null;
+    }
+
+    const setAttemptTimeout =
+        options.setAttemptTimeout ??
+        net.setDefaultAutoSelectFamilyAttemptTimeout;
+    if (typeof setAttemptTimeout !== 'function') {
+        return null;
+    }
+
+    setAttemptTimeout(DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS);
+    return DEFAULT_AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS;
+}

--- a/apps/web-backend/src/app/provider-error.spec.ts
+++ b/apps/web-backend/src/app/provider-error.spec.ts
@@ -1,0 +1,156 @@
+import {
+    collectProviderErrorCodes,
+    logProviderRequestFailure,
+    normalizeProviderError,
+} from './provider-error';
+
+function errorWithCode(message: string, code: string): Error {
+    return Object.assign(new Error(message), { code });
+}
+
+describe('collectProviderErrorCodes', () => {
+    it('collects the aggregate code and the per-address member codes', () => {
+        const aggregate = Object.assign(
+            new AggregateError([
+                errorWithCode('connect ETIMEDOUT 104.21.0.1:80', 'ETIMEDOUT'),
+                errorWithCode(
+                    'connect ENETUNREACH 2606:4700::1:80',
+                    'ENETUNREACH'
+                ),
+            ]),
+            { code: 'ETIMEDOUT' }
+        );
+
+        expect(collectProviderErrorCodes(aggregate)).toEqual([
+            'ETIMEDOUT',
+            'ENETUNREACH',
+        ]);
+    });
+
+    it('walks the cause chain', () => {
+        const wrapped = new Error('request failed', {
+            cause: errorWithCode('getaddrinfo ENOTFOUND host', 'ENOTFOUND'),
+        });
+
+        expect(collectProviderErrorCodes(wrapped)).toEqual(['ENOTFOUND']);
+    });
+
+    it('survives cyclic error graphs', () => {
+        const first = errorWithCode('first', 'ECONNRESET') as Error & {
+            cause?: unknown;
+        };
+        const second = new Error('second', { cause: first });
+        first.cause = second;
+
+        expect(collectProviderErrorCodes(second)).toEqual(['ECONNRESET']);
+    });
+
+    it('ignores non-string and empty codes', () => {
+        expect(
+            collectProviderErrorCodes(
+                Object.assign(new Error('numeric'), { code: 502 })
+            )
+        ).toEqual([]);
+        expect(
+            collectProviderErrorCodes(
+                Object.assign(new Error('empty'), { code: '' })
+            )
+        ).toEqual([]);
+        expect(collectProviderErrorCodes(undefined)).toEqual([]);
+        expect(collectProviderErrorCodes('ETIMEDOUT')).toEqual([]);
+    });
+});
+
+describe('normalizeProviderError', () => {
+    it('keeps the HTTP response status and statusText untouched', () => {
+        const httpError = Object.assign(new Error('Forbidden'), {
+            code: 'ERR_BAD_REQUEST',
+            response: { status: 403, statusText: 'Forbidden' },
+        });
+
+        expect(normalizeProviderError(httpError)).toEqual({
+            message: 'Forbidden',
+            status: 403,
+        });
+    });
+
+    it('keeps a statusText-only response on the HTTP branch', () => {
+        const partial = Object.assign(new Error('partial'), {
+            response: { statusText: 'Gateway Timeout' },
+        });
+
+        expect(normalizeProviderError(partial)).toEqual({
+            message: 'Gateway Timeout',
+            status: 502,
+        });
+    });
+
+    it('names the network code in message and body for non-HTTP failures', () => {
+        expect(
+            normalizeProviderError(errorWithCode('timeout', 'ETIMEDOUT'))
+        ).toEqual({
+            message: 'Bad Gateway (ETIMEDOUT)',
+            status: 502,
+            code: 'ETIMEDOUT',
+        });
+    });
+
+    it('falls back to a bare bad gateway when no code exists', () => {
+        expect(normalizeProviderError(new Error('boom'))).toEqual({
+            message: 'Bad Gateway',
+            status: 502,
+        });
+    });
+});
+
+describe('logProviderRequestFailure', () => {
+    it('logs hostname and codes but never the URL query string', () => {
+        const logger = jest.fn();
+
+        logProviderRequestFailure({
+            error: errorWithCode('timeout', 'ETIMEDOUT'),
+            route: '/xtream',
+            url: 'http://provider.example/player_api.php?username=user&password=pass',
+            logger,
+        });
+
+        expect(logger).toHaveBeenCalledTimes(1);
+        const line = logger.mock.calls[0][0] as string;
+        expect(line).toContain('/xtream');
+        expect(line).toContain('provider.example');
+        expect(line).toContain('ETIMEDOUT');
+        expect(line).not.toContain('username');
+        expect(line).not.toContain('password');
+        expect(line).not.toContain('player_api.php');
+    });
+
+    it('describes HTTP failures by status instead of codes', () => {
+        const logger = jest.fn();
+
+        logProviderRequestFailure({
+            error: Object.assign(new Error('Forbidden'), {
+                response: { status: 403, statusText: 'Forbidden' },
+            }),
+            route: '/stalker',
+            url: new URL('http://portal.example/portal.php'),
+            logger,
+        });
+
+        expect(logger.mock.calls[0][0]).toContain('HTTP 403 Forbidden');
+    });
+
+    it('tolerates unparseable URLs and codeless errors', () => {
+        const logger = jest.fn();
+
+        logProviderRequestFailure({
+            error: new Error('boom'),
+            route: '/parse',
+            url: 'not a url',
+            logger,
+        });
+
+        const line = logger.mock.calls[0][0] as string;
+        expect(line).toContain('<invalid url>');
+        expect(line).toContain('unknown network error');
+    });
+});

--- a/apps/web-backend/src/app/provider-error.spec.ts
+++ b/apps/web-backend/src/app/provider-error.spec.ts
@@ -124,19 +124,43 @@ describe('logProviderRequestFailure', () => {
         expect(line).not.toContain('player_api.php');
     });
 
-    it('describes HTTP failures by status instead of codes', () => {
+    it('describes HTTP failures by numeric status only — the reason phrase is provider-controlled', () => {
         const logger = jest.fn();
 
         logProviderRequestFailure({
-            error: Object.assign(new Error('Forbidden'), {
-                response: { status: 403, statusText: 'Forbidden' },
+            error: Object.assign(new Error('Unauthorized'), {
+                response: {
+                    status: 401,
+                    statusText:
+                        'Unauthorized username=alice&password=secret-pass',
+                },
             }),
             route: '/stalker',
             url: new URL('http://portal.example/portal.php'),
             logger,
         });
 
-        expect(logger.mock.calls[0][0]).toContain('HTTP 403 Forbidden');
+        const line = logger.mock.calls[0][0] as string;
+        expect(line).toContain('HTTP 401');
+        expect(line).not.toContain('alice');
+        expect(line).not.toContain('secret-pass');
+    });
+
+    it('logs a generic HTTP error for a statusText-only response', () => {
+        const logger = jest.fn();
+
+        logProviderRequestFailure({
+            error: Object.assign(new Error('partial'), {
+                response: { statusText: 'Gateway Timeout' },
+            }),
+            route: '/stalker',
+            url: new URL('http://portal.example/portal.php'),
+            logger,
+        });
+
+        const line = logger.mock.calls[0][0] as string;
+        expect(line).toContain('HTTP error');
+        expect(line).not.toContain('Gateway Timeout');
     });
 
     it('tolerates unparseable URLs and codeless errors', () => {

--- a/apps/web-backend/src/app/provider-error.ts
+++ b/apps/web-backend/src/app/provider-error.ts
@@ -1,0 +1,133 @@
+/**
+ * Provider-facing error normalization for the web backend proxy routes.
+ *
+ * Outbound provider failures used to collapse into a bare `502 Bad Gateway`,
+ * hiding the network error codes (`ETIMEDOUT`, `ENETUNREACH`, ...) that
+ * explain what actually went wrong (#1400). These helpers surface those codes
+ * in the JSON error body and in a server-side log line. The log line carries
+ * only the provider hostname — never the full URL, whose query string
+ * routinely holds Xtream credentials.
+ */
+
+export interface ProviderError extends Error {
+    readonly code?: unknown;
+    readonly cause?: unknown;
+    readonly errors?: unknown;
+    readonly response?: {
+        readonly status?: number;
+        readonly statusText?: string;
+    };
+}
+
+export interface NormalizedProviderError {
+    readonly message: string;
+    readonly status: number;
+    readonly code?: string;
+}
+
+const MAX_COLLECTED_CODES = 5;
+const MAX_TRAVERSAL_DEPTH = 4;
+
+/**
+ * Collects the `code` properties of an error, its `cause` chain, and any
+ * `AggregateError` members — Node's happy-eyeballs failure is an
+ * `AggregateError` whose members carry the per-address codes that tell the
+ * IPv6-vs-IPv4 story. Bounded so a hostile or cyclic error graph cannot spin.
+ */
+export function collectProviderErrorCodes(error: unknown): string[] {
+    const codes: string[] = [];
+    visitErrorNode(error, 0, codes, new Set());
+    return codes;
+}
+
+function visitErrorNode(
+    error: unknown,
+    depth: number,
+    codes: string[],
+    seen: Set<unknown>
+): void {
+    if (
+        !error ||
+        typeof error !== 'object' ||
+        depth > MAX_TRAVERSAL_DEPTH ||
+        seen.has(error) ||
+        codes.length >= MAX_COLLECTED_CODES
+    ) {
+        return;
+    }
+    seen.add(error);
+
+    const candidate = error as ProviderError;
+    if (
+        typeof candidate.code === 'string' &&
+        candidate.code.length > 0 &&
+        !codes.includes(candidate.code)
+    ) {
+        codes.push(candidate.code);
+    }
+
+    if (Array.isArray(candidate.errors)) {
+        for (const nested of candidate.errors) {
+            visitErrorNode(nested, depth + 1, codes, seen);
+        }
+    }
+
+    visitErrorNode(candidate.cause, depth + 1, codes, seen);
+}
+
+export function normalizeProviderError(
+    error: unknown
+): NormalizedProviderError {
+    const providerError = error as ProviderError | null | undefined;
+    const response = providerError?.response;
+    if (
+        response &&
+        (response.status !== undefined || response.statusText !== undefined)
+    ) {
+        return {
+            message: response.statusText ?? 'Bad Gateway',
+            status: response.status ?? 502,
+        };
+    }
+
+    const code = collectProviderErrorCodes(error)[0];
+    return {
+        message: code ? `Bad Gateway (${code})` : 'Bad Gateway',
+        status: 502,
+        ...(code ? { code } : {}),
+    };
+}
+
+export function logProviderRequestFailure(options: {
+    readonly error: unknown;
+    readonly route: string;
+    readonly url: URL | string;
+    readonly logger?: (message: string) => void;
+}): void {
+    const log = options.logger ?? console.error;
+    log(
+        `[web-backend] ${options.route} request to ${safeHostname(options.url)} failed: ${describeProviderFailure(options.error)}`
+    );
+}
+
+function describeProviderFailure(error: unknown): string {
+    const providerError = error as ProviderError | null | undefined;
+    const response = providerError?.response;
+    if (
+        response &&
+        (response.status !== undefined || response.statusText !== undefined)
+    ) {
+        return `HTTP ${response.status ?? '?'} ${response.statusText ?? ''}`.trim();
+    }
+
+    const codes = collectProviderErrorCodes(error);
+    return codes.length > 0 ? codes.join(', ') : 'unknown network error';
+}
+
+function safeHostname(url: URL | string): string {
+    try {
+        return (url instanceof URL ? url : new URL(url)).hostname;
+    } catch {
+        return '<invalid url>';
+    }
+}

--- a/apps/web-backend/src/app/provider-error.ts
+++ b/apps/web-backend/src/app/provider-error.ts
@@ -117,7 +117,13 @@ function describeProviderFailure(error: unknown): string {
         response &&
         (response.status !== undefined || response.statusText !== undefined)
     ) {
-        return `HTTP ${response.status ?? '?'} ${response.statusText ?? ''}`.trim();
+        // The reason phrase is provider-controlled text and can echo the
+        // credential-bearing request URL; only the numeric status may be
+        // logged. (The statusText still reaches the client response body,
+        // which the provider could see anyway.)
+        return response.status !== undefined
+            ? `HTTP ${response.status}`
+            : 'HTTP error';
     }
 
     const codes = collectProviderErrorCodes(error);

--- a/apps/web-backend/src/app/web-backend-app.spec.ts
+++ b/apps/web-backend/src/app/web-backend-app.spec.ts
@@ -46,6 +46,10 @@ class StubHttpClient implements WebBackendHttpClient {
         this.queuedResponses.push({ data: null, error: new Error(message) });
     }
 
+    queueNetworkError(error: Error): void {
+        this.queuedResponses.push({ data: null, error });
+    }
+
     async get<T>(
         url: string,
         options: WebBackendHttpGetOptions = {}
@@ -496,9 +500,9 @@ https://stream.example/live.m3u8`);
                     `${baseUrl}/stalker?targetId=${targetId}&action=get_categories`
                 );
 
-                expect(
-                    httpClient.requests[0].headers
-                ).not.toHaveProperty('Cookie');
+                expect(httpClient.requests[0].headers).not.toHaveProperty(
+                    'Cookie'
+                );
                 expect(httpClient.requests[0].headers).toMatchObject(
                     STALKER_IDENTITY_HEADERS
                 );
@@ -586,7 +590,9 @@ https://stream.example/live.m3u8`);
                     `${baseUrl}/stalker?targetId=${bareQueryTarget}&action=create_link&cmd=${encodeURIComponent('/media/2.mpg')}`
                 );
 
-                expect(httpClient.requests.map((request) => request.url)).toEqual([
+                expect(
+                    httpClient.requests.map((request) => request.url)
+                ).toEqual([
                     'http://stalker.example/portal.php?action=create_link&cmd=/media/1.mpg&JsHttpRequest=1-xml',
                     'http://stalker.example/load.php?action=create_link&cmd=/media/2.mpg&JsHttpRequest=1-xml',
                 ]);
@@ -644,6 +650,139 @@ https://stream.example/live.m3u8`);
                 });
             }
         );
+    });
+
+    it('surfaces happy-eyeballs network codes on xtream failures', async () => {
+        const httpClient = new StubHttpClient();
+        httpClient.queueNetworkError(
+            Object.assign(
+                new AggregateError([
+                    Object.assign(
+                        new Error('connect ETIMEDOUT 104.21.0.1:80'),
+                        { code: 'ETIMEDOUT' }
+                    ),
+                    Object.assign(
+                        new Error('connect ENETUNREACH 2606:4700::1:80'),
+                        { code: 'ENETUNREACH' }
+                    ),
+                ]),
+                { code: 'ETIMEDOUT' }
+            )
+        );
+        const errorSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        try {
+            await withServer(
+                createWebBackendApp({
+                    httpClient,
+                    resolveHostname: resolvePublicHost,
+                }),
+                async (baseUrl) => {
+                    const targetId = await registerProviderTarget(
+                        baseUrl,
+                        'http://xtream.example'
+                    );
+                    const response = await fetch(
+                        `${baseUrl}/xtream?targetId=${targetId}&action=get_account_info&username=secret-user&password=secret-pass`
+                    );
+
+                    await expect(response.json()).resolves.toEqual({
+                        message: 'Bad Gateway (ETIMEDOUT)',
+                        status: 502,
+                        code: 'ETIMEDOUT',
+                    });
+                }
+            );
+
+            expect(errorSpy).toHaveBeenCalledTimes(1);
+            const logLine = errorSpy.mock.calls[0][0] as string;
+            expect(logLine).toContain('/xtream');
+            expect(logLine).toContain('xtream.example');
+            expect(logLine).toContain('ETIMEDOUT, ENETUNREACH');
+            expect(logLine).not.toContain('secret-user');
+            expect(logLine).not.toContain('secret-pass');
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+
+    it('surfaces network error codes on stalker failures', async () => {
+        const httpClient = new StubHttpClient();
+        httpClient.queueNetworkError(
+            Object.assign(new Error('connect ENETUNREACH'), {
+                code: 'ENETUNREACH',
+            })
+        );
+        const errorSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        try {
+            await withServer(
+                createWebBackendApp({
+                    httpClient,
+                    resolveHostname: resolvePublicHost,
+                }),
+                async (baseUrl) => {
+                    const targetId = await registerProviderTarget(
+                        baseUrl,
+                        'http://stalker.example/portal.php'
+                    );
+                    const response = await fetch(
+                        `${baseUrl}/stalker?targetId=${targetId}&action=handshake`
+                    );
+
+                    await expect(response.json()).resolves.toEqual({
+                        message: 'Bad Gateway (ENETUNREACH)',
+                        status: 502,
+                        code: 'ENETUNREACH',
+                    });
+                }
+            );
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+
+    it('surfaces network error codes on playlist parse failures', async () => {
+        const httpClient = new StubHttpClient();
+        httpClient.queueNetworkError(
+            Object.assign(new Error('connect ETIMEDOUT'), {
+                code: 'ETIMEDOUT',
+            })
+        );
+        const errorSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        try {
+            await withServer(
+                createWebBackendApp({
+                    httpClient,
+                    resolveHostname: resolvePublicHost,
+                }),
+                async (baseUrl) => {
+                    const targetId = await registerProviderTarget(
+                        baseUrl,
+                        'https://provider.example/list.m3u'
+                    );
+                    const response = await fetch(
+                        `${baseUrl}/parse?targetId=${targetId}`
+                    );
+
+                    expect(response.status).toBe(500);
+                    await expect(response.json()).resolves.toEqual({
+                        message: 'Error, something went wrong (ETIMEDOUT)',
+                        status: 500,
+                        code: 'ETIMEDOUT',
+                    });
+                }
+            );
+        } finally {
+            errorSpy.mockRestore();
+        }
     });
 
     it('returns provider parse errors as JSON instead of executable text', async () => {

--- a/apps/web-backend/src/app/web-backend-app.ts
+++ b/apps/web-backend/src/app/web-backend-app.ts
@@ -13,6 +13,12 @@ import {
     normalizeXtreamServerUrl,
 } from '@iptvnator/shared/interfaces';
 import { extractDrmFromRaw } from '@iptvnator/shared/m3u-utils';
+import {
+    collectProviderErrorCodes,
+    logProviderRequestFailure,
+    normalizeProviderError,
+    ProviderError,
+} from './provider-error';
 
 export interface WebBackendHttpGetOptions {
     readonly headers?: Record<string, string>;
@@ -27,16 +33,10 @@ export interface WebBackendHttpClient {
     ): Promise<{ data: T }>;
 }
 
-interface ProviderError extends Error {
-    readonly response?: {
-        readonly status?: number;
-        readonly statusText?: string;
-    };
-}
-
 interface PlaylistParseError {
     readonly message: string;
     readonly status: number;
+    readonly code?: string;
 }
 
 export interface WebBackendAppOptions {
@@ -176,6 +176,7 @@ export function createWebBackendApp(
 
             res.json(result);
         } catch (error) {
+            logProviderRequestFailure({ error, route: '/parse-xml', url });
             const providerError = normalizeProviderError(error);
             res.status(providerError.status).json(providerError);
         }
@@ -193,10 +194,11 @@ export function createWebBackendApp(
         const url = new URL(registeredUrl.href);
 
         try {
-            const providerUrlError = await normalizeAndValidateXtreamProviderUrl(
-                url,
-                providerUrlPolicy
-            );
+            const providerUrlError =
+                await normalizeAndValidateXtreamProviderUrl(
+                    url,
+                    providerUrlPolicy
+                );
             if (providerUrlError) {
                 res.status(providerUrlError.status).json(providerUrlError);
                 return;
@@ -216,6 +218,7 @@ export function createWebBackendApp(
                 payload: response.data,
             });
         } catch (error) {
+            logProviderRequestFailure({ error, route: '/xtream', url });
             res.json(normalizeProviderError(error));
         }
     });
@@ -274,6 +277,7 @@ export function createWebBackendApp(
                 payload: response.data,
             });
         } catch (error) {
+            logProviderRequestFailure({ error, route: '/stalker', url });
             res.json(normalizeProviderError(error));
         }
     });
@@ -487,12 +491,21 @@ async function handlePlaylistParse(options: {
             url: options.url,
         });
     } catch (error) {
+        logProviderRequestFailure({ error, route: '/parse', url: options.url });
         const providerError = error as ProviderError;
+        if (providerError?.response?.statusText !== undefined) {
+            return {
+                status: providerError.response.status ?? 500,
+                message: providerError.response.statusText,
+            };
+        }
+        const code = collectProviderErrorCodes(error)[0];
         return {
-            status: providerError.response?.status ?? 500,
-            message:
-                providerError.response?.statusText ??
-                'Error, something went wrong',
+            status: providerError?.response?.status ?? 500,
+            message: code
+                ? `Error, something went wrong (${code})`
+                : 'Error, something went wrong',
+            ...(code ? { code } : {}),
         };
     }
 }
@@ -575,17 +588,6 @@ function createPlaylistObject(options: {
 function getLastUrlSegment(value: string): string {
     const segment = value.slice(value.lastIndexOf('/') + 1).trim();
     return segment.length > 0 ? segment : 'Playlist without title';
-}
-
-function normalizeProviderError(error: unknown): {
-    readonly message: string;
-    readonly status: number;
-} {
-    const providerError = error as ProviderError;
-    return {
-        message: providerError.response?.statusText ?? 'Bad Gateway',
-        status: providerError.response?.status ?? 502,
-    };
 }
 
 function createGuid(): string {

--- a/apps/web-backend/src/main.ts
+++ b/apps/web-backend/src/main.ts
@@ -1,4 +1,15 @@
+import {
+    applyDefaultAutoSelectFamilyAttemptTimeout,
+    AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG,
+} from './app/network-family-autoselection';
 import { createWebBackendApp } from './app/web-backend-app';
+
+const attemptTimeout = applyDefaultAutoSelectFamilyAttemptTimeout();
+if (attemptTimeout !== null) {
+    console.log(
+        `[web-backend] connection attempt timeout set to ${attemptTimeout} ms for IPv6->IPv4 fallback; pass ${AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_FLAG} via NODE_OPTIONS to override`
+    );
+}
 
 const port = Number(process.env['PORT'] ?? 3000);
 const app = createWebBackendApp();

--- a/apps/web/src/app/services/pwa.service.spec.ts
+++ b/apps/web/src/app/services/pwa.service.spec.ts
@@ -7,7 +7,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { SwUpdate } from '@angular/service-worker';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import { EMPTY } from 'rxjs';
+import { config as rxjsConfig, EMPTY } from 'rxjs';
 import {
     PLAYLIST_PARSE_BY_URL,
     PLAYLIST_UPDATE,
@@ -77,6 +77,84 @@ describe('PwaService', () => {
         });
 
         expect(http.match(() => true)).toHaveLength(0);
+    });
+
+    it('appends the proxy network code to the URL-import failure toast', async () => {
+        // The /parse proxy reports connection-level failures as HTTP 500 with
+        // a `code` field in the body (#1400). The toast must carry that code —
+        // status-only mapping used to collapse ETIMEDOUT into the generic
+        // fetch error. The rethrow after the snackbar has no downstream error
+        // observer, so park RxJS's unhandled-error hook for the test.
+        const unhandled: unknown[] = [];
+        const previousHandler = rxjsConfig.onUnhandledError;
+        rxjsConfig.onUnhandledError = (error) => unhandled.push(error);
+
+        try {
+            service.sendIpcEvent(PLAYLIST_PARSE_BY_URL, {
+                url: 'https://provider.example/list.m3u',
+            });
+
+            await Promise.resolve();
+            http.expectOne((req) =>
+                req.url.endsWith('/provider-targets')
+            ).flush({ targetId: 'target-1' });
+            await new Promise((resolve) => setTimeout(resolve));
+
+            http.expectOne((req) => req.url.endsWith('/parse')).flush(
+                {
+                    message: 'Error, something went wrong (ETIMEDOUT)',
+                    status: 500,
+                    code: 'ETIMEDOUT',
+                },
+                { status: 500, statusText: 'Internal Server Error' }
+            );
+            await new Promise((resolve) => setTimeout(resolve));
+
+            expect(TestBed.inject(MatSnackBar).open).toHaveBeenCalledWith(
+                'HOME.URL_UPLOAD.ERROR_FETCH_FAILED (ETIMEDOUT)',
+                'Close',
+                { duration: 5000 }
+            );
+        } finally {
+            rxjsConfig.onUnhandledError = previousHandler;
+        }
+    });
+
+    it('appends the proxy network code to the playlist-refresh failure toast', async () => {
+        const unhandled: unknown[] = [];
+        const previousHandler = rxjsConfig.onUnhandledError;
+        rxjsConfig.onUnhandledError = (error) => unhandled.push(error);
+
+        try {
+            service.sendIpcEvent(PLAYLIST_UPDATE, {
+                id: 'playlist-1',
+                url: 'https://provider.example/list.m3u',
+            });
+
+            await Promise.resolve();
+            http.expectOne((req) =>
+                req.url.endsWith('/provider-targets')
+            ).flush({ targetId: 'target-1' });
+            await new Promise((resolve) => setTimeout(resolve));
+
+            http.expectOne((req) => req.url.endsWith('/parse')).flush(
+                {
+                    message: 'Error, something went wrong (ENETUNREACH)',
+                    status: 500,
+                    code: 'ENETUNREACH',
+                },
+                { status: 500, statusText: 'Internal Server Error' }
+            );
+            await new Promise((resolve) => setTimeout(resolve));
+
+            expect(TestBed.inject(MatSnackBar).open).toHaveBeenCalledWith(
+                'HOME.URL_UPLOAD.ERROR_FETCH_FAILED (ENETUNREACH)',
+                'CLOSE',
+                { duration: 5000 }
+            );
+        } finally {
+            rxjsConfig.onUnhandledError = previousHandler;
+        }
     });
 
     it('surfaces the stalker proxy error envelope as an HTTP error instead of undefined', async () => {
@@ -152,9 +230,7 @@ describe('PwaService', () => {
                 '00:1A:79:AA:BB:CC'
             );
             expect(requestUrl.searchParams.get('token')).toBe('TOKEN123');
-            expect(requestUrl.searchParams.get('serialNumber')).toBe(
-                'SN1234'
-            );
+            expect(requestUrl.searchParams.get('serialNumber')).toBe('SN1234');
             expect(requestUrl.searchParams.get('action')).toBe(
                 'get_ordered_list'
             );

--- a/apps/web/src/app/services/pwa.service.ts
+++ b/apps/web/src/app/services/pwa.service.ts
@@ -158,7 +158,10 @@ export class PwaService extends DataService {
             .pipe(
                 catchError((error) => {
                     this.snackBar.open(
-                        this.getPlaylistRefreshErrorMessage(error),
+                        this.appendProviderErrorCode(
+                            this.getPlaylistRefreshErrorMessage(error),
+                            error
+                        ),
                         this.translateService.instant('CLOSE'),
                         {
                             duration: 5000,
@@ -220,8 +223,11 @@ export class PwaService extends DataService {
             .pipe(
                 catchError((error) => {
                     this.snackBar.open(
-                        this.getErrorMessageByStatusCode(
-                            this.extractHttpStatusCode(error)
+                        this.appendProviderErrorCode(
+                            this.getErrorMessageByStatusCode(
+                                this.extractHttpStatusCode(error)
+                            ),
+                            error
                         ),
                         'Close',
                         {
@@ -267,6 +273,19 @@ export class PwaService extends DataService {
                 break;
         }
         return this.translateService.instant(messageKey);
+    }
+
+    /**
+     * The web backend attaches the underlying Node network code (ETIMEDOUT,
+     * ENETUNREACH, ...) to proxy error bodies; without it the toast collapses
+     * every connection failure into the same generic fetch error (#1400).
+     */
+    private appendProviderErrorCode(message: string, error: unknown): string {
+        const body = (error as { error?: { code?: unknown } } | null)?.error;
+        const code = typeof body?.code === 'string' ? body.code : '';
+        return code && !message.includes(`(${code})`)
+            ? `${message} (${code})`
+            : message;
     }
 
     private extractHttpStatusCode(error: unknown): number | null {

--- a/docker/README.md
+++ b/docker/README.md
@@ -123,6 +123,37 @@ define a health check against `/api/health`. If nginx or the backend exits
 after startup, the entrypoint exits the container so Docker Compose can apply
 the `restart: unless-stopped` policy.
 
+## IPv6, VPNs, And Connection Fallback
+
+Node races IPv6 and IPv4 addresses when a provider hostname has both ("happy
+eyeballs"), and its stock per-attempt budget of 250 ms is too short for many
+VPN and container networks. The classic symptom is a provider that answers
+`wget` from inside the container but fails in IPTVnator with
+`Bad Gateway (ETIMEDOUT)` — typically behind an IPv4-only VPN namespace such
+as Gluetun/WireGuard, where the IPv6 route is unreachable and the working
+IPv4 handshake needs more than 250 ms.
+
+The backend therefore raises the per-attempt connection budget to 2500 ms at
+startup. This keeps the IPv6→IPv4 fallback fully automatic in both
+directions. If you pass
+`--network-family-autoselection-attempt-timeout` yourself through
+`NODE_OPTIONS`, your value wins and the backend leaves it untouched.
+
+If a provider still fails, check the container logs first: outbound provider
+failures are logged with the target hostname and the underlying Node error
+codes (`ETIMEDOUT`, `ENETUNREACH`, `ENOTFOUND`, ...), and the same code is
+returned to the app in the error message. As a last resort you can pin the
+legacy behavior entirely:
+
+```yaml
+services:
+    iptvnator:
+        environment:
+            # Disables IPv6/IPv4 racing completely; only for networks where
+            # IPv6 can never work. Breaks IPv6-only deployments.
+            NODE_OPTIONS: '--dns-result-order=ipv4first --no-network-family-autoselection'
+```
+
 ## Local Validation
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes #1400 — the Docker/PWA web backend answered `502 Bad Gateway` for a working Xtream provider whenever the provider hostname has both A and AAAA records but the container network has no usable IPv6 route (e.g. `network_mode: service:gluetun`).

### Root cause

Node enables happy-eyeballs connection racing (`autoSelectFamily`) by default and gives **each address attempt only 250 ms**. Behind a VPN namespace the IPv6 attempts fail instantly (`ENETUNREACH`) and the working IPv4 handshake routinely needs more than 250 ms (`ETIMEDOUT`) — so every attempt fails, axios surfaces a response-less error, and `normalizeProviderError` collapsed it into a bare 502. That is why `wget` from the same container succeeded while the backend failed.

### Fix

- **`main.ts` raises the per-attempt budget to 2500 ms** via `net.setDefaultAutoSelectFamilyAttemptTimeout()` at startup. Unlike the reporter's `--no-network-family-autoselection --dns-result-order=ipv4first` workaround this keeps the IPv6↔IPv4 fallback fully automatic, so IPv6-only deployments keep working.
- An explicit `--network-family-autoselection-attempt-timeout` passed by the operator (CLI or `NODE_OPTIONS`) always wins — the backend detects it and leaves it untouched (`network-family-autoselection.ts`).
- **Provider failures are no longer opaque** (the issue's second ask): the new `provider-error.ts` walks `code`/`cause`/`AggregateError` members, returns the primary code in the error body — the app now shows `Bad Gateway (ETIMEDOUT)` — and logs `[web-backend] /xtream request to <hostname> failed: ETIMEDOUT, ENETUNREACH` server-side. Log lines carry only the hostname, never the URL query string (it holds Xtream credentials).
- All four proxy routes are covered: `/xtream`, `/stalker`, `/parse`, `/parse-xml`. HTTP-status failures keep their exact previous shape (`statusText`/`status`, no `code` field).
- `docker/README.md` gains an "IPv6, VPNs, And Connection Fallback" section documenting the behavior, the log diagnostics, and the last-resort NODE_OPTIONS pin.

### Tests

- `network-family-autoselection.spec.ts`: applies 2500 ms, respects the explicit flag in both argv shapes and NODE_OPTIONS, real-`net` default round-trip.
- `provider-error.spec.ts`: aggregate/cause/cycle traversal, HTTP-branch precedence, credential-free logging.
- `web-backend-app.spec.ts`: route-level regression tests reproducing the issue's exact failure (AggregateError with `ETIMEDOUT` + `ENETUNREACH`) on `/xtream`, plus `/stalker` and `/parse`; asserts the log line names the host and codes but never the credentials.

`pnpm nx test web-backend` (41/41), `pnpm nx lint web-backend`, `pnpm nx build web-backend`, `pnpm run release:notes:validate` — all green. Smoke-ran the built `main.cjs`: startup log confirms 2500 ms applied, and with the explicit flag in `NODE_OPTIONS` the backend leaves it alone.

Release note added: `.changes/pwa-ipv6-ipv4-fallback.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)