### PR TITLE
test(playback): stub the inline player in the VOD details spec

### DIFF
--- a/jest.web-esm.workspace.ts
+++ b/jest.web-esm.workspace.ts
@@ -13,6 +13,12 @@ export default {
     ...angularEsmPreset,
     rootDir: '.',
     roots: ['<rootDir>/apps/web', '<rootDir>/libs'],
+    // Jest's 5s default is thin for Angular component specs: TestBed compiles
+    // and instantiates a real component tree per test, and CI runners are far
+    // slower per-core than a dev machine. A starved worker then fails a test
+    // that is merely slow, with no defect behind it. Raised as headroom only —
+    // a spec that genuinely hangs still fails, just later.
+    testTimeout: 15_000,
     setupFilesAfterEnv: ['<rootDir>/apps/web/src/test-setup.ts'],
     resolver: nxPreset.resolver,
     moduleFileExtensions: Array.from(

--- a/libs/ui/playback/src/lib/vod-details/vod-details.component.spec.ts
+++ b/libs/ui/playback/src/lib/vod-details/vod-details.component.spec.ts
@@ -1,8 +1,21 @@
-import { signal } from '@angular/core';
+import { Component, input, output, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import {
+    TranslateModule,
+    TranslatePipe,
+    TranslateService,
+} from '@ngx-translate/core';
+import { MatIcon } from '@angular/material/icon';
+import { SafePipe } from '@iptvnator/pipes';
+import {
+    DetailActionsTemplateDirective,
+    DetailMetaTemplateDirective,
+    DetailTagsTemplateDirective,
+    PortalDetailShellComponent,
+    ViewInPortalActionComponent,
+} from '@iptvnator/ui/components';
 import { PORTAL_EXTERNAL_PLAYBACK } from '@iptvnator/portal/shared/util';
 import {
     CrossPortalSimilarService,
@@ -22,6 +35,29 @@ jest.unstable_mockModule('video.js', () => ({
 jest.unstable_mockModule('@yangkghjh/videojs-aspect-ratio-panel', () => ({}));
 jest.unstable_mockModule('videojs-contrib-quality-levels', () => ({}));
 jest.unstable_mockModule('videojs-quality-selector-hls', () => ({}));
+
+/**
+ * Stand-in for the inline player. The real one imports
+ * `WebPlayerViewComponent`, which drags ArtPlayer, video.js and the
+ * embedded-MPV bridge into this suite and instantiates that whole tree on
+ * every `createComponent`. These specs only assert what the host *hands* the
+ * player, so mirroring the selector and the template's bindings is enough —
+ * and it keeps the per-test budget clear of Jest's timeout on slower CI
+ * hardware.
+ */
+@Component({
+    selector: 'app-portal-inline-player',
+    template: '<div data-test-id="stub-portal-inline-player"></div>',
+})
+class StubPortalInlinePlayerComponent {
+    readonly playbackSessionKey = input<string>('');
+    readonly playback = input<unknown>(null);
+    readonly timeUpdate = output<{ currentTime: number; duration: number }>();
+    readonly closed = output<void>();
+    readonly backClicked = output<void>();
+    readonly streamUrlCopied = output<void>();
+    readonly externalFallbackRequested = output<unknown>();
+}
 
 const STALKER_VOD: VodDetailsItem = createStalkerVodItem(
     {
@@ -250,7 +286,25 @@ describe('VodDetailsComponent offline playback', () => {
                     },
                 },
             ],
-        }).compileComponents();
+        })
+            .overrideComponent(VodDetailsComponent, {
+                // Same import list the component declares, with the inline
+                // player swapped for the stub above.
+                set: {
+                    imports: [
+                        DetailActionsTemplateDirective,
+                        DetailMetaTemplateDirective,
+                        DetailTagsTemplateDirective,
+                        MatIcon,
+                        PortalDetailShellComponent,
+                        ViewInPortalActionComponent,
+                        StubPortalInlinePlayerComponent,
+                        SafePipe,
+                        TranslatePipe,
+                    ],
+                },
+            })
+            .compileComponents();
 
         const translate = TestBed.inject(TranslateService);
         translate.setTranslation('en', {


### PR DESCRIPTION
Follow-up to #1434. That PR fixed specs that **raced a wall-clock deadline**; this one fixes specs that are simply **slow** against Jest's 5000ms default. Different mechanism, so it's a separate PR — and this branch is cut from `master`, independent of #1434.

## The problem

`VodDetailsComponent` and `WebPlayerViewComponent recovery` were failing under load with `Exceeded timeout of 5000 ms`. Neither contains a `setTimeout`, sleep, poll, or `Date.now()` deadline — there is no race to lose. The only clock is Jest's own budget, and what exhausts it is CPU-bound Angular TestBed work.

Measured idle on a 10-core M-series Mac (Jest JSON per-test `duration`):

| spec | slowest test | margin to 5s | `beforeEach` overhead |
|---|---|---|---|
| `vod-details.component.spec.ts` | 2521 ms | **2.0x** | ~1300 ms × 11 tests |
| `web-player-view.component.recovery.spec.ts` | 1877 ms | 2.7x | ~358 ms × 40 tests |
| `html-video-player.component.spec.ts` | 864 ms | 5.8x | ~419 ms × 15 tests |

A 2.0x margin on a dev machine is thin for `ubuntu-latest`.

## Two fixes, each doing a distinct job

**1. Stub the inline player in `vod-details`.** The spec imported the real tree, so every `createComponent` pulled `PortalInlinePlayerComponent` → `WebPlayerViewComponent` → ArtPlayer + video.js + the embedded-MPV bridge, and instantiated all of it. The specs only assert what the host *hands* the player, so a stand-in mirroring the selector and the template's bindings is enough.

- worst test **2521 ms → 306 ms** (8.2x)
- summed test time **3427 ms → 632 ms** (5.4x)
- assertions unchanged

`recovery` already stubs its players this way — this brings `vod-details` in line with the existing pattern.

**2. `testTimeout: 15_000`** on the shared web-ESM config (6 Angular component libs: `ui-playback`, `ui-components`, `ui-epg`, `@iptvnator/pipes`, `playlist-m3u-feature-player`, `playback-util`). Headroom, not a mute — a spec that genuinely hangs still fails, just later.

## Attribution

Both levers earn their place. Full suite at `--maxWorkers=48` on 10 cores:

| config | result |
|---|---|
| forced back to **5000ms** | `VodDetails` **no longer fails** (it did before this change) — the stubbing alone fixed it. `HtmlVideoPlayer` still does, which is what the timeout covers. |
| shipped **15000ms** | **2/2 runs, 975/975** |

## Verification

- All six projects sharing the config: **1656 tests passing**
- ESLint clean on both changed files
- `testTimeout: 15000` confirmed present in the resolved config via `jest --showConfig`

## Notes

- **No release note**: test/config-only; `.spec.ts` is auto-exempt in `tools/release/check-release-note-gate.mjs:31`. `jest.web-esm.workspace.ts` is build tooling with no runtime effect.
- **No doc update**: CLAUDE.md lists isolated test-only changes as a skip case.
- Not addressed here: `recovery`'s `.overrideComponent()` invalidates Angular's compiled-component cache, so its host recompiles across all 40 tests. At 2.7x margin it isn't urgent, and the timeout covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)