### PR TITLE
ci(deps): split sensitive dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 # Every Dependabot PR triggers the full pipeline (~15 jobs), so version
 # updates are batched weekly. Nx minor+patch updates use a dedicated group so
-# official packages move together; Nx majors are manual coordinated migrations,
-# and other minor+patch updates are grouped per ecosystem. Security updates are
-# separate and are not limited by this schedule; CI enforces complete Nx lockstep.
+# official packages move together; Nx majors are manual coordinated migrations.
+# Native packaging, parser, and version-locked playback dependencies stay in
+# standalone PRs; other minor+patch updates are grouped per ecosystem. Security
+# updates are separate and are not limited by this schedule; CI enforces complete
+# Nx lockstep.
 version: 2
 updates:
     - package-ecosystem: npm
@@ -36,8 +38,14 @@ updates:
           npm-minor-patch:
               applies-to: version-updates
               exclude-patterns:
+                  - better-sqlite3
+                  - electron
+                  - electron-builder
+                  - epg-parser
+                  - mpegts.js
                   - nx
                   - '@nx/*'
+                  - shaka-player
               update-types:
                   - minor
                   - patch

--- a/docs/architecture/workspace-shell.md
+++ b/docs/architecture/workspace-shell.md
@@ -324,6 +324,11 @@ Toolchain notes for the Electron 41 upgrade:
    carries the v26 backport that fully extracts the Snap template's `.tar.7z`
    payload; 26.15.0–26.15.6 can
    produce a Snap that is missing `desktop-init.sh`. CI already runs Node 22.
+4. Dependabot keeps Electron, native database, packaging, EPG parser, and
+   version-locked Shaka/mpegts updates out of the shared npm minor/patch group.
+   Those dependencies require standalone PRs so their dedicated package,
+   worker, playback, and diagnostic-contract validation cannot be hidden by an
+   unrelated grouped update.
 
 Known caveats:
 


### PR DESCRIPTION
## Summary

- keep Electron/native packaging dependencies out of the shared npm minor/patch group
- keep the version-locked EPG, Shaka, and mpegts contracts in standalone dependency PRs
- document why these updates need dedicated validation

## Why

Dependabot PR #1407 combines unrelated safe tooling updates with packaging and playback/parser contracts that require different validation. GitHub documents `exclude-patterns` as the supported way to keep those dependencies updating in separate PRs.

## Validation

- parsed `.github/dependabot.yml` and asserted the exact standalone dependency set
- `pnpm exec prettier --check .github/dependabot.yml`
- `pnpm run release:notes:validate`
- `git diff --check`

## Release note

Skipped: dependency automation and documentation only; no runtime behavior changes.