### PR TITLE
fix(search): keep in-flight typing when the page rewrites its query params

### DIFF
--- a/.changes/search-keeps-typing-during-navigation.md
+++ b/.changes/search-keeps-typing-during-navigation.md
@@ -1,0 +1,9 @@
+---
+type: fix
+area: search
+---
+
+The search box no longer loses what you are typing when the page updates its
+address at the same moment — switching a downloads filter and immediately
+typing used to wipe the term, and fast typing could snap back to an earlier
+word.

--- a/docs/architecture/workspace-shell.md
+++ b/docs/architecture/workspace-shell.md
@@ -162,6 +162,15 @@ Search is shell-owned and route-aware:
 7. Global search uses the header input as its primary input and writes the
    search phrase to the `q` query parameter, so history/back-forward behavior
    matches the rest of the workspace.
+8. The URL is authoritative for the search box only when it carries search
+   intent. `WorkspaceShellSearchSyncService` re-reads `q` on every
+   `NavigationEnd`, but a navigation that stays on the same page and carries
+   the term already applied is ignored while input is still debouncing —
+   otherwise a page writing an unrelated query param (a downloads filter chip,
+   a refresh bump) or the router echoing back our own `q` would cancel the
+   pending debounce and reset the box, eating everything typed since. Pages are
+   free to write their own query params while the user types; they must not
+   assume the shell will re-apply the search afterwards.
 
 Rail navigation is also shell-owned:
 

--- a/docs/architecture/workspace-shell.md
+++ b/docs/architecture/workspace-shell.md
@@ -164,13 +164,20 @@ Search is shell-owned and route-aware:
    matches the rest of the workspace.
 8. The URL is authoritative for the search box only when it carries search
    intent. `WorkspaceShellSearchSyncService` re-reads `q` on every
-   `NavigationEnd`, but a navigation that stays on the same page and carries
-   the term already applied is ignored while input is still debouncing —
-   otherwise a page writing an unrelated query param (a downloads filter chip,
-   a refresh bump) or the router echoing back our own `q` would cancel the
-   pending debounce and reset the box, eating everything typed since. Pages are
-   free to write their own query params while the user types; they must not
-   assume the shell will re-apply the search afterwards.
+   `NavigationEnd`, but an **app-initiated** navigation that stays on the same
+   page and carries the term already applied is ignored while input is still
+   debouncing — otherwise a page writing an unrelated query param (a downloads
+   filter chip, a refresh bump) or the router echoing back our own `q` would
+   cancel the pending debounce and reset the box, eating everything typed
+   since. Pages are free to write their own query params while the user types;
+   they must not assume the shell will re-apply the search afterwards.
+9. Browser history overrides that guard. The exemption is keyed on
+   `Navigation.trigger === 'imperative'`, so back/forward always re-applies
+   what the history entry carries, even mid-typing.
+10. Applying a term explicitly supersedes a queued one. `applySearchQuery()`
+    cancels any pending debounce, so the Enter key committing a trimmed term
+    cannot be overwritten a moment later by the untrimmed keystroke still
+    waiting behind it.
 
 Rail navigation is also shell-owned:
 

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/helpers/workspace-shell-route-utils.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/helpers/workspace-shell-route-utils.ts
@@ -29,6 +29,14 @@ export function getRouteQueryParam(
     return typeof value === 'string' ? value : '';
 }
 
+/**
+ * The page part of a router URL, without query params or fragment — i.e. the
+ * identity of "which page am I on", as opposed to how it is parameterised.
+ */
+export function getRoutePath(url: string): string {
+    return url.split('?')[0].split('#')[0];
+}
+
 export function syncSearchQueryParam(
     router: Router,
     currentUrl: string,
@@ -40,7 +48,7 @@ export function syncSearchQueryParam(
         return false;
     }
 
-    const routePath = currentUrl.split('?')[0];
+    const routePath = getRoutePath(currentUrl);
     const queryParams = {
         ...router.parseUrl(currentUrl).queryParams,
     };
@@ -58,7 +66,7 @@ export function syncSearchQueryParam(
 }
 
 export function bumpRefreshQueryParam(router: Router, currentUrl: string): void {
-    const routePath = currentUrl.split('?')[0];
+    const routePath = getRoutePath(currentUrl);
     const queryParams = {
         ...router.parseUrl(currentUrl).queryParams,
         refresh: Date.now().toString(),

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-search-sync.service.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-search-sync.service.spec.ts
@@ -11,6 +11,7 @@ import { RuntimeCapabilitiesService } from '@iptvnator/services';
 import { WorkspaceStartupPreferencesService } from '@iptvnator/workspace/shell/util';
 import { SEARCH_INPUT_DEBOUNCE_MS } from './helpers/workspace-shell-constants';
 import { WorkspaceShellRouteStateService } from './workspace-shell-route-state.service';
+import { WorkspaceShellSearchService } from './workspace-shell-search.service';
 import { WorkspaceShellSearchSyncService } from './workspace-shell-search-sync.service';
 
 const DOWNLOADS_URL = '/workspace/downloads';
@@ -19,28 +20,41 @@ describe('WorkspaceShellSearchSyncService', () => {
     let service: WorkspaceShellSearchSyncService;
     let routeState: WorkspaceShellRouteStateService;
     let events: Subject<NavigationEnd>;
+    let searchService: WorkspaceShellSearchService;
+    let trigger: 'imperative' | 'popstate';
     let router: {
         url: string;
         events: Subject<NavigationEnd>;
         navigate: jest.Mock;
         navigateByUrl: jest.Mock;
         parseUrl: jest.Mock;
+        lastSuccessfulNavigation: () => { trigger: string };
     };
 
-    /** Emits the NavigationEnd both shell services listen for. */
-    function navigateTo(url: string): void {
+    /**
+     * Emits the NavigationEnd both shell services listen for. `origin` mirrors
+     * `Navigation.trigger`: 'imperative' is the app navigating, 'popstate' is
+     * the user moving through browser history.
+     */
+    function navigateTo(
+        url: string,
+        origin: 'imperative' | 'popstate' = 'imperative'
+    ): void {
         router.url = url;
+        trigger = origin;
         events.next(new NavigationEnd(1, url, url));
     }
 
     beforeEach(() => {
         jest.useFakeTimers();
         events = new Subject<NavigationEnd>();
+        trigger = 'imperative';
         router = {
             url: DOWNLOADS_URL,
             events,
             navigate: jest.fn().mockResolvedValue(true),
             navigateByUrl: jest.fn().mockResolvedValue(true),
+            lastSuccessfulNavigation: () => ({ trigger }),
             parseUrl: jest.fn((url: string) => {
                 const parsed = new URL(url, 'http://localhost');
                 const queryParams: Record<string, string> = {};
@@ -55,6 +69,7 @@ describe('WorkspaceShellSearchSyncService', () => {
             providers: [
                 WorkspaceShellRouteStateService,
                 WorkspaceShellSearchSyncService,
+                WorkspaceShellSearchService,
                 { provide: Router, useValue: router },
                 {
                     provide: Store,
@@ -95,17 +110,23 @@ describe('WorkspaceShellSearchSyncService', () => {
                     useValue: {
                         setSearchTerm: jest.fn(),
                         setCategorySearchTerm: jest.fn(),
+                        getSelectedCategory: signal(null),
                     },
                 },
                 {
                     provide: StalkerStore,
-                    useValue: { setSearchPhrase: jest.fn() },
+                    useValue: {
+                        setSearchPhrase: jest.fn(),
+                        getSelectedCategoryName: signal(''),
+                        itvFullListActive: signal(false),
+                    },
                 },
             ],
         });
 
         routeState = TestBed.inject(WorkspaceShellRouteStateService);
         service = TestBed.inject(WorkspaceShellSearchSyncService);
+        searchService = TestBed.inject(WorkspaceShellSearchService);
     });
 
     afterEach(() => {
@@ -125,6 +146,13 @@ describe('WorkspaceShellSearchSyncService', () => {
 
         expect(service.appliedSearchQuery()).toBe('Beta Movie');
         expect(service.searchQuery()).toBe('Beta Movie');
+
+        // The term has to reach the URL — that is what the page reads back.
+        TestBed.flushEffects();
+        expect(router.navigateByUrl).toHaveBeenCalledWith(
+            `${DOWNLOADS_URL}?q=Beta+Movie`,
+            { replaceUrl: true }
+        );
     });
 
     it('does not roll typing back to the term its own q navigation echoes', () => {
@@ -166,6 +194,38 @@ describe('WorkspaceShellSearchSyncService', () => {
         jest.advanceTimersByTime(SEARCH_INPUT_DEBOUNCE_MS);
 
         expect(service.appliedSearchQuery()).toBe('Alpha');
+    });
+
+    it('lets browser history win over in-flight typing', () => {
+        // Back/forward is authoritative even when the entry restores the term
+        // already applied — only app-initiated navigations are treated as
+        // echoes worth ignoring.
+        service.onSearchInput('Beta');
+        jest.advanceTimersByTime(SEARCH_INPUT_DEBOUNCE_MS);
+        service.onSearchInput('Beta Movie');
+
+        navigateTo(`${DOWNLOADS_URL}?q=Beta`, 'popstate');
+
+        expect(service.searchQuery()).toBe('Beta');
+
+        jest.advanceTimersByTime(SEARCH_INPUT_DEBOUNCE_MS);
+
+        expect(service.appliedSearchQuery()).toBe('Beta');
+    });
+
+    it('does not let a pending keystroke reapply behind an Enter commit', () => {
+        // Enter commits the trimmed term immediately; the debounce still
+        // holding the untrimmed keystroke must not overwrite it afterwards.
+        service.onSearchInput('Beta Movie ');
+        searchService.onSearchEnter('Beta Movie ');
+
+        expect(service.appliedSearchQuery()).toBe('Beta Movie');
+
+        navigateTo(`${DOWNLOADS_URL}?q=Beta+Movie`);
+        jest.advanceTimersByTime(SEARCH_INPUT_DEBOUNCE_MS);
+
+        expect(service.appliedSearchQuery()).toBe('Beta Movie');
+        expect(service.searchQuery()).toBe('Beta Movie');
     });
 
     it('syncs the search box from the url when nothing is being typed', () => {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-search-sync.service.spec.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-search-sync.service.spec.ts
@@ -1,0 +1,183 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NavigationEnd, Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { TranslateService } from '@ngx-translate/core';
+import { Subject, of } from 'rxjs';
+import { PlaylistContextFacade } from '@iptvnator/playlist/shared/util';
+import { StalkerStore } from '@iptvnator/portal/stalker/data-access';
+import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
+import { RuntimeCapabilitiesService } from '@iptvnator/services';
+import { WorkspaceStartupPreferencesService } from '@iptvnator/workspace/shell/util';
+import { SEARCH_INPUT_DEBOUNCE_MS } from './helpers/workspace-shell-constants';
+import { WorkspaceShellRouteStateService } from './workspace-shell-route-state.service';
+import { WorkspaceShellSearchSyncService } from './workspace-shell-search-sync.service';
+
+const DOWNLOADS_URL = '/workspace/downloads';
+
+describe('WorkspaceShellSearchSyncService', () => {
+    let service: WorkspaceShellSearchSyncService;
+    let routeState: WorkspaceShellRouteStateService;
+    let events: Subject<NavigationEnd>;
+    let router: {
+        url: string;
+        events: Subject<NavigationEnd>;
+        navigate: jest.Mock;
+        navigateByUrl: jest.Mock;
+        parseUrl: jest.Mock;
+    };
+
+    /** Emits the NavigationEnd both shell services listen for. */
+    function navigateTo(url: string): void {
+        router.url = url;
+        events.next(new NavigationEnd(1, url, url));
+    }
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        events = new Subject<NavigationEnd>();
+        router = {
+            url: DOWNLOADS_URL,
+            events,
+            navigate: jest.fn().mockResolvedValue(true),
+            navigateByUrl: jest.fn().mockResolvedValue(true),
+            parseUrl: jest.fn((url: string) => {
+                const parsed = new URL(url, 'http://localhost');
+                const queryParams: Record<string, string> = {};
+                parsed.searchParams.forEach((value, key) => {
+                    queryParams[key] = value;
+                });
+                return { queryParams };
+            }),
+        };
+
+        TestBed.configureTestingModule({
+            providers: [
+                WorkspaceShellRouteStateService,
+                WorkspaceShellSearchSyncService,
+                { provide: Router, useValue: router },
+                {
+                    provide: Store,
+                    useValue: {
+                        selectSignal: jest.fn().mockReturnValue(signal([])),
+                        dispatch: jest.fn(),
+                    },
+                },
+                {
+                    provide: PlaylistContextFacade,
+                    useValue: { activePlaylist: signal(null) },
+                },
+                {
+                    provide: WorkspaceStartupPreferencesService,
+                    useValue: {
+                        getFirstAvailableWorkspacePath: jest.fn(() => '/'),
+                        persistLastRestorablePath: jest.fn(),
+                        showDashboard: jest.fn(() => true),
+                    },
+                },
+                {
+                    provide: TranslateService,
+                    useValue: {
+                        instant: jest.fn((key: string) => key),
+                        onLangChange: of(null),
+                    },
+                },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: {
+                        isElectron: true,
+                        isMacOS: true,
+                        supportsDownloads: true,
+                    },
+                },
+                {
+                    provide: XtreamStore,
+                    useValue: {
+                        setSearchTerm: jest.fn(),
+                        setCategorySearchTerm: jest.fn(),
+                    },
+                },
+                {
+                    provide: StalkerStore,
+                    useValue: { setSearchPhrase: jest.fn() },
+                },
+            ],
+        });
+
+        routeState = TestBed.inject(WorkspaceShellRouteStateService);
+        service = TestBed.inject(WorkspaceShellSearchSyncService);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('keeps in-flight typing when the page writes an unrelated query param', () => {
+        // The downloads filter chips write `?filter=…` with replaceUrl. Under
+        // load that navigation can land after the first keystroke — it must
+        // not eat the search term the user is still typing.
+        service.onSearchInput('Beta Movie');
+        navigateTo(DOWNLOADS_URL);
+
+        expect(service.searchQuery()).toBe('Beta Movie');
+
+        jest.advanceTimersByTime(SEARCH_INPUT_DEBOUNCE_MS);
+
+        expect(service.appliedSearchQuery()).toBe('Beta Movie');
+        expect(service.searchQuery()).toBe('Beta Movie');
+    });
+
+    it('does not roll typing back to the term its own q navigation echoes', () => {
+        service.onSearchInput('Beta');
+        jest.advanceTimersByTime(SEARCH_INPUT_DEBOUNCE_MS);
+        expect(service.appliedSearchQuery()).toBe('Beta');
+
+        // The user keeps typing while the applied term reaches the URL.
+        service.onSearchInput('Beta Movie');
+        navigateTo(`${DOWNLOADS_URL}?q=Beta`);
+
+        expect(service.searchQuery()).toBe('Beta Movie');
+
+        jest.advanceTimersByTime(SEARCH_INPUT_DEBOUNCE_MS);
+
+        expect(service.appliedSearchQuery()).toBe('Beta Movie');
+    });
+
+    it('clears in-flight typing when the navigation leaves the page', () => {
+        service.onSearchInput('Beta Movie');
+        navigateTo('/workspace/sources');
+
+        expect(service.searchQuery()).toBe('');
+
+        jest.advanceTimersByTime(SEARCH_INPUT_DEBOUNCE_MS);
+
+        expect(service.appliedSearchQuery()).toBe('');
+        expect(service.searchQuery()).toBe('');
+    });
+
+    it('adopts a same-page q that differs from the applied term', () => {
+        // Back/forward and the command palette change `q` in place; that is
+        // real search intent and wins over whatever is being typed.
+        service.onSearchInput('Beta Movie');
+        navigateTo(`${DOWNLOADS_URL}?q=Alpha`);
+
+        expect(service.searchQuery()).toBe('Alpha');
+
+        jest.advanceTimersByTime(SEARCH_INPUT_DEBOUNCE_MS);
+
+        expect(service.appliedSearchQuery()).toBe('Alpha');
+    });
+
+    it('syncs the search box from the url when nothing is being typed', () => {
+        navigateTo(`${DOWNLOADS_URL}?q=Gamma`);
+
+        expect(service.searchQuery()).toBe('Gamma');
+        expect(service.appliedSearchQuery()).toBe('Gamma');
+        expect(routeState.currentUrl()).toBe(`${DOWNLOADS_URL}?q=Gamma`);
+
+        navigateTo('/workspace/settings/general');
+
+        expect(service.searchQuery()).toBe('');
+        expect(service.appliedSearchQuery()).toBe('');
+    });
+});

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-search-sync.service.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-search-sync.service.ts
@@ -7,6 +7,7 @@ import { XtreamStore } from '@iptvnator/portal/xtream/data-access';
 import { parseWorkspaceShellRoute } from '@iptvnator/workspace/shell/util';
 import { SEARCH_INPUT_DEBOUNCE_MS } from './helpers/workspace-shell-constants';
 import {
+    getRoutePath,
     getRouteQueryParam,
     syncSearchQueryParam,
 } from './helpers/workspace-shell-route-utils';
@@ -22,6 +23,7 @@ export class WorkspaceShellSearchSyncService {
 
     private searchDebounceTimeoutId: ReturnType<typeof setTimeout> | null =
         null;
+    private lastSyncedUrl: string | null = null;
 
     readonly searchQuery = signal('');
     readonly appliedSearchQuery = signal('');
@@ -127,12 +129,30 @@ export class WorkspaceShellSearchSyncService {
     }
 
     private syncSearchFromUrl(url: string): void {
-        if (parseWorkspaceShellRoute(url).usesQuerySearch) {
-            this.setSearchState(getRouteQueryParam(this.router, url, 'q'));
+        const previousUrl = this.lastSyncedUrl;
+        this.lastSyncedUrl = url;
+
+        const nextTerm = parseWorkspaceShellRoute(url).usesQuerySearch
+            ? getRouteQueryParam(this.router, url, 'q')
+            : '';
+
+        // A navigation that stays on the same page and carries the term we
+        // already applied brings no search intent of its own: it is either an
+        // unrelated query param the page wrote (a filter chip, a refresh bump)
+        // or the router echoing back our own `q`. Syncing anyway would cancel
+        // the pending debounce and reset the box to the applied term, silently
+        // eating everything typed since — including the whole word, when the
+        // first keystroke has not been applied yet.
+        if (
+            this.searchDebounceTimeoutId !== null &&
+            previousUrl !== null &&
+            getRoutePath(url) === getRoutePath(previousUrl) &&
+            nextTerm === this.appliedSearchQuery()
+        ) {
             return;
         }
 
-        this.setSearchState('');
+        this.setSearchState(nextTerm);
     }
 
     private scheduleSearchApply(value: string): void {

--- a/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-search-sync.service.ts
+++ b/libs/workspace/shell/feature/src/lib/workspace-shell/services/workspace-shell-search-sync.service.ts
@@ -29,12 +29,7 @@ export class WorkspaceShellSearchSyncService {
     readonly appliedSearchQuery = signal('');
 
     constructor() {
-        this.destroyRef.onDestroy(() => {
-            if (this.searchDebounceTimeoutId !== null) {
-                clearTimeout(this.searchDebounceTimeoutId);
-                this.searchDebounceTimeoutId = null;
-            }
-        });
+        this.destroyRef.onDestroy(() => this.cancelPendingSearchApply());
 
         this.router.events
             .pipe(
@@ -115,16 +110,18 @@ export class WorkspaceShellSearchSyncService {
     }
 
     setSearchState(value: string): void {
-        if (this.searchDebounceTimeoutId !== null) {
-            clearTimeout(this.searchDebounceTimeoutId);
-            this.searchDebounceTimeoutId = null;
-        }
-
+        this.cancelPendingSearchApply();
         this.searchQuery.set(value);
         this.appliedSearchQuery.set(value);
     }
 
+    /**
+     * Applies a term now. This supersedes a queued debounce — pressing Enter
+     * commits the trimmed term, and the keystroke that is still waiting must
+     * not reapply the untrimmed one behind it.
+     */
     applySearchQuery(value: string): void {
+        this.cancelPendingSearchApply();
         this.appliedSearchQuery.set(value);
     }
 
@@ -136,18 +133,24 @@ export class WorkspaceShellSearchSyncService {
             ? getRouteQueryParam(this.router, url, 'q')
             : '';
 
-        // A navigation that stays on the same page and carries the term we
-        // already applied brings no search intent of its own: it is either an
-        // unrelated query param the page wrote (a filter chip, a refresh bump)
-        // or the router echoing back our own `q`. Syncing anyway would cancel
-        // the pending debounce and reset the box to the applied term, silently
-        // eating everything typed since — including the whole word, when the
-        // first keystroke has not been applied yet.
+        // An app-initiated navigation that stays on the same page and carries
+        // the term we already applied brings no search intent of its own: it is
+        // either an unrelated query param the page wrote (a filter chip, a
+        // refresh bump) or the router echoing back our own `q`. Syncing anyway
+        // would cancel the pending debounce and reset the box to the applied
+        // term, silently eating everything typed since — including the whole
+        // word, when the first keystroke has not been applied yet.
+        //
+        // The trigger check keeps that narrow: history is always authoritative,
+        // so back/forward re-applies what the entry carries even mid-typing.
+        // `lastSuccessfulNavigation` is set immediately before `NavigationEnd`
+        // is emitted, so it describes the navigation being handled here.
         if (
             this.searchDebounceTimeoutId !== null &&
             previousUrl !== null &&
             getRoutePath(url) === getRoutePath(previousUrl) &&
-            nextTerm === this.appliedSearchQuery()
+            nextTerm === this.appliedSearchQuery() &&
+            this.router.lastSuccessfulNavigation()?.trigger === 'imperative'
         ) {
             return;
         }
@@ -156,13 +159,17 @@ export class WorkspaceShellSearchSyncService {
     }
 
     private scheduleSearchApply(value: string): void {
-        if (this.searchDebounceTimeoutId !== null) {
-            clearTimeout(this.searchDebounceTimeoutId);
-        }
-
+        this.cancelPendingSearchApply();
         this.searchDebounceTimeoutId = setTimeout(() => {
             this.searchDebounceTimeoutId = null;
             this.applySearchQuery(value);
         }, SEARCH_INPUT_DEBOUNCE_MS);
+    }
+
+    private cancelPendingSearchApply(): void {
+        if (this.searchDebounceTimeoutId !== null) {
+            clearTimeout(this.searchDebounceTimeoutId);
+            this.searchDebounceTimeoutId = null;
+        }
     }
 }


### PR DESCRIPTION
## Problem

`apps/electron-backend-e2e/src/downloads.e2e.ts:411` was flaky in CI, failing all 3 attempts on the `q` query-param poll after `search.fill('Beta Movie')` (master run [31568352129](https://github.com/4gray/iptvnator/actions/runs/31568352129), PR #1420 run [31615342591](https://github.com/4gray/iptvnator/actions/runs/31615342591)).

The race is in product code, not the test.

`WorkspaceShellSearchSyncService` re-reads `q` on **every** `NavigationEnd` and unconditionally calls `setSearchState(...)`, which cancels the pending debounce **and** overwrites `searchQuery` (bound to the input via `[value]`).

The test clicks `downloads-filter-all` and fills the searchbox with nothing awaited in between. That chip's `replaceUrl` navigation carries no search intent, but when it lands after the keystroke it wipes the typed text and kills the debounce — so `q` is never written and nothing re-triggers it.

This is user-facing beyond the test:

- switch a filter and immediately type → the term is lost
- type fast enough that the app's own `q` write lands mid-word → the box snaps back to the earlier word

## Fix

While input is debouncing, ignore a navigation that stays on the same page and carries the term already applied. Real search intent — route change, back/forward, a different `q` — still syncs as before.

`getRoutePath()` is extracted next to it and reused by the two existing callers that hand-rolled `split('?')[0]`.

## Reproduction

Playwright's `click()` + `fill()` each round-trip, so the navigation always finishes first and the race never happens locally. Dispatching the chip click and the `input` event in the **same page task** makes it deterministic:

```
13754 q=null input=""   ← "Beta Movie" already wiped, stays "" forever
```

CPU throttling alone did not reproduce it (verified applied: 4 ms → 60 ms busy loop at rate 20) — timers still fire on wall clock, so the debounce still won.

## Verification

| Check | Result |
|---|---|
| New spec vs **unfixed** code | 2 regression tests fail, 3 guard tests pass |
| New spec vs fixed code | 5/5 pass |
| `nx test workspace-shell-feature` | 149/149 |
| `nx affected -t test` | 277/277 across 3 projects |
| Forced-interleave e2e repro | passes (also under 20× CPU throttling) |
| `downloads.e2e.ts` full file | 6/6 |
| `nx lint workspace-shell-feature` | clean |
| `release:notes:validate` | 105 valid |

The 3 guard tests passing on *both* versions is what shows the regression tests aren't vacuous and that the guard doesn't over-apply.

## Notes

- `downloads.e2e.ts` is untouched — the behavior was wrong, not the assertion.
- No e2e regression added: expressing the interleave requires raw DOM dispatch that fights the suite's idiom, and the unit tests pin the shell contract deterministically.
- New spec is a separate file because the facade spec sits at 1145 of its 1200-line budget.
- `docs/architecture/workspace-shell.md` records the contract as rule 8, since pages writing their own query params now depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)