### PR TITLE
fix(embedded-mpv): disable the youtube-dl hook in the frame-copy helper

### DIFF
--- a/.changes/embedded-mpv-no-ytdl-hook.md
+++ b/.changes/embedded-mpv-no-ytdl-hook.md
@@ -1,0 +1,10 @@
+---
+type: fix
+area: embedded-mpv
+---
+
+When a stream refuses the connection, the embedded MPV player (frame-copy
+engine) no longer hands the URL to yt-dlp before giving up: the failure
+shows up right away and its error no longer reads "youtube-dl failed:
+unexpected error occurred", matching the native-view engines and the
+external MPV player.

--- a/apps/electron-backend/native/helper/mpv_frame_helper.cpp
+++ b/apps/electron-backend/native/helper/mpv_frame_helper.cpp
@@ -823,6 +823,12 @@ int main(int argc, char** argv) {
     mpv_set_option_string(g_state.mpv, "idle", "yes");
     mpv_set_option_string(g_state.mpv, "input-default-bindings", "no");
     mpv_set_option_string(g_state.mpv, "osc", "no");
+    /* Keep parity with the native-view addons and the external MPV launch
+     * path: with mpv's youtube-dl hook enabled, a refused HTTP open falls
+     * through to yt-dlp and the session error reads "youtube-dl failed"
+     * instead of the load error. A user `ytdl=yes` session option
+     * (applied below, before mpv_initialize) still overrides it. */
+    mpv_set_option_string(g_state.mpv, "ytdl", "no");
     if (!args.audioDelay.empty()) {
         /* Compensates the frame-copy video-path latency to restore
          * lip-sync; calibrated per platform, see the architecture doc. */

--- a/docs/architecture/embedded-mpv-native.md
+++ b/docs/architecture/embedded-mpv-native.md
@@ -537,6 +537,17 @@ user line overrides both:
 | Linux native-view   | written to a user-only (0600) config file under `userData/embedded-mpv/options-<pid>/` and referenced as `--include=<path>` on the `mpv --wid` command line (before the per-playback options, so a playlist's user-agent/headers still win); the file is removed on dispose, the instance directory on shutdown, and another instance's leftovers only once its process is gone (two instances may share one `userData`) |
 | Frame-copy helper   | the first stdin line (`mpv-options`, helper started with `--mpv-options-stdin`), applied after the helper's built-in block                                                                                                                                                                                                                                                                                               |
 
+The helper's own built-in block is `vo=libmpv`, the session's `hwdec`,
+`keep-open=yes`, `idle=yes`, `input-default-bindings=no`, `osc=no` and
+`ytdl=no`. The last one keeps parity with the native-view addons and the
+external MPV launch path (`--ytdl=no` in `mpv-session.service.ts`): with
+mpv's youtube-dl hook enabled, a refused HTTP open falls through to yt-dlp
+before it fails, which delays the `error` transition and can leave the
+session error reading `youtube-dl failed: unexpected error occurred`
+instead of the load error (the helper stores every error-level libmpv log
+line as the snapshot error, so whichever line lands last wins). A user
+`ytdl=yes` line overrides it like every other built-in.
+
 The list never appears on a command line: an option such as
 `http-header-fields=Authorization: …` would otherwise be readable by every
 local user through `ps` / `/proc/<pid>/cmdline`.


### PR DESCRIPTION
## Summary

- The frame-copy helper (`apps/electron-backend/native/helper/mpv_frame_helper.cpp`) now sets `ytdl=no` in its built-in option block, matching the native-view addons (`embedded_mpv.mm`, `embedded_mpv_wid_common.h`) and the external MPV launch path (`--ytdl=no` in `mpv-session.service.ts`).
- Without it, a refused HTTP open fell through to mpv's `ytdl_hook` and yt-dlp before failing, which delayed the `error` transition the auto-reconnect policy (#1515) waits for and could leave the session error reading `youtube-dl failed: unexpected error occurred` instead of the load error.
- The option is applied before the stdin `mpv-options` loop, so a user `ytdl=yes` line in *Settings > Playback > Extra embedded MPV options* still overrides it.
- `docs/architecture/embedded-mpv-native.md` ("Session Options") now lists the helper's built-in block and the reason for `ytdl=no`.
- Release note: `.changes/embedded-mpv-no-ytdl-hook.md` (`type: fix`, `area: embedded-mpv`).

## Validation

- `pnpm run embedded-mpv:build-native:homebrew` on macOS: addon and helper compile and link (`gyp info ok`).
- Drove the rebuilt `iptvnator_mpv_helper` by hand against `http://127.0.0.1:1/...` (connection refused):
  - built-in default: mpv logs only `ffmpeg: tcp ... Connection refused` / `stream: Failed to open`, no `ytdl_hook` activity;
  - `mpv-options` stdin line `ytdl=yes`: the same plus a `ytdl_hook` line from a spawned yt-dlp, proving the override path.
- `pnpm run release:notes:validate` passes; Prettier accepts the Markdown.

## Test impact

No TypeScript changed, so no unit or E2E suites are affected; the helper has no C++ tests. The manual helper probe above is the regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
