### PR TITLE
feat(playback): bake HD buffering lavf options + cache-secs into MPV launch args

### DIFF
--- a/.changes/playback-hd-buffering-lavf-options.md
+++ b/.changes/playback-hd-buffering-lavf-options.md
@@ -1,0 +1,9 @@
+---
+type: perf
+area: playback
+---
+
+HD channels now keep playing through brief network drops instead of failing
+the playback session. The embedded MPV cache buffers 30 seconds of stream
+ahead of the playhead, which smooths out jittery connections without
+introducing noticeable startup delay.

--- a/apps/electron-backend/src/app/events/mpv-session.service.ts
+++ b/apps/electron-backend/src/app/events/mpv-session.service.ts
@@ -282,6 +282,15 @@ export async function openMpvPlayer({
             args.push(`--input-ipc-server=${socketPath}`, '--idle=yes');
         }
 
+        // HD buffering: lavf options are init-only; HLS ignores demuxer-readahead-secs so cache-secs is the operative lever.
+        args.push(
+            '--demuxer-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1'
+        );
+        args.push(
+            '--demuxer-lavf-o=protocol_whitelist=file,crypto,http,https,tcp,tls,crypto'
+        );
+        args.push('--cache-secs=30');
+
         args.push('--ytdl=no');
 
         if (effectiveUserAgent) {


### PR DESCRIPTION
## Problem

HD HLS streams exhibit persistent micro-stutter and segment-boundary rebuffering under the default mpv launch flags. Two structural constraints make this unfixable via Settings → Custom MPV options alone:

1. `--demuxer-lavf-o` is **init-only**: libavformat parses it when the demuxer initializes. `set_property` after launch is a no-op.
2. HLS streams **ignore** `--demuxer-readahead-secs` because mpv reads by segments; the operative cache lever is the mpv-level `--cache-secs`.

## Fix

Bake three options into `args` in `mpv-session.service.ts` (applied before `--ytdl=no` so they precede the URL and the demuxer init):

```text
--demuxer-lavf-o=reconnect=1,reconnect_streamed=1,reconnect_on_network_error=1
--demuxer-lavf-o=protocol_whitelist=file,crypto,http,https,tcp,tls,crypto
--cache-secs=30
```

The reconnect triple survives transient network drops without forcing a full relaunch — the stream keeps rolling through HLS segment boundaries. The protocol whitelist keeps the default restrictive set explicit (covers HLS, DASH, and progressive HTTPS). `--cache-secs=30` (default 10) extends the mpv-level cache window so a single segment fetch stall no longer drains the buffer on HD streams.

## Validation gap

Local validation of this PR ran inside a sandbox without `pnpm install` (sparse-checkout expansion for the full build scope hangs in this environment). The diff was reviewed against upstream `mpv-session.service.ts` and the option semantics against mpv's manual. CI on `4gray/iptvnator` will be the authoritative build.

## Concerns

- Backward compatibility: all three flags are additive; existing flags still apply and Custom MPV options still override.
- Performance: `--cache-secs=30` raises RAM by ~the bitrate × 30. For a 10 Mbps HD stream that is ~38 MB per session. Acceptable on a media-player workstation; flag for review on RAM-constrained boxes.
- 4K streams (`#541`): the cache increase is necessary but may not be sufficient for 4K. Worth tracking separately if you want to revisit.