### PR TITLE
fix(playback): apply saved player changes to mounted web players

### DIFF
--- a/.changes/playback-live-player-switch.md
+++ b/.changes/playback-live-player-switch.md
@@ -1,0 +1,10 @@
+---
+type: fix
+area: playback
+---
+
+Switching the video player — from the command palette or the settings page —
+now takes effect immediately on an already-playing Xtream or Stalker stream
+instead of waiting for the player to be reopened. Playback also starts with
+the saved player right away, without briefly mounting the default engine
+first.

--- a/apps/web-e2e/src/xtream.e2e.ts
+++ b/apps/web-e2e/src/xtream.e2e.ts
@@ -534,6 +534,139 @@ test('@xtream minimal scenario — reduced item count', async ({ request }) => {
     expect(streams.length).toBe(10);
 });
 
+// ---------------------------------------------------------------------------
+// Player engine selection on the live route
+//
+// The Xtream live layout mounts app-web-player-view WITHOUT a playerOverride,
+// so the engine must track the saved player setting live. Regression guarded:
+// the engine used to come from a one-shot storage snapshot taken at mount, so
+// a command-palette switch confirmed via snackbar and persisted the setting
+// while the mounted player silently kept the previous engine.
+// ---------------------------------------------------------------------------
+
+async function openLiveChannel(page: Page): Promise<void> {
+    await page.goto(page.url().replace(/\/vod.*$/, '/live'));
+
+    // On the live root the category click updates store state without
+    // navigating; the channel sidebar appearing is the completion signal.
+    const firstCategory = page
+        .locator('.context-panel .category-item')
+        .first();
+    await expect(firstCategory).toBeVisible();
+    await firstCategory.click();
+
+    const channel = page
+        .locator('app-live-stream-layout [data-test-id="channel-item"]')
+        .first();
+    await expect(channel).toBeVisible();
+    await channel.click();
+}
+
+test('@xtream command palette player switch reaches the mounted live player', async ({
+    page,
+}) => {
+    await addXtreamPortal(page);
+    await openLiveChannel(page);
+
+    const playerView = page.locator('app-web-player-view');
+    await expect(playerView.locator('app-vjs-player')).toBeVisible({
+        timeout: 15_000,
+    });
+
+    // Tag the mounted layout so the final assertion proves the switch reached
+    // the EXISTING player instead of surviving through a layout remount.
+    await page.locator('app-live-stream-layout').evaluate((el) => {
+        (el as HTMLElement & { __e2eSameMount?: boolean }).__e2eSameMount =
+            true;
+    });
+
+    await page.keyboard.press('Control+k');
+    const palette = page.locator('.workspace-command-palette-overlay');
+    await expect(palette).toBeVisible();
+    await palette.locator('input[type="search"]').fill('html5');
+    await palette
+        .getByRole('button', { name: 'Switch player to HTML5 video player' })
+        .click();
+
+    await expect(playerView.locator('app-html-video-player')).toBeVisible({
+        timeout: 15_000,
+    });
+    await expect(playerView.locator('app-vjs-player')).toHaveCount(0);
+    expect(
+        await page
+            .locator('app-live-stream-layout')
+            .evaluate(
+                (el) =>
+                    (el as HTMLElement & { __e2eSameMount?: boolean })
+                        .__e2eSameMount
+            )
+    ).toBe(true);
+});
+
+test('@xtream the saved engine mounts the live player first time — no default-engine flash', async ({
+    page,
+}) => {
+    // Persist HTML5 as the saved player before any player ever mounts.
+    await page.goto('/workspace/settings/playback');
+    await page.locator('[data-test-id="select-video-player"]').click();
+    await page
+        .getByRole('option', { name: 'HTML5 video player', exact: true })
+        .click();
+    const saveButton = page.getByRole('button', { name: 'Save changes' });
+    await saveButton.click();
+    await expect(saveButton).toBeHidden();
+
+    await page.goto('/');
+    await addXtreamPortal(page);
+    await page.goto(page.url().replace(/\/vod.*$/, '/live'));
+    const firstCategory = page
+        .locator('.context-panel .category-item')
+        .first();
+    await expect(firstCategory).toBeVisible();
+    await firstCategory.click();
+
+    // Record every engine that is ever attached. A polling assertion cannot
+    // see the defect this guards: mounting Video.js first and correcting to
+    // the saved engine once the async settings read lands leaves the same
+    // final DOM.
+    await page.evaluate(() => {
+        const seen = new Set<string>();
+        (window as unknown as { __enginesSeen: Set<string> }).__enginesSeen =
+            seen;
+        const record = () => {
+            for (const selector of [
+                'app-vjs-player',
+                'app-html-video-player',
+            ]) {
+                if (document.querySelector(selector)) {
+                    seen.add(selector);
+                }
+            }
+        };
+        record();
+        new MutationObserver(record).observe(document.body, {
+            childList: true,
+            subtree: true,
+        });
+    });
+
+    const channel = page
+        .locator('app-live-stream-layout [data-test-id="channel-item"]')
+        .first();
+    await expect(channel).toBeVisible();
+    await channel.click();
+
+    await expect(
+        page.locator('app-web-player-view app-html-video-player')
+    ).toBeVisible({ timeout: 15_000 });
+    expect(
+        await page.evaluate(() => [
+            ...(window as unknown as { __enginesSeen: Set<string> })
+                .__enginesSeen,
+        ])
+    ).toEqual(['app-html-video-player']);
+});
+
 type XtreamLiveStream = {
     category_id: string;
     name: string;

--- a/docs/architecture/embedded-inline-playback.md
+++ b/docs/architecture/embedded-inline-playback.md
@@ -375,7 +375,10 @@ mounted `WebPlayerViewComponent` in place as a new playback application, and a
 first mount reads the already-loaded store value so the default engine never
 flashes before the saved one. Hosts that pass no `playerOverride` (the Xtream
 and Stalker live layouts, the portal inline detail player) rely on this live
-tracking.
+tracking. A saved switch to managed MPV/VLC is the one exception
+(`resolveRenderableWebPlayer`): the viewport can neither render nor launch an
+external player, so the mounted engine is retained and the external choice
+applies when the host starts the next playback.
 
 Video.js, HTML5, and ArtPlayer
 report native media errors, hls.js errors, Video.js/VHS errors, Shaka errors,

--- a/docs/architecture/embedded-inline-playback.md
+++ b/docs/architecture/embedded-inline-playback.md
@@ -364,7 +364,20 @@ Current contract:
 
 The shared `WebPlayerViewComponent` is the central browser-player viewport for
 M3U, Xtream, and Stalker inline playback, including live streams opened from
-favorites and recently viewed collections. Video.js, HTML5, and ArtPlayer
+favorites and recently viewed collections.
+
+The mounted engine resolves in a fixed order: temporary recovery override →
+host `playerOverride` input → the saved player read from the live
+`SettingsStore` signal (Video.js as the last-resort default). The saved player
+is deliberately NOT a mount-time storage snapshot: persisting a different
+player — from the settings page or the command palette — re-applies to every
+mounted `WebPlayerViewComponent` in place as a new playback application, and a
+first mount reads the already-loaded store value so the default engine never
+flashes before the saved one. Hosts that pass no `playerOverride` (the Xtream
+and Stalker live layouts, the portal inline detail player) rely on this live
+tracking.
+
+Video.js, HTML5, and ArtPlayer
 report native media errors, hls.js errors, Video.js/VHS errors, Shaka errors,
 mpegts.js errors, and HLS manifest codec metadata into the DOM-free classifiers
 exported by `@iptvnator/playback/util`.

--- a/libs/ui/playback/src/lib/web-player-view/web-player-recovery-policy.ts
+++ b/libs/ui/playback/src/lib/web-player-view/web-player-recovery-policy.ts
@@ -208,3 +208,19 @@ export function toInlinePlaybackPlayer(
             return null;
     }
 }
+
+/**
+ * Managed MPV/VLC cannot render inside the web player viewport and the view
+ * never launches them itself, so a mid-session saved-player switch to one
+ * retains whatever engine is already mounted — the external choice applies
+ * when the host starts the next playback. Every renderable player, including
+ * Embedded MPV, is applied directly.
+ */
+export function resolveRenderableWebPlayer(
+    configured: VideoPlayer,
+    previous?: { value: VideoPlayer }
+): VideoPlayer {
+    const external =
+        configured === VideoPlayer.MPV || configured === VideoPlayer.VLC;
+    return external && previous ? previous.value : configured;
+}

--- a/libs/ui/playback/src/lib/web-player-view/web-player-view.component.spec.ts
+++ b/libs/ui/playback/src/lib/web-player-view/web-player-view.component.spec.ts
@@ -656,6 +656,47 @@ describe('WebPlayerViewComponent', () => {
             ).toBeNull();
         });
 
+        it('retains the mounted engine when the saved player becomes MPV/VLC', async () => {
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(
+                fixture.debugElement.query(By.directive(StubVjsPlayerComponent))
+            ).not.toBeNull();
+
+            // The view can neither render nor launch an external player, so
+            // the switch must not blank the viewport; it applies when the
+            // host starts the next playback.
+            await TestBed.inject(SettingsStore).updateSettings({
+                player: VideoPlayer.MPV,
+            });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(
+                fixture.debugElement.query(By.directive(StubVjsPlayerComponent))
+            ).not.toBeNull();
+
+            // A later inline choice still applies live.
+            await TestBed.inject(SettingsStore).updateSettings({
+                player: VideoPlayer.Html5Player,
+            });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(
+                fixture.debugElement.query(By.directive(StubVjsPlayerComponent))
+            ).toBeNull();
+            expect(
+                fixture.debugElement.query(
+                    By.directive(StubHtmlVideoPlayerComponent)
+                )
+            ).not.toBeNull();
+        });
+
         it('keeps an explicit playerOverride ahead of the saved player', async () => {
             fixture.componentRef.setInput(
                 'playerOverride',

--- a/libs/ui/playback/src/lib/web-player-view/web-player-view.component.spec.ts
+++ b/libs/ui/playback/src/lib/web-player-view/web-player-view.component.spec.ts
@@ -12,9 +12,9 @@ import { By } from '@angular/platform-browser';
 import { VodSourceRowComponent } from '@iptvnator/ui/components';
 import { StorageMap } from '@ngx-pwa/local-storage';
 import { TranslateModule } from '@ngx-translate/core';
-import { of, Subject } from 'rxjs';
+import { of } from 'rxjs';
 import { VideoPlayer } from '@iptvnator/shared/interfaces';
-import { RuntimeCapabilitiesService } from '@iptvnator/services';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import { ErrorDetails, ErrorTypes } from 'hls.js';
 import type { WebPlayerViewComponent as WebPlayerViewComponentInstance } from './web-player-view.component';
 import {
@@ -119,6 +119,7 @@ describe('WebPlayerViewComponent', () => {
     let component: WebPlayerViewComponentInstance;
     const storageMap = {
         get: jest.fn(() => of({ player: VideoPlayer.VideoJs })),
+        set: jest.fn(() => of(undefined)),
     };
     let runtimeCapabilities: { supportsManagedExternalPlayers: boolean };
 
@@ -591,19 +592,7 @@ describe('WebPlayerViewComponent', () => {
         );
     });
 
-    it('renders embedded MPV before settings storage emits', () => {
-        fixture.destroy();
-
-        const pendingSettings = new Subject<unknown>();
-        storageMap.get.mockReturnValue(pendingSettings.asObservable());
-        fixture = TestBed.createComponent(WebPlayerViewComponent);
-        fixture.componentRef.setInput('playbackSessionKey', 'test-session');
-        component = fixture.componentInstance;
-        fixture.componentRef.setInput(
-            'streamUrl',
-            'https://example.com/archive/movie.mkv'
-        );
-        fixture.componentRef.setInput('title', 'Example Movie');
+    it('renders embedded MPV with an empty recording folder fallback', () => {
         fixture.componentRef.setInput(
             'playerOverride',
             VideoPlayer.EmbeddedMpv
@@ -615,6 +604,83 @@ describe('WebPlayerViewComponent', () => {
             By.directive(StubEmbeddedMpvPlayerComponent)
         ).componentInstance as StubEmbeddedMpvPlayerComponent;
         expect(player.recordingFolder()).toBe('');
+    });
+
+    describe('saved player changes', () => {
+        // The selected engine must come from the live SettingsStore signal.
+        // It used to come from a one-shot StorageMap snapshot taken at mount,
+        // so a saved player change (settings page, command palette) never
+        // reached an already-mounted Xtream/Stalker player.
+        it('switches the mounted engine when the saved player changes', async () => {
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(
+                fixture.debugElement.query(By.directive(StubVjsPlayerComponent))
+            ).not.toBeNull();
+
+            await TestBed.inject(SettingsStore).updateSettings({
+                player: VideoPlayer.Html5Player,
+            });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(
+                fixture.debugElement.query(By.directive(StubVjsPlayerComponent))
+            ).toBeNull();
+            expect(
+                fixture.debugElement.query(
+                    By.directive(StubHtmlVideoPlayerComponent)
+                )
+            ).not.toBeNull();
+        });
+
+        it('mounts the engine saved in the settings store on first render', async () => {
+            const settingsStore = TestBed.inject(SettingsStore);
+            await settingsStore.loadSettings();
+            await settingsStore.updateSettings({
+                player: VideoPlayer.ArtPlayer,
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(
+                fixture.debugElement.query(By.directive(StubArtPlayerComponent))
+            ).not.toBeNull();
+            expect(
+                fixture.debugElement.query(By.directive(StubVjsPlayerComponent))
+            ).toBeNull();
+        });
+
+        it('keeps an explicit playerOverride ahead of the saved player', async () => {
+            fixture.componentRef.setInput(
+                'playerOverride',
+                VideoPlayer.ArtPlayer
+            );
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            await TestBed.inject(SettingsStore).updateSettings({
+                player: VideoPlayer.Html5Player,
+            });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(
+                fixture.debugElement.query(By.directive(StubArtPlayerComponent))
+            ).not.toBeNull();
+            expect(
+                fixture.debugElement.query(
+                    By.directive(StubHtmlVideoPlayerComponent)
+                )
+            ).toBeNull();
+        });
     });
 
     it('suppresses browser diagnostics while embedded MPV is selected', () => {

--- a/libs/ui/playback/src/lib/web-player-view/web-player-view.component.ts
+++ b/libs/ui/playback/src/lib/web-player-view/web-player-view.component.ts
@@ -6,6 +6,7 @@ import {
     effect,
     inject,
     input,
+    linkedSignal,
     output,
     signal,
     untracked,
@@ -55,6 +56,7 @@ import { resolveWebPlayerMediaTitle } from './web-player-playback-state';
 import {
     createWebPlayerRecommendations,
     isPlaybackExternallyTransferable,
+    resolveRenderableWebPlayer,
     toInlinePlaybackPlayer,
     toVideoPlayer,
 } from './web-player-recovery-policy';
@@ -143,14 +145,21 @@ export class WebPlayerViewComponent implements OnDestroy {
 
     // Resolved from the live SettingsStore signal, not a mount-time storage
     // snapshot: a saved player change (settings page, command palette) must
-    // reach an already-mounted player without a remount.
+    // reach an already-mounted player without a remount. A saved managed
+    // MPV/VLC retains the mounted engine (resolveRenderableWebPlayer),
+    // because this view can neither render nor launch external players.
+    private readonly renderablePlayer = linkedSignal({
+        source: () =>
+            this.playerOverride() ??
+            this.settingsStore.player?.() ??
+            VideoPlayer.VideoJs,
+        computation: resolveRenderableWebPlayer,
+    });
     readonly selectedPlayer = computed<VideoPlayer>(() => {
         const temporary = this.recoverySession.temporaryPlayerOverride();
         return temporary
             ? toVideoPlayer(temporary)
-            : (this.playerOverride() ??
-                  this.settingsStore.player?.() ??
-                  VideoPlayer.VideoJs);
+            : this.renderablePlayer();
     });
     private readonly applicationState = createWebPlayerApplicationState({
         playback: this.playback,

--- a/libs/ui/playback/src/lib/web-player-view/web-player-view.component.ts
+++ b/libs/ui/playback/src/lib/web-player-view/web-player-view.component.ts
@@ -1,7 +1,6 @@
 import {
     Component,
     OnDestroy,
-    Signal,
     ViewEncapsulation,
     computed,
     effect,
@@ -11,8 +10,6 @@ import {
     signal,
     untracked,
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { StorageMap } from '@ngx-pwa/local-storage';
 import {
     type PlaybackDiagnostic,
     type PlaybackDiagnosticCode,
@@ -22,11 +19,9 @@ import {
 import { PORTAL_EXTERNAL_PLAYBACK } from '@iptvnator/portal/shared/util';
 import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import {
-    STORE_KEY,
     VideoPlayer,
     type Channel,
     type ResolvedPortalPlayback,
-    type Settings,
     type VodSourceDescriptor,
 } from '@iptvnator/shared/interfaces';
 import { ArtPlayerComponent } from '../art-player/art-player.component';
@@ -91,7 +86,6 @@ function resolveWebPlayerSharedControls(): boolean {
     encapsulation: ViewEncapsulation.None,
 })
 export class WebPlayerViewComponent implements OnDestroy {
-    private readonly storage = inject(StorageMap);
     private readonly runtime = inject(RuntimeCapabilitiesService);
     private readonly settingsStore = inject(SettingsStore);
     private readonly externalPlayback = inject(PORTAL_EXTERNAL_PLAYBACK, {
@@ -130,9 +124,6 @@ export class WebPlayerViewComponent implements OnDestroy {
     readonly previousEpisodeRequested = output<void>();
     readonly nextEpisodeRequested = output<void>();
 
-    readonly settings = toSignal(
-        this.storage.get(STORE_KEY.Settings)
-    ) as Signal<Settings | undefined>;
     readonly showCaptions = computed(
         () => this.settingsStore.showCaptions?.() ?? false
     );
@@ -150,12 +141,15 @@ export class WebPlayerViewComponent implements OnDestroy {
     channel: Channel | undefined;
     vjsOptions: VideoPlayerOptions | undefined;
 
+    // Resolved from the live SettingsStore signal, not a mount-time storage
+    // snapshot: a saved player change (settings page, command palette) must
+    // reach an already-mounted player without a remount.
     readonly selectedPlayer = computed<VideoPlayer>(() => {
         const temporary = this.recoverySession.temporaryPlayerOverride();
         return temporary
             ? toVideoPlayer(temporary)
             : (this.playerOverride() ??
-                  this.settings()?.player ??
+                  this.settingsStore.player?.() ??
                   VideoPlayer.VideoJs);
     });
     private readonly applicationState = createWebPlayerApplicationState({
@@ -208,7 +202,7 @@ export class WebPlayerViewComponent implements OnDestroy {
         isPlaybackExternallyTransferable(this.resolvedPlayback())
     );
     readonly recordingFolder = computed(
-        () => this.settings()?.recordingFolder ?? ''
+        () => this.settingsStore.recordingFolder?.() ?? ''
     );
     get supportsManagedExternalPlayers(): boolean {
         return this.runtime.supportsManagedExternalPlayers;


### PR DESCRIPTION
## Summary

Switching the video player from the command palette (⌘K → "Switch player to …") or the settings page had no effect on already-playing Xtream/Stalker streams: the snackbar confirmed the switch and `Settings.player` was persisted, but the mounted player kept the previous engine until remounted.

**Root cause:** `WebPlayerViewComponent` resolved the saved engine from a one-shot `StorageMap` snapshot (`toSignal(storage.get(...))` — `StorageMap.get()` emits once and completes) taken when the component was created. Neither the in-memory `SettingsStore` patch nor the IndexedDB write from `WorkspacePlayerCommandsContributor.activate()` ever reached it.

Two symptoms, one cause:

1. A palette/settings player switch never applied to a mounted player on hosts that pass no `playerOverride` (Xtream/Stalker live layouts, portal inline detail player). M3U layouts were unaffected — they already pass an override.
2. On first play those hosts mounted Video.js and swapped to the saved engine once the async storage read landed (brief wrong engine).

**Fix:** resolve the player (and `recordingFolder`) from the live `SettingsStore` signal and delete the snapshot entirely. Precedence is unchanged: temporary recovery override → host `playerOverride` → saved player → Video.js. A mid-VOD switch resumes at the recorded position; live restarts at the edge — the same semantics as recommendation-driven switches. Removing the snapshot *shrank* the file (~391 counted lines), so no `max-lines` split was needed.

## Tests

All new tests were verified to **fail with the fix reverted** and pass with it:

- **Unit** (`web-player-view.component.spec.ts`): mounted engine follows a `SettingsStore` player update; first render mounts the store's saved engine; `playerOverride` still outranks the saved player. Also reworked the obsolete "before settings storage emits" test whose pending-`Subject` mechanism guarded the now-deleted code path.
- **E2E** (`xtream.e2e.ts`, chromium/firefox/webkit): palette switch reaches the mounted live player without a layout remount (DOM-node tag proves identity); MutationObserver engines-ever-seen assertion that the saved engine mounts first time with no default-engine flash (polling can't catch this — both paths converge on the same final DOM).

`ui-playback` 978/978 green; host projects mounting the view (`playlist-m3u-feature-player`, `portal-stalker-feature`, `portal-xtream-feature`, `portal-shared-ui`) 849 tests green; lint green.

## Docs & release note

- `.changes/playback-live-player-switch.md` (type: fix, area: playback) — validated.
- `docs/architecture/embedded-inline-playback.md` now pins the engine-resolution order and that the saved player is deliberately live-tracked, not a mount-time snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)