### PR TITLE
test(stalker): cover radio playback surviving a category switch in web E2E

### DIFF
--- a/apps/web-e2e/src/stalker.e2e.ts
+++ b/apps/web-e2e/src/stalker.e2e.ts
@@ -552,6 +552,44 @@ test('@stalker radio — stations use the inline audio player without EPG', asyn
     expect(epgRequests).toHaveLength(0);
 });
 
+test('@stalker radio playback survives a category switch', async ({ page }) => {
+    // Radio shares the ITV layout and the same context-panel handler that
+    // used to clear the selected item on every category click (#1517). The
+    // inline audio player is gated on that selection, so a category switch
+    // silenced the station the user never switched away from.
+    await addStalkerPortal(page);
+
+    await page.getByRole('link', { name: /radio/i }).click();
+    await page.waitForURL(/stalker.*radio/);
+
+    const categories = page.locator('.category-item');
+    await expect(categories.nth(2)).toBeVisible({ timeout: 10_000 });
+    await categories.nth(1).click();
+
+    const sidebar = page.locator('app-stalker-live-stream-layout .sidebar');
+    const sidebarTitle = sidebar.locator('.category-title');
+    const stations = page.locator('[data-test-id="channel-item"]');
+    await expect(stations.first()).toBeVisible({ timeout: 20_000 });
+    const firstCategoryTitle = (await sidebarTitle.textContent())?.trim() ?? '';
+    expect(firstCategoryTitle).not.toBe('');
+
+    await stations.first().click();
+    await expect(stations.first()).toHaveClass(/active/, { timeout: 20_000 });
+    const audioPlayer = page.locator('app-audio-player');
+    await expect(audioPlayer).toBeVisible({ timeout: 20_000 });
+
+    await categories.nth(2).click();
+
+    // The sidebar re-filters to the new category (proves the click landed and
+    // change detection ran)…
+    await expect(sidebarTitle).not.toHaveText(firstCategoryTitle, {
+        timeout: 20_000,
+    });
+    await expect(stations.first()).toBeVisible({ timeout: 20_000 });
+    // …while the station picked from the previous category keeps playing.
+    await expect(audioPlayer).toBeVisible();
+});
+
 test('@stalker PWA skips bulk EPG across channel switches', async ({
     page,
 }) => {


### PR DESCRIPTION
## Summary
- Follow-up to #1517: the web E2E there covers ITV only. Radio shares `StalkerLiveStreamLayoutComponent` and the same `onStalkerCategoryClicked` early return, and its inline `app-audio-player` is gated on the store selection just like the ITV player, so a regression would silence a station the user never switched away from.
- Adds `@stalker radio playback survives a category switch` to `apps/web-e2e/src/stalker.e2e.ts`, mirroring the ITV scenario: play a station, pick another category, wait for the sidebar `.category-title` to change (so the assertion cannot pass before change detection ran), then assert the audio player is still visible.

## Changes
- `apps/web-e2e/src/stalker.e2e.ts`: one new test next to the existing radio test. No production code touched.

## Testing
- [x] `pnpm nx run web-e2e:e2e-ci--src/stalker.e2e.ts` — whole Stalker suite green; the new scenario passed in chromium, webkit and firefox.
- [x] `pnpm nx lint web-e2e` — clean (pre-existing warnings only).
- Test-only change: E2E paths are auto-exempt from the release-note gate, so no `.changes/` note.

Closes #1521

🤖 Generated with [Claude Code](https://claude.com/claude-code)