### PR TITLE
chore(deps): update epg-parser to 0.5.0

### DIFF
--- a/.changes/deps-epg-parser-0-5-0.md
+++ b/.changes/deps-epg-parser-0-5-0.md
@@ -1,0 +1,6 @@
+---
+type: internal
+area: deps
+---
+
+The web backend now uses the current structured XMLTV parser output, covered by a route-level contract test for future PWA EPG support.

--- a/apps/web-backend/src/app/web-backend-app.spec.ts
+++ b/apps/web-backend/src/app/web-backend-app.spec.ts
@@ -210,6 +210,87 @@ https://stream.example/news.m3u8`);
         );
     });
 
+    it('parses XMLTV metadata into the current EPG shape', async () => {
+        const httpClient = new StubHttpClient();
+        httpClient.queueResponse(`<?xml version="1.0"?>
+<tv source-info-name="Fixture Guide">
+  <channel id="news">
+    <display-name lang="en">News</display-name>
+    <icon src="https://example.test/news.png" width="100" height="50" />
+    <url system="homepage">https://example.test/news</url>
+  </channel>
+  <programme start="20260811010000 +0000" stop="20260811020000 +0000" channel="news">
+    <title lang="en">Morning News</title>
+    <desc lang="en">Headlines</desc>
+    <icon src="https://example.test/program.png" />
+  </programme>
+</tv>`);
+
+        await withServer(
+            createWebBackendApp({
+                clientOrigins: ['http://localhost:4200'],
+                httpClient,
+                resolveHostname: resolvePublicHost,
+            }),
+            async (baseUrl) => {
+                const targetId = await registerProviderTarget(
+                    baseUrl,
+                    'https://provider.example/guide.xml'
+                );
+                const response = await fetch(
+                    `${baseUrl}/parse-xml?targetId=${targetId}`,
+                    { headers: { Origin: 'http://localhost:4200' } }
+                );
+                const body = (await response.json()) as Record<string, unknown>;
+
+                expect(response.status).toBe(200);
+                expect(body).toMatchObject({
+                    sourceInfoName: 'Fixture Guide',
+                    channels: [
+                        {
+                            id: 'news',
+                            displayName: [{ lang: 'en', value: 'News' }],
+                            icon: [
+                                {
+                                    src: 'https://example.test/news.png',
+                                    width: '100',
+                                    height: '50',
+                                },
+                            ],
+                            url: [
+                                {
+                                    system: 'homepage',
+                                    value: 'https://example.test/news',
+                                },
+                            ],
+                        },
+                    ],
+                    programs: [
+                        {
+                            channel: 'news',
+                            start: '2026-08-11T01:00:00.000Z',
+                            stop: '2026-08-11T02:00:00.000Z',
+                            title: [{ lang: 'en', value: 'Morning News' }],
+                            desc: [{ lang: 'en', value: 'Headlines' }],
+                            icon: [
+                                {
+                                    src: 'https://example.test/program.png',
+                                },
+                            ],
+                        },
+                    ],
+                });
+                expect(httpClient.requests).toEqual([
+                    {
+                        headers: undefined,
+                        params: undefined,
+                        url: 'https://provider.example/guide.xml',
+                    },
+                ]);
+            }
+        );
+    });
+
     it('extracts KODIPROP ClearKey DRM on the /parse URL-import path', async () => {
         const httpClient = new StubHttpClient();
         const kid = '00112233445566778899aabbccddeeff';

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "drizzle-orm": "0.45.2",
         "electron-conf": "1.3.0",
         "electron-updater": "6.8.9",
-        "epg-parser": "^0.1.6",
+        "epg-parser": "^0.5.0",
         "fix-path": "5.0.0",
         "hls.js": "1.6.16",
         "iptv-playlist-parser": "github:4gray/iptv-playlist-parser#v0.15.2-iptvnator.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,8 +122,8 @@ importers:
         specifier: 6.8.9
         version: 6.8.9
       epg-parser:
-        specifier: ^0.1.6
-        version: 0.1.6
+        specifier: ^0.5.0
+        version: 0.5.0
       fix-path:
         specifier: 5.0.0
         version: 5.0.0
@@ -6049,6 +6049,9 @@ packages:
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -6487,8 +6490,8 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
-  epg-parser@0.1.6:
-    resolution: {integrity: sha512-g6AxKOvs0E4bTGPdIUh8/FDKdrVjbf4DVK0jIFuChDt7wBRJmMVyqbLeS8NApf6M2wpCRLBpIenXOCS88w0Rqw==}
+  epg-parser@0.5.0:
+    resolution: {integrity: sha512-NK9vSev/KkCVcKilJd35PmB9tP4+tN45dhcsSxHagVoUTINh8KLZ1yvgtoPDVYr0IaSPJXIIIZWcu1JPjS5HMw==}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -8090,6 +8093,9 @@ packages:
 
   lodash.escaperegexp@4.1.2:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
@@ -17978,6 +17984,8 @@ snapshots:
 
   date-fns@4.4.0: {}
 
+  dayjs@1.11.21: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -18313,8 +18321,10 @@ snapshots:
 
   environment@1.1.0: {}
 
-  epg-parser@0.1.6:
+  epg-parser@0.5.0:
     dependencies:
+      dayjs: 1.11.21
+      lodash.groupby: 4.6.0
       xml-js: 1.6.11
 
   err-code@2.0.3: {}
@@ -20553,6 +20563,8 @@ snapshots:
   lodash.debounce@4.0.8: {}
 
   lodash.escaperegexp@4.1.2: {}
+
+  lodash.groupby@4.6.0: {}
 
   lodash.isequal@4.5.0: {}
 
@@ -24675,7 +24687,7 @@ snapshots:
 
   xml-js@1.6.11:
     dependencies:
-      sax: 1.6.0
+      sax: 1.6.1
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Summary

- update epg-parser from 0.1.6 to 0.5.0 in a standalone dependency PR
- add route-level coverage for the web backend XMLTV parser contract
- record the maintenance update as internal because the PWA does not currently expose EPG workflows

## Compatibility audit

- v0.2 converts XMLTV program start/stop timestamps to ISO 8601
- v0.3 changes channel names and icon/URL fields to structured values
- v0.4 reduces the package footprint
- v0.5 preserves top-level tv metadata in the parsed output
- the Electron EPG path is unaffected because it uses the in-repo streaming SAX parser rather than epg-parser

## Validation

- RED: `pnpm nx test web-backend --skip-nx-cache --runInBand` on 0.1.6 failed the new contract test on legacy names, scalar icon/URL fields, raw dates, and missing tv metadata (44/45 passed)
- GREEN: `pnpm nx test web-backend --skip-nx-cache --runInBand` on 0.5.0 (45/45)
- `pnpm install --frozen-lockfile`
- `pnpm nx lint web-backend --skip-nx-cache`
- `pnpm nx build web-backend --skip-nx-cache`
- `pnpm run release:notes:validate`
- relevant Prettier check
- `git diff --check`

Canonical docs were reviewed and left unchanged: `docs/architecture/pwa-self-hosted.md` explicitly states that PWA EPG/XMLTV is not supported yet and `/parse-xml` is not in the application's active PWA route list.

Upstream releases: https://github.com/freearhey/epg-parser/releases