### PR TITLE
chore(deps): bump ngx-indexed-db from 21.0.0 to 22.0.0

### DIFF
--- a/.changes/deps-ngx-indexed-db-22.md
+++ b/.changes/deps-ngx-indexed-db-22.md
@@ -1,0 +1,6 @@
+---
+type: internal
+area: deps
+---
+
+Updated ngx-indexed-db (the PWA's IndexedDB storage library) from 21 to 22. No behavior change.

--- a/libs/shared/interfaces/package.json
+++ b/libs/shared/interfaces/package.json
@@ -6,7 +6,7 @@
     "main": "./src/index.js",
     "types": "./src/index.d.ts",
     "dependencies": {
-        "ngx-indexed-db": "^21.0.0",
+        "ngx-indexed-db": "^22.0.0",
         "tslib": "^2.3.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         "marked": "18.0.9",
         "mpegts.js": "1.8.1",
         "ms": "2.1.3",
-        "ngx-indexed-db": "21.0.0",
+        "ngx-indexed-db": "22.0.0",
         "ngx-skeleton-loader": "11.3.0",
         "rxjs": "7.8.2",
         "saxes": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: 2.1.3
         version: 2.1.3
       ngx-indexed-db:
-        specifier: 21.0.0
-        version: 21.0.0(@angular/common@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))
+        specifier: 22.0.0
+        version: 22.0.0(@angular/common@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))
       ngx-skeleton-loader:
         specifier: 11.3.0
         version: 11.3.0(@angular/common@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))
@@ -8806,11 +8806,11 @@ packages:
       '@angular/forms': 5.0.0-alpha - 5 || 6.0.0-alpha - 6 || 7.0.0-alpha - 7 || 8.0.0-alpha - 8 || 9.0.0-alpha - 9 || 10.0.0-alpha - 10 || 11.0.0-alpha - 11 || 12.0.0-alpha - 12 || 13.0.0-alpha - 13 || 14.0.0-alpha - 14 || 15.0.0-alpha - 15 || 16.0.0-alpha - 16 || 17.0.0-alpha - 17 || 18.0.0-alpha - 18 || 19.0.0-alpha - 19 || 20.0.0-alpha - 20 || 21.0.0-alpha - 21 || 22.0.0-alpha - 22
       '@angular/platform-browser': 5.0.0-alpha - 5 || 6.0.0-alpha - 6 || 7.0.0-alpha - 7 || 8.0.0-alpha - 8 || 9.0.0-alpha - 9 || 10.0.0-alpha - 10 || 11.0.0-alpha - 11 || 12.0.0-alpha - 12 || 13.0.0-alpha - 13 || 14.0.0-alpha - 14 || 15.0.0-alpha - 15 || 16.0.0-alpha - 16 || 17.0.0-alpha - 17 || 18.0.0-alpha - 18 || 19.0.0-alpha - 19 || 20.0.0-alpha - 20 || 21.0.0-alpha - 21 || 22.0.0-alpha - 22
 
-  ngx-indexed-db@21.0.0:
-    resolution: {integrity: sha512-781n0P4ZWt0CegInpvQ7WB2Z9Z9A4Pi3GKOUuAfsKFof4ZSv85g05+IXkSx+h3jBIibCuNWcQd77VLj84xLBQA==}
+  ngx-indexed-db@22.0.0:
+    resolution: {integrity: sha512-h8I1w9U/X5swG1Py3Ir9dPjxEVpE59aitIU+aP0PoQ8qYGWw+/7VYm7t6EJmvWHWedIczH1XBcqG65b/fONY6Q==}
     peerDependencies:
-      '@angular/common': '>=10.0.6 < 21.0.0'
-      '@angular/core': '>=10.0.6 < 21.0.0'
+      '@angular/common': '>=10.0.6 < 22.0.0'
+      '@angular/core': '>=10.0.6 < 22.0.0'
 
   ngx-skeleton-loader@11.3.0:
     resolution: {integrity: sha512-MLm5shgXGiCA1W5NEqct6glBFx2AEgEKbk8pDyY15BsZ2zTGUwa5jw4pe6nJdrCj6xcl/d9oFTinQHrO0q+3RA==}
@@ -10246,7 +10246,6 @@ packages:
 
   shaka-player@5.2.4:
     resolution: {integrity: sha512-vf81av2EIcb03jRpeeZBhrPT3PMyggXnZA9k4sxGBxpr/H6v0iEL6b51T2Kwz5YNrQG/yDYoadgBW+oW40LeoA==}
-    engines: {node: '>=18'}
 
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
@@ -21595,7 +21594,7 @@ snapshots:
       '@angular/forms': 21.2.19(@angular/common@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.19(@angular/animations@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@angular/platform-browser': 21.2.19(@angular/animations@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))
 
-  ngx-indexed-db@21.0.0(@angular/common@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2)):
+  ngx-indexed-db@22.0.0(@angular/common@21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2)):
     dependencies:
       '@angular/common': 21.2.19(@angular/core@21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 21.2.19(@angular/compiler@21.2.19)(rxjs@7.8.2)(zone.js@0.16.2)


### PR DESCRIPTION
Coordinated replacement for #1461, which failed lint: Dependabot bumped only the root `package.json`, while `libs/shared/interfaces/package.json` kept the `^21.0.0` specifier — `@nx/dependency-checks` rejects that. This PR updates both specifiers plus the lockfile.

Compatibility: ngx-indexed-db 22 declares peer deps `@angular/core >=10 <22` — we are on Angular 21.2.19, so no framework constraint changes.

Validation:
- `pnpm nx lint shared-interfaces` — passes (the check that failed on the bot branch)
- `pnpm nx run-many --target=test --projects=web,services` — 285 tests passed (covers `PwaService`/`PlaylistsService`, the ngx-indexed-db consumers)
- `pnpm run release:notes:validate` — valid (adds a `type: internal` note)

Closes #1461 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)