### PR TITLE
test(playback): drive embedded MPV controller specs on a fake clock

### DIFF
--- a/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-session-controller.dpr.spec.ts
+++ b/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-session-controller.dpr.spec.ts
@@ -50,6 +50,9 @@ describe('EmbeddedMpvSessionController devicePixelRatio watch', () => {
     let mediaQueries: FakeMediaQueryList[];
 
     beforeEach(() => {
+        // See `waitFor`: the startup chain is drained on a virtual clock so a
+        // loaded machine cannot change the outcome.
+        jest.useFakeTimers();
         electron = {
             platform: 'win32',
             getEmbeddedMpvSupport: jest
@@ -110,6 +113,7 @@ describe('EmbeddedMpvSessionController devicePixelRatio watch', () => {
         TestBed.resetTestingModule();
         delete (window as unknown as { electron?: unknown }).electron;
         delete (window as unknown as { matchMedia?: unknown }).matchMedia;
+        jest.useRealTimers();
         jest.restoreAllMocks();
     });
 
@@ -197,17 +201,25 @@ function createSession(): EmbeddedMpvSession {
     };
 }
 
+/**
+ * Settle the controller's async startup chain on the fake clock, bounded by
+ * drain rounds rather than wall-clock time — under parallel Jest workers a
+ * real-timer deadline expired before the chain settled and failed at random.
+ *
+ * One millisecond per round, never zero: `waitForStartupPaint` nests rAF
+ * inside rAF, and a zero-delay timer scheduled from inside a timer callback is
+ * clamped to the next millisecond, so a 0ms advance strands the inner hop.
+ */
 async function waitFor(
     condition: () => boolean,
     description: string
 ): Promise<void> {
-    const deadline = Date.now() + 1_000;
-    while (Date.now() < deadline) {
+    for (let round = 0; round < 100; round += 1) {
         if (condition()) {
             return;
         }
         await Promise.resolve();
-        await new Promise((resolve) => window.setTimeout(resolve, 0));
+        await jest.advanceTimersByTimeAsync(1);
     }
     throw new Error(`Timed out waiting for ${description}`);
 }

--- a/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-session-controller.lifecycle.spec.ts
+++ b/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-session-controller.lifecycle.spec.ts
@@ -27,6 +27,9 @@ describe('EmbeddedMpvSessionController (lifecycle & support edges)', () => {
         });
 
     beforeEach(() => {
+        // See `waitFor`: the startup chain is drained on a virtual clock so a
+        // loaded machine cannot change the outcome.
+        jest.useFakeTimers();
         electron = {
             platform: 'darwin',
             getEmbeddedMpvSupport: jest
@@ -167,7 +170,6 @@ describe('EmbeddedMpvSessionController (lifecycle & support edges)', () => {
 
     it('flags a stalled session after 30s of loading and clears it on playback', async () => {
         const controller = TestBed.inject(EmbeddedMpvSessionController);
-        jest.useFakeTimers();
 
         controller.session.set(createSession({ status: 'loading' }));
         TestBed.tick();
@@ -243,8 +245,7 @@ describe('EmbeddedMpvSessionController (lifecycle & support edges)', () => {
 
         teardown();
         resolveLoad?.();
-        await Promise.resolve();
-        await new Promise((resolve) => window.setTimeout(resolve, 0));
+        await flush();
 
         expect(electron.attachEmbeddedMpvFrameView).not.toHaveBeenCalled();
         expect(controller.session()).toBeNull();
@@ -288,8 +289,7 @@ describe('EmbeddedMpvSessionController (lifecycle & support edges)', () => {
             'requestAnimationFrame'
         );
         resolveAttach?.(true);
-        await Promise.resolve();
-        await new Promise((resolve) => window.setTimeout(resolve, 0));
+        await flush();
 
         expect(requestAnimationFrame).not.toHaveBeenCalled();
         expect(controller.session()).toBeNull();
@@ -377,17 +377,36 @@ function createSession(
     };
 }
 
+async function drainRound(): Promise<void> {
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(1);
+}
+
+/**
+ * Settle the controller's async startup chain on the fake clock, bounded by
+ * drain rounds rather than wall-clock time — under parallel Jest workers a
+ * real-timer deadline expired before the chain settled and failed at random.
+ *
+ * One millisecond per round, never zero: `waitForStartupPaint` nests rAF
+ * inside rAF, and a zero-delay timer scheduled from inside a timer callback is
+ * clamped to the next millisecond, so a 0ms advance strands the inner hop.
+ */
 async function waitFor(
     condition: () => boolean,
     description: string
 ): Promise<void> {
-    const deadline = Date.now() + 1_000;
-    while (Date.now() < deadline) {
+    for (let round = 0; round < 100; round += 1) {
         if (condition()) {
             return;
         }
-        await Promise.resolve();
-        await new Promise((resolve) => window.setTimeout(resolve, 0));
+        await drainRound();
     }
     throw new Error(`Timed out waiting for ${description}`);
+}
+
+/** Settle everything pending where there is no condition to poll for. */
+async function flush(): Promise<void> {
+    for (let round = 0; round < 5; round += 1) {
+        await drainRound();
+    }
 }

--- a/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-session-controller.spec.ts
+++ b/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-session-controller.spec.ts
@@ -24,6 +24,10 @@ describe('EmbeddedMpvSessionController', () => {
     let testingModuleDestroyed: boolean;
 
     beforeEach(() => {
+        // Fake timers before anything else: the controller's startup chain is
+        // driven from here (see `waitFor`), and the rAF shim below defers
+        // through `setTimeout`, so it has to resolve to the faked one.
+        jest.useFakeTimers();
         testingModuleDestroyed = false;
         sessionUpdate = null;
         unsubscribeSessionUpdate = jest.fn();
@@ -98,6 +102,9 @@ describe('EmbeddedMpvSessionController', () => {
             TestBed.resetTestingModule();
         }
         delete (window as unknown as { electron?: unknown }).electron;
+        // After teardown has cancelled the controller's timers, so the stalled
+        // tracker's 30s timeout never leaks into the real timer queue.
+        jest.useRealTimers();
         jest.restoreAllMocks();
     });
 
@@ -218,7 +225,7 @@ describe('EmbeddedMpvSessionController', () => {
         controller.session.set(newer);
 
         rejectPrepare?.(new Error('native module missing'));
-        await new Promise((resolve) => window.setTimeout(resolve, 0));
+        await flush();
 
         expect(controller.session()).toBe(newer);
         expect(controller.sessionId()).toBe('mpv-2');
@@ -363,19 +370,54 @@ function createSession(
     };
 }
 
+/**
+ * Advance the fake clock by one drain round: flush pending microtasks (the IPC
+ * promises the startup chain awaits), then run every timer now due — which is
+ * how the rAF shim's continuations get to run.
+ *
+ * One millisecond, never zero: a zero-delay timer scheduled from *inside* a
+ * timer callback is clamped to the next millisecond, and `waitForStartupPaint`
+ * nests exactly that way (rAF inside rAF). Advancing by 0 fires the outer hop
+ * and strands the inner one forever.
+ */
+async function drainRound(): Promise<void> {
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(1);
+}
+
+/**
+ * Settle the controller's async startup chain, then assert.
+ *
+ * The bound is a number of drain rounds, not elapsed wall-clock time. Polling
+ * real timers against a `Date.now()` deadline made these specs load-sensitive:
+ * under parallel Jest workers the budget expired before the chain settled, so
+ * a different pair of tests failed on each run. With the clock virtual, how
+ * busy the machine is no longer changes the outcome — the rounds only ever
+ * advance when this loop says so.
+ */
 async function waitFor(
     condition: () => boolean,
     description: string
 ): Promise<void> {
-    const deadline = Date.now() + 1_000;
-
-    while (Date.now() < deadline) {
+    // Generous next to the ~4 rounds the longest chain needs, while still
+    // failing fast (and reporting `description`) if it never settles.
+    for (let round = 0; round < 100; round += 1) {
         if (condition()) {
             return;
         }
-        await Promise.resolve();
-        await new Promise((resolve) => window.setTimeout(resolve, 0));
+        await drainRound();
     }
 
     throw new Error(`Timed out waiting for ${description}`);
+}
+
+/**
+ * Settle everything pending with no condition to poll for — used by the
+ * negative assertions, where the point is that a late continuation runs and
+ * still changes nothing.
+ */
+async function flush(): Promise<void> {
+    for (let round = 0; round < 5; round += 1) {
+        await drainRound();
+    }
 }

--- a/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-session-controller.spec.ts
+++ b/libs/ui/playback/src/lib/embedded-mpv-player/embedded-mpv-session-controller.spec.ts
@@ -391,9 +391,10 @@ async function drainRound(): Promise<void> {
  * The bound is a number of drain rounds, not elapsed wall-clock time. Polling
  * real timers against a `Date.now()` deadline made these specs load-sensitive:
  * under parallel Jest workers the budget expired before the chain settled, so
- * a different pair of tests failed on each run. With the clock virtual, how
- * busy the machine is no longer changes the outcome — the rounds only ever
- * advance when this loop says so.
+ * a different pair of tests failed on each run. With the clock virtual the
+ * spec imposes no deadline of its own — the rounds only ever advance when this
+ * loop says so — so settling stops being a race against the machine. Jest's
+ * own per-test timeout still applies, as it does to every spec.
  */
 async function waitFor(
     condition: () => boolean,


### PR DESCRIPTION
## Problem

`pnpm nx test ui-playback --skip-nx-cache` intermittently failed **2 tests of `embedded-mpv-session-controller.spec.ts` — a different pair each run**. E.g. one run failed *"loads support and unsubscribes from session updates on destroy"* + *"ignores a late startup rejection after teardown…"*, the next failed *"starts a session, forwards matching updates…"* + *"sets an error session when Electron cannot create playback"*.

## Root cause

The spec's `waitFor` helper polled **real timers against a `Date.now() + 1_000` wall-clock deadline**. Under load from parallel Jest workers, the controller's async startup chain (support load → `waitForStartupPaint` → session create → update subscription) did not settle inside that budget, and whichever tests lost the race failed. The controller itself is not at fault — only the spec's flushing strategy.

Reproduced deterministically by running the suite at `--maxWorkers=32` on a 10-core machine; every failure was `Timed out waiting for …` thrown by `waitFor` itself.

## Fix

`jest.useFakeTimers()` in `beforeEach` / `useRealTimers()` in `afterEach`, and `waitFor` now bounds itself by **drain rounds instead of elapsed time**, so machine load can no longer change the outcome. Added a `flush()` helper for the negative assertions that have no condition to poll.

**Assertions and behavior under test are unchanged** — only the flushing mechanism.

### One non-obvious detail

Each round advances **1ms, never 0ms**. `waitForStartupPaint()` nests rAF inside rAF, and a zero-delay timer scheduled from *inside* a timer callback is clamped to the next millisecond. A `advanceTimersByTimeAsync(0)` fires the outer hop and **strands the inner one forever** — that would have converted the flake into a hang to Jest's 5s timeout. Verified empirically with a throwaway probe before committing to the approach:

| advance | nested rAF chain |
|---|---|
| `0` | `["raf1"]` — never completes |
| `1` | `["raf1","raf2","resolved"]` |

## Scope

The task named one file, but the two siblings — `.dpr.spec.ts` and `.lifecycle.spec.ts` — carry a **byte-identical `waitFor`** and were demonstrated flaking under the same repro. They are included because `--testPathPatterns` is ignored by `tools/testing/run-web-esm-lib-tests.mjs` (it passes `--runTestsByPath` with every spec, which takes precedence), so any verification run of this project executes all three; leaving them would have made the fix unverifiable. The pattern now appears nowhere else in the repo.

## Verification

| condition | before | after |
|---|---|---|
| `--maxWorkers=32` (repro) | failed 2/2 runs | **5/5 runs, 975/975** |
| `pnpm nx test ui-playback --skip-nx-cache` ×5 | passed (flake needs load) | **5/5 runs, 975/975** |
| three specs solo | ~62s est. | 18/18 in 4.2s |

ESLint clean on all three files. The `"A worker process has failed to exit gracefully"` warning also disappeared — fake timers stop the stalled tracker's 30s timeout leaking into the real timer queue.

## Notes

- **No release note**: test-only change; `.spec.ts` is auto-exempt in `tools/release/check-release-note-gate.mjs:31`, so no `no-release-note` label is required either.
- **No doc update**: CLAUDE.md lists isolated test-only changes as a skip case.
- Two *unrelated* specs (`VodDetailsComponent`, `WebPlayerViewComponent recovery integration`) also failed under `--maxWorkers=32` before this change, but via Jest's own 5000ms timeout — a different mechanism, not investigated here. They were green across all 10 post-fix runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)