### PR TITLE
docs(agents): re-run pnpm install after the checkout moves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This file provides guidance to coding agents working in this repository.
 ## Agent Bootstrap
 
 - In a fresh worktree, run `pnpm install --frozen-lockfile` before relying on Nx project discovery, lint, test, or build commands. Without `node_modules`, `pnpm nx show projects` will fail because the local Nx modules are unavailable.
+- Re-run the install whenever the checkout moves — `git pull`, `git reset --hard`, a rebase, or a worktree branch being re-pointed. Git rewrites `pnpm-lock.yaml` but never re-links `node_modules`, so a tree installed at an older commit keeps serving the old dependency versions and tests fail locally while CI stays green. Check with `cmp pnpm-lock.yaml node_modules/.pnpm/lock.yaml`; any difference means the tree is stale, and a plain `pnpm install --frozen-lockfile` in that directory repairs it. Each worktree needs its own install — with no local `node_modules`, Nx aborts with `Could not find ".modules.yaml"`.
 - After dependencies are installed, verify workspace discovery with `pnpm nx show projects`.
 - Use scoped path aliases from `tsconfig.base.json` such as `@iptvnator/services`, `@iptvnator/shared/interfaces`, and `@iptvnator/ui/components`. Do not add new imports from legacy bare aliases such as `services`, `shared-interfaces`, `components`, `m3u-state`, or `database`.
 - Every Nx project should keep `scope:*`, `domain:*`, and `type:*` tags in `project.json` so `@nx/enforce-module-boundaries` remains useful for humans and agents.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ pnpm nx show projects
 ```
 
 - Run the install step in a fresh worktree before relying on Nx discovery, lint, test, or build commands. Without `node_modules`, local Nx modules are unavailable.
+- Re-run the install whenever the checkout moves — `git pull`, `git reset --hard`, a rebase, or a worktree branch being re-pointed. Git rewrites `pnpm-lock.yaml` but never re-links `node_modules`, so a tree installed at an older commit keeps serving the old dependency versions and tests fail locally while CI stays green. Check with `cmp pnpm-lock.yaml node_modules/.pnpm/lock.yaml`; any difference means the tree is stale, and a plain `pnpm install --frozen-lockfile` in that directory repairs it. Each worktree needs its own install — with no local `node_modules`, Nx aborts with `Could not find ".modules.yaml"`.
 - Use scoped path aliases from `tsconfig.base.json` such as `@iptvnator/services`, `@iptvnator/shared/interfaces`, and `@iptvnator/ui/components`.
 - Do not add new imports from legacy bare aliases such as `services`, `shared-interfaces`, `components`, `m3u-state`, or `database`.
 - Every Nx project should keep `scope:*`, `domain:*`, and `type:*` tags in `project.json`.


### PR DESCRIPTION
## Why

`pnpm nx test web-backend` failed locally with 2 failures in `apps/web-backend/src/app/web-backend-app.spec.ts` while CI on `master` was green for the same commits. The cause turned out to be a stale `node_modules` tree: `epg-parser` was linked at `0.1.6` even though `package.json` pins `^0.5.0` and the lockfile resolves `0.5.0`.

It was not a pnpm bug. The tree had been installed at an older commit and never re-installed after the checkout moved forward. In one worktree the sequence was exactly:

```
09:37  branch created from 09764e24   (Jul 7 master; "epg-parser": "^0.1.6")
09:49  pnpm install ran here          → correct tree for that commit
09:49  reset: moving to FETCH_HEAD    (Aug 22 master; epg-parser 0.5.0)
       → no re-install
```

Its `node_modules/.pnpm/lock.yaml` was byte-identical to `git show 09764e24:pnpm-lock.yaml`. `git reset --hard` rewrote `pnpm-lock.yaml` but nothing re-linked `node_modules`, so the old dependency versions kept being served and the tests failed locally while CI stayed green.

A plain `pnpm install --frozen-lockfile` in the affected directory repaired every stale tree — no `--force`, no `pnpm nx reset`, no deleting `node_modules`.

## What changed

One bullet added to the Agent Bootstrap section of `CLAUDE.md` and the mirrored `AGENTS.md` (kept byte-identical). The existing bullet only covers a *fresh* worktree; this documents the re-install trigger when a checkout moves afterwards, plus the cheap staleness check:

```bash
cmp pnpm-lock.yaml node_modules/.pnpm/lock.yaml
```

Any difference means the tree is stale.

## Validation

- Docs-only change; no runtime code under `apps/**` or `libs/**` touched, so no unit/E2E work was required and the release-note gate does not apply.
- `npx prettier --check CLAUDE.md AGENTS.md` passes.
- `pnpm nx test web-backend --skip-nx-cache` — 4 suites / 58 tests passed after the repair and again after rebasing onto current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)