### PR TITLE
fix(playback): update Shaka Player to 5.2.4

### DIFF
--- a/.changes/playback-shaka-5-2-4.md
+++ b/.changes/playback-shaka-5-2-4.md
@@ -1,0 +1,6 @@
+---
+type: fix
+area: playback
+---
+
+DASH playback now resets a failed media buffer before switching variants, avoiding repeated append failures and crashes on affected platforms.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,7 @@ Key files:
   engine (`libs/ui/playback/src/lib/shaka-engine/`) inside the HTML5 and
   ArtPlayer components; ClearKey keys come from KODIPROP-derived
   `Channel.drm`, and the shared bridge exposes Shaka audio/text tracks via
-  source kind `shaka`. The DOM-free Shaka `5.2.2` diagnostic boundary lives in
+  source kind `shaka`. The DOM-free Shaka `5.2.4` diagnostic boundary lives in
   `libs/playback/util`; it version-locks public severity/category/code evidence,
   ignores recoverable error events,
   treats rejected loads as terminal lifecycle outcomes, preserves exact public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -920,7 +920,7 @@ app as a real argument, so it is not an option.
   ArtPlayer). Unsupported license types (Widevine/PlayReady — out of scope,
   need the castLabs Electron fork) surface a DRM playback diagnostic instead
   of crashing. ClearKey EME works in stock Electron. Engine:
-  `libs/ui/playback/src/lib/shaka-engine/`. Its DOM-free Shaka `5.2.2`
+  `libs/ui/playback/src/lib/shaka-engine/`. Its DOM-free Shaka `5.2.4`
   diagnostic boundary lives in `libs/playback/util`; it version-locks public
   severity/category/code evidence, ignores
   recoverable error events, treats rejected loads as terminal lifecycle

--- a/docs/architecture/embedded-inline-playback.md
+++ b/docs/architecture/embedded-inline-playback.md
@@ -464,7 +464,7 @@ external-player workflows; it is not copied from the HLS error payload into
 the evidence or technical details. HLS startup development logs are event-only:
 they do not include provider-supplied channel names or source URLs.
 
-Shaka Player `5.2.2` errors cross a separate structured boundary before the
+Shaka Player `5.2.4` errors cross a separate structured boundary before the
 HTML5 or ArtPlayer DASH session emits a diagnostic. Version-locked tests assert
 the installed Shaka version plus the public `Severity`, `Category`, and selected
 online-playback `Code` values used by the boundary. Evidence retains only

--- a/docs/architecture/m3u-playlist-module.md
+++ b/docs/architecture/m3u-playlist-module.md
@@ -1017,7 +1017,7 @@ player in settings.
   engine: lazy `import('shaka-player')` on first use (the module is a separate
   lazy chunk, ~217 KB transfer), `drm.clearKeys` configuration, an operation
   queue + generation guard against channel-switch races. The DOM-free Shaka
-  `5.2.2` public-error boundary lives in `libs/playback/util`; it version-locks
+  `5.2.4` public-error boundary lives in `libs/playback/util`; it version-locks
   its allowlisted
   severity/category/code values, emits only structured sanitized
   `PlaybackDiagnosticSource.Shaka` evidence, ignores recoverable error events,

--- a/libs/playback/util/src/lib/diagnostics/shaka-error-contract.ts
+++ b/libs/playback/util/src/lib/diagnostics/shaka-error-contract.ts
@@ -1,10 +1,10 @@
 /**
- * Public Shaka error values audited against the locked 5.2.2 runtime.
+ * Public Shaka error values audited against the locked 5.2.4 runtime.
  *
  * Keep the version assertion in the contract spec: a Shaka upgrade must stop
  * here for a new audit instead of silently accepting new error layouts.
  */
-export const SHAKA_DIAGNOSTIC_VERSION = 'v5.2.2';
+export const SHAKA_DIAGNOSTIC_VERSION = 'v5.2.4';
 
 export const SHAKA_ERROR_SEVERITY = {
     RECOVERABLE: 1,

--- a/libs/playback/util/src/lib/diagnostics/shaka-playback-evidence.util.spec.ts
+++ b/libs/playback/util/src/lib/diagnostics/shaka-playback-evidence.util.spec.ts
@@ -41,7 +41,7 @@ interface ShakaEvidenceExports {
 const exportsUnderTest = shakaDiagnostics as ShakaEvidenceExports;
 
 describe('Shaka playback evidence', () => {
-    it('matches the installed public Shaka 5.2.2 error contract', () => {
+    it('matches the installed public Shaka 5.2.4 error contract', () => {
         const installed = getInstalledShakaContract();
 
         expect(exportsUnderTest.SHAKA_DIAGNOSTIC_VERSION).toBe(

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
         "ngx-skeleton-loader": "11.3.0",
         "rxjs": "7.8.2",
         "saxes": "6.0.0",
-        "shaka-player": "5.2.2",
+        "shaka-player": "5.2.4",
         "video.js": "8.23.9",
         "videojs-contrib-quality-levels": "4.1.0",
         "videojs-quality-selector-hls": "1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
         specifier: 6.0.0
         version: 6.0.0
       shaka-player:
-        specifier: 5.2.2
-        version: 5.2.2
+        specifier: 5.2.4
+        version: 5.2.4
       video.js:
         specifier: 8.23.9
         version: 8.23.9
@@ -10110,8 +10110,9 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shaka-player@5.2.2:
-    resolution: {integrity: sha512-1Z5Sxqz7nEAtvp4zlZKAHQSEq6cUlw5CKAdUxqmuMNeZgu23090VXMcEDdiSLU5qtMn1skFOzq+KKCVX71bHqw==}
+  shaka-player@5.2.4:
+    resolution: {integrity: sha512-vf81av2EIcb03jRpeeZBhrPT3PMyggXnZA9k4sxGBxpr/H6v0iEL6b51T2Kwz5YNrQG/yDYoadgBW+oW40LeoA==}
+    engines: {node: '>=18'}
 
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
@@ -23149,7 +23150,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shaka-player@5.2.2: {}
+  shaka-player@5.2.4: {}
 
   shallow-clone@3.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- update Shaka Player from 5.2.2 to 5.2.4
- re-audit and advance the version-locked public diagnostic boundary
- update canonical player documentation and add a user-facing fix note

## Compatibility audit

The installed 5.2.4 runtime preserves every severity/category value and every public error code accepted by IPTVnator. The existing fail-closed contract test intentionally failed on `v5.2.2` after the package update, then passed after the audited version advanced to `v5.2.4`.

Upstream 5.2.2...5.2.4 comparison: https://github.com/shaka-project/shaka-player/compare/646f8a4ea878bcc767b35d6b9f5bc3d8b3585952...e0a0011e013dd7c8f625c5d87a31f1f5926846f1

## Validation

- `pnpm nx test playback-util --skip-nx-cache --runInBand` (300/300)
- `pnpm nx test ui-playback --skip-nx-cache --runInBand`
- `pnpm nx test playlist-m3u-feature-player --skip-nx-cache --runInBand` (54/54)
- `pnpm nx lint playback-util --skip-nx-cache`
- `pnpm nx lint ui-playback --skip-nx-cache`
- `pnpm install --frozen-lockfile`
- `pnpm nx build web --configuration=production --skip-nx-cache`
- `pnpm run release:notes:validate`
- `git diff --check`

## Release note

Added `.changes/playback-shaka-5-2-4.md` as a playback fix.