### PR TITLE
fix(playback): update mpegts.js to 1.8.1

### DIFF
--- a/.changes/playback-mpegts-1-8-1.md
+++ b/.changes/playback-mpegts-1-8-1.md
@@ -1,0 +1,6 @@
+---
+type: fix
+area: playback
+---
+
+MPEG-TS playback is now more reliable on newer Safari versions when streams contain audio timestamp gaps.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ Key files:
   KODIPROP DRM still suppress it. See the CLAUDE.md "Video Players" feature
   entry and the "DASH + ClearKey Playback" section of
   `docs/architecture/m3u-playlist-module.md`.
-- mpegts.js `1.8.0` errors from HTML5, Video.js, and ArtPlayer cross one
+- mpegts.js `1.8.1` errors from HTML5, Video.js, and ArtPlayer cross one
   version-locked structured evidence boundary in `libs/playback/util`. Only
   exact public type/detail pairs, pair-derived stage/failure, terminal
   disposition, and the validated HTTP 4xx/5xx status slot are retained; raw

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -775,7 +775,7 @@ app as a real argument, so it is not an option.
 **Video Players**:
 
 - Built-in web players: HTML5+hls.js, Video.js, and ArtPlayer
-- mpegts.js `1.8.0` errors from all three built-in players cross one
+- mpegts.js `1.8.1` errors from all three built-in players cross one
   version-locked structured evidence boundary in `libs/playback/util`. It
   retains only exact public type/detail pairs, pair-derived stage/failure,
   terminal disposition, and a

--- a/docs/architecture/embedded-inline-playback.md
+++ b/docs/architecture/embedded-inline-playback.md
@@ -512,7 +512,7 @@ configuration.
 
 `network-error` is reserved for provider/network loading failures. Engines that expose concrete browser security evidence, such as CORS, mixed content, Content Security Policy, or private-network-access blocks, use `browser-access-error` so the UI can explain that the browser player was blocked before playback reached decoding.
 
-mpegts.js `1.8.0` errors cross one shared structured boundary before the HTML5,
+mpegts.js `1.8.1` errors cross one shared structured boundary before the HTML5,
 Video.js, or ArtPlayer owner emits a diagnostic. Version-locked tests compare
 the installed public `ErrorTypes` and `ErrorDetails` exports with the accepted
 contract. Evidence retains only an exact type/detail pair, terminal

--- a/libs/playback/util/src/lib/diagnostics/mpegts-playback-evidence.util.spec.ts
+++ b/libs/playback/util/src/lib/diagnostics/mpegts-playback-evidence.util.spec.ts
@@ -21,7 +21,7 @@ const METADATA = createPlaybackSourceMetadata({
 });
 
 describe('mpegts.js playback evidence', () => {
-    it('locks the accepted public contract to mpegts.js 1.8.0', () => {
+    it('locks the accepted public contract to mpegts.js 1.8.1', () => {
         expect(mpegts.version).toBe(MPEGTS_DIAGNOSTIC_VERSION);
         expect(mpegts.ErrorTypes).toEqual({
             NETWORK_ERROR: MpegTsPlaybackEngineType.Network,

--- a/libs/playback/util/src/lib/diagnostics/mpegts-playback-evidence.util.ts
+++ b/libs/playback/util/src/lib/diagnostics/mpegts-playback-evidence.util.ts
@@ -11,7 +11,7 @@ import {
     MpegTsPlaybackStage,
 } from './mpegts-playback-evidence.model';
 
-export const MPEGTS_DIAGNOSTIC_VERSION = '1.8.0';
+export const MPEGTS_DIAGNOSTIC_VERSION = '1.8.1';
 
 interface MpegTsPlaybackCause {
     readonly stage: MpegTsPlaybackStageValue;

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         "hls.js": "1.6.16",
         "iptv-playlist-parser": "github:4gray/iptv-playlist-parser#v0.15.2-iptvnator.2",
         "marked": "18.0.7",
-        "mpegts.js": "1.8.0",
+        "mpegts.js": "1.8.1",
         "ms": "2.1.3",
         "ngx-indexed-db": "21.0.0",
         "ngx-skeleton-loader": "11.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,8 +137,8 @@ importers:
         specifier: 18.0.7
         version: 18.0.7
       mpegts.js:
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.8.1
+        version: 1.8.1
       ms:
         specifier: 2.1.3
         version: 2.1.3
@@ -8568,8 +8568,9 @@ packages:
     resolution: {integrity: sha512-blbA7XpAaOdC/PR0Tu8GiUxlx6CpBuRowQPYV7lhi9Yr9G9+dkPXIUjqjzc/NCn/uZZPopluaJlIYntIEI/VLw==}
     hasBin: true
 
-  mpegts.js@1.8.0:
-    resolution: {integrity: sha512-ZtujqtmTjWgcDDkoOnLvrOKUTO/MKgLHM432zGDI8oPaJ0S+ebPxg1nEpDpLw6I7KmV/GZgUIrfbWi3qqEircg==}
+  mpegts.js@1.8.1:
+    resolution: {integrity: sha512-mQ2daxqBaS+QmBYTmJMDUGwAOw08534b08KSyqUGkjkhuBODNod15j8pnRfVEIQVWulKNe201/6UqILe4m4YRQ==}
+    engines: {node: '>=20.9.0'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -11321,10 +11322,6 @@ packages:
   websocket-extensions@0.1.4:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
-
-  webworkify-webpack@https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef:
-    resolution: {tarball: https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef}
-    version: 2.1.5
 
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
@@ -21288,10 +21285,10 @@ snapshots:
       '@xmldom/xmldom': 0.8.13
       global: 4.4.0
 
-  mpegts.js@1.8.0:
+  mpegts.js@1.8.1:
     dependencies:
       es6-promise: 4.2.8
-      webworkify-webpack: https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef
+      events: 3.3.0
 
   mrmime@2.0.1: {}
 
@@ -24542,8 +24539,6 @@ snapshots:
       websocket-extensions: 0.1.4
 
   websocket-extensions@0.1.4: {}
-
-  webworkify-webpack@https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef: {}
 
   whatwg-encoding@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- update the exact mpegts.js dependency from 1.8.0 to 1.8.1
- advance the version-locked structured diagnostics boundary after auditing the installed public error contract
- document the current boundary and add a user-facing fix note for newer Safari audio-gap playback

## Compatibility audit

- npm latest is 1.8.1
- upstream 1.8.0...1.8.1 contains 29 commits, including the Safari audio timestamp-gap fix and MediaSource detection improvements
- `src/player/player-errors.js` is byte-identical between upstream v1.8.0 and the installed v1.8.1 package (SHA-256 `605ebf63c662749ea5082c392b870ea9b2f56203b965b2be48c33343ea120036`)
- the existing contract test still asserts every accepted `ErrorTypes` and `ErrorDetails` value

## Validation

- `pnpm install --frozen-lockfile`
- RED: `pnpm nx test playback-util --skip-nx-cache --runInBand` failed only on expected 1.8.0 vs installed 1.8.1 (299/300 passed)
- GREEN: `pnpm nx test playback-util --skip-nx-cache --runInBand` (300/300)
- `pnpm nx test ui-playback --skip-nx-cache --runInBand` (975/975)
- `pnpm nx test playlist-m3u-feature-player --skip-nx-cache --runInBand` (54/54)
- `pnpm nx lint playback-util --skip-nx-cache`
- `pnpm nx lint ui-playback --skip-nx-cache`
- `pnpm nx build web --configuration=production --skip-nx-cache`
- `pnpm run release:notes:validate`
- `git diff --check`

Upstream compare: https://github.com/xqq/mpegts.js/compare/v1.8.0...v1.8.1