### PR TITLE
feat(website): turn the screenshot showcase into a channel switcher

### DIFF
--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -64,6 +64,19 @@ resolved version.
 canonicals, direct asset links, JSON-LD, cross-links and sitemap entries
 without depending on a specific version.
 
+Two of the suites drive the built site in a real browser:
+`tools/testing/website-screenshot-showcase.test.mjs` (the home page channel
+switcher: autoplay, hover/focus pausing, keyboard navigation, deferred frame
+sources) and `tools/testing/website-home-sections.test.mjs` (the hero and
+download panel following the visitor's OS). They share
+`tools/testing/website-browser-support.mjs`, which serves `dist/apps/website`
+on a loopback port and launches Chromium from the Playwright download or,
+failing that, the system Chrome/Chromium channel. Without any Chromium the
+browser half is **skipped locally** (the structural checks still run) and
+**fails in CI**, so a green local run only proves the interactions when a
+browser was found — run `pnpm exec playwright install chromium` once if the
+skip shows up in your output.
+
 ## Guides
 
 Evergreen how-to posts live in the blog collection next to release notes

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -64,11 +64,9 @@ resolved version.
 canonicals, direct asset links, JSON-LD, cross-links and sitemap entries
 without depending on a specific version.
 
-Two of the suites drive the built site in a real browser:
-`tools/testing/website-screenshot-showcase.test.mjs` (the home page channel
-switcher: autoplay, hover/focus pausing, keyboard navigation, deferred frame
-sources) and `tools/testing/website-home-sections.test.mjs` (the hero and
-download panel following the visitor's OS). They share
+`tools/testing/website-screenshot-showcase.test.mjs` drives the built site in
+a real browser: the home page channel switcher (autoplay, hover/focus pausing,
+keyboard navigation, deferred frame sources). It relies on
 `tools/testing/website-browser-support.mjs`, which serves `dist/apps/website`
 on a loopback port and launches Chromium from the Playwright download or,
 failing that, the system Chrome/Chromium channel. Without any Chromium the

--- a/apps/website/project.json
+++ b/apps/website/project.json
@@ -18,7 +18,7 @@
             "executor": "nx:run-commands",
             "dependsOn": ["build"],
             "options": {
-                "command": "node --test tools/testing/website-giscus-comments.test.mjs tools/testing/website-download-pages.test.mjs tools/testing/website-guides.test.mjs tools/testing/website-feature-pages.test.mjs tools/testing/website-compare-pages.test.mjs tools/testing/website-blog-tags.test.mjs"
+                "command": "node --test tools/testing/website-giscus-comments.test.mjs tools/testing/website-download-pages.test.mjs tools/testing/website-guides.test.mjs tools/testing/website-feature-pages.test.mjs tools/testing/website-compare-pages.test.mjs tools/testing/website-blog-tags.test.mjs tools/testing/website-screenshot-showcase.test.mjs"
             }
         },
         "serve": {

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -300,39 +300,37 @@ const pad = (n: number) => String(n).padStart(2, '0');
       if (focus) tabs[current].focus({ preventScroll: true });
     }
 
-    // The dwell clock stops while paused: the time spent hovering or focused is
-    // added to the start mark on resume, so the bar continues from where it froze.
-    function tick(now) {
-      if (paused()) {
-        if (!pausedAt) pausedAt = now;
-      } else {
+    // One scheduler. The frame loop runs only while the block is on screen
+    // and nothing pauses it; every state change calls sync(), which starts or
+    // cancels the loop. The dwell clock stops while paused: the time spent
+    // paused is added to the start mark on resume, so the bar continues from
+    // where it froze. Only a channel change resets the dwell. A paused block
+    // schedules no frames at all.
+    let visible = false;
+
+    function loop(now) {
+      const progress = (now - startedAt) / DWELL_MS;
+      if (progress >= 1) show(current + 1);
+      else progressOf(current).style.width = `${progress * 100}%`;
+      frame = window.requestAnimationFrame(loop);
+    }
+
+    function sync() {
+      const shouldRun = visible && !reduceMotion && !paused();
+      if (shouldRun && !frame) {
+        const now = performance.now();
+        if (!startedAt) startedAt = now;
         if (pausedAt) {
           startedAt += now - pausedAt;
           pausedAt = 0;
         }
-        const progress = (now - startedAt) / DWELL_MS;
-        if (progress >= 1) show(current + 1);
-        else progressOf(current).style.width = `${progress * 100}%`;
+        loadFrame(current + 1); // autoplay is on, so the next frame will be needed
+        frame = window.requestAnimationFrame(loop);
+      } else if (!shouldRun && frame) {
+        window.cancelAnimationFrame(frame);
+        frame = 0;
+        pausedAt = performance.now();
       }
-      frame = window.requestAnimationFrame(tick);
-    }
-
-    // Leaving the viewport is a pause like any other: the frame loop stops,
-    // the bar keeps its width, and the clock resumes from the same mark when
-    // the block scrolls back in. Only a channel change resets the dwell.
-    function start() {
-      if (reduceMotion || frame) return;
-      loadFrame(current + 1); // autoplay is on, so the next frame will be needed
-
-      if (!startedAt) startedAt = performance.now();
-      frame = window.requestAnimationFrame(tick);
-    }
-
-    function stop() {
-      if (!frame) return;
-      window.cancelAnimationFrame(frame);
-      frame = 0;
-      if (!pausedAt) pausedAt = performance.now();
     }
 
     tabs.forEach((tab, i) => tab.addEventListener('click', () => show(i, { focus: true })));
@@ -352,16 +350,16 @@ const pad = (n: number) => String(n).padStart(2, '0');
     const regions = [root.querySelector('[role="tablist"]'), root.querySelector('[data-channel-screen]')].filter(Boolean);
     const insideRegion = (node) => node instanceof Node && regions.some((region) => region.contains(node));
     for (const region of regions) {
-      region.addEventListener('mouseenter', () => { hovered = true; });
-      region.addEventListener('mouseleave', () => { hovered = false; });
-      region.addEventListener('focusin', () => { focused = true; });
+      region.addEventListener('mouseenter', () => { hovered = true; sync(); });
+      region.addEventListener('mouseleave', () => { hovered = false; sync(); });
+      region.addEventListener('focusin', () => { focused = true; sync(); });
       region.addEventListener('focusout', (event) => {
         if (insideRegion(event.relatedTarget)) return;
         focused = false;
+        sync();
       });
     }
 
-    // Only run while the block is on screen.
     const toggle = root.querySelector('[data-autoplay-toggle]');
     if (toggle) {
       if (reduceMotion) {
@@ -375,14 +373,19 @@ const pad = (n: number) => String(n).padStart(2, '0');
           toggle.setAttribute('aria-label', stopped ? 'Resume auto-advance' : 'Pause auto-advance');
           toggle.querySelector('[data-icon-pause]').classList.toggle('hidden', stopped);
           toggle.querySelector('[data-icon-play]').classList.toggle('hidden', !stopped);
-          // A channel picked while paused skipped its successor; fetch it now that autoplay can reach it.
-          if (!stopped) loadFrame(current + 1);
+          sync();
         });
       }
     }
 
+    // Only run while the block is on screen.
     const observer = new IntersectionObserver(
-      (entries) => entries.forEach((entry) => (entry.isIntersecting ? start() : stop())),
+      (entries) => {
+        entries.forEach((entry) => {
+          visible = entry.isIntersecting;
+        });
+        sync();
+      },
       { threshold: 0.25 },
     );
     observer.observe(root);

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -245,7 +245,10 @@ const pad = (n: number) => String(n).padStart(2, '0');
     const captionLink = root.querySelector('[data-caption-link]');
 
     const DWELL_MS = 7000;
-    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    // Live, not a snapshot: a visitor may switch the OS preference while the
+    // page is open, and the scheduler follows it (see the change listener).
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    let reduceMotion = motionQuery.matches;
     // Hover and focus pause while they last; the toggle pauses until the
     // visitor resumes. Autoplay runs only when none of the three holds.
     let hovered = false;
@@ -319,7 +322,9 @@ const pad = (n: number) => String(n).padStart(2, '0');
     }
 
     function sync() {
-      const shouldRun = visible && !reduceMotion && !paused();
+      // Background tabs throttle animation frames while the clock keeps
+      // running, so a hidden document counts as a pause too.
+      const shouldRun = visible && !document.hidden && !reduceMotion && !paused();
       if (shouldRun && !frame) {
         const now = performance.now();
         if (!startedAt) startedAt = now;
@@ -363,23 +368,28 @@ const pad = (n: number) => String(n).padStart(2, '0');
       });
     }
 
+    // Nothing to pause under reduced motion: the loop never starts, so the
+    // control is hidden (not removed — the preference can change at runtime).
     const toggle = root.querySelector('[data-autoplay-toggle]');
-    if (toggle) {
-      if (reduceMotion) {
-        // Nothing to pause: the loop never starts under reduced motion.
-        toggle.remove();
-      } else {
-        toggle.addEventListener('click', () => {
-          stopped = !stopped;
-          toggle.setAttribute('aria-pressed', String(stopped));
-          toggle.querySelector('[data-autoplay-label]').textContent = stopped ? 'Resume' : 'Pause';
-          toggle.setAttribute('aria-label', stopped ? 'Resume auto-advance' : 'Pause auto-advance');
-          toggle.querySelector('[data-icon-pause]').classList.toggle('hidden', stopped);
-          toggle.querySelector('[data-icon-play]').classList.toggle('hidden', !stopped);
-          sync();
-        });
-      }
-    }
+    const reflectMotionPreference = () => {
+      toggle?.classList.toggle('hidden', reduceMotion);
+      sync();
+    };
+    toggle?.addEventListener('click', () => {
+      stopped = !stopped;
+      toggle.setAttribute('aria-pressed', String(stopped));
+      toggle.querySelector('[data-autoplay-label]').textContent = stopped ? 'Resume' : 'Pause';
+      toggle.setAttribute('aria-label', stopped ? 'Resume auto-advance' : 'Pause auto-advance');
+      toggle.querySelector('[data-icon-pause]').classList.toggle('hidden', stopped);
+      toggle.querySelector('[data-icon-play]').classList.toggle('hidden', !stopped);
+      sync();
+    });
+    motionQuery.addEventListener('change', (event) => {
+      reduceMotion = event.matches;
+      reflectMotionPreference();
+    });
+    reflectMotionPreference();
+    document.addEventListener('visibilitychange', sync);
 
     // Only run while the block is on screen.
     const observer = new IntersectionObserver(

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -1,159 +1,310 @@
 ---
-const tabs = [
+/**
+ * "Flip through the app": the screenshot showcase as a channel switcher.
+ *
+ * The list on the left is the channel list of a TV player — number, name,
+ * one line about what the screen is for — and the screen on the right shows
+ * the selected shot. Channels advance on their own (a progress hairline runs
+ * under the active row) until the visitor hovers, focuses or scrolls the block
+ * out of view; `prefers-reduced-motion` turns autoplay off entirely. Arrow keys
+ * move between channels like a remote.
+ */
+const channels = [
   {
     id: 'dashboard',
     label: 'Dashboard',
+    description: 'Continue watching, recent channels and favorites across every source.',
     image: '/iptvnator/screenshots/dashboard-with-content.webp',
-    alt: 'Dashboard with recently watched content and global favorites',
+    alt: 'Dashboard with continue watching, recently watched and global favorites',
     width: 2072,
     height: 1602,
+    link: { href: '/iptvnator/features/', label: 'Every feature' },
   },
   {
     id: 'live-tv',
     label: 'Live TV',
+    description: 'Channel list with the current program, the player and the EPG timeline side by side.',
     image: '/iptvnator/screenshots/screenshot-player.webp',
-    alt: 'Live channels with the inline player and EPG',
+    alt: 'Live channels with the inline player and the program timeline',
     width: 2442,
     height: 1806,
+    link: { href: '/iptvnator/features/m3u-player/', label: 'M3U playlist player' },
   },
   {
     id: 'epg',
-    label: 'EPG Guide',
+    label: 'Program guide',
+    description: 'A multi-channel grid with a now-line you can scrub through the day.',
     image: '/iptvnator/screenshots/multi-epg-view.webp',
     alt: 'Multi-channel electronic program guide',
     width: 2180,
     height: 1448,
+    link: { href: '/iptvnator/features/epg/', label: 'TV guide (EPG)' },
+  },
+  {
+    id: 'movies',
+    label: 'Movies & series',
+    description: 'Detail pages with cast, seasons and the position you stopped at.',
+    image: '/iptvnator/screenshots/vod-details.webp',
+    alt: 'Movie detail page with poster, cast and play button',
+    width: 2260,
+    height: 1490,
+    link: { href: '/iptvnator/features/xtream-codes-player/', label: 'Xtream Codes player' },
+  },
+  {
+    id: 'downloads',
+    label: 'Downloads',
+    description: 'Offline library, download queue and live-TV recordings in one place.',
+    image: '/iptvnator/screenshots/download-manager.webp',
+    alt: 'Download manager with an offline library and a queue',
+    width: 2500,
+    height: 1602,
+    link: { href: '/iptvnator/blog/v0-23-release-notes/', label: 'Download manager notes' },
   },
   {
     id: 'settings',
     label: 'Settings',
+    description: 'Player engine, EPG, TMDB metadata, remote control and backup.',
     image: '/iptvnator/screenshots/settings.webp',
     alt: 'Application settings in the dark theme',
     width: 2500,
     height: 1602,
+    link: { href: '/iptvnator/features/remote-control/', label: 'Phone remote control' },
   },
-  {
-    id: 'add-playlist',
-    label: 'Add Playlist',
-    image: '/iptvnator/screenshots/add-playlist.webp',
-    alt: 'Add playlist dialog for M3U, Xtream, and Stalker sources',
-    width: 2260,
-    height: 1490,
-  },
-];
+] as const;
+
+const pad = (n: number) => String(n).padStart(2, '0');
 ---
 
 <section id="screenshots" class="relative py-28">
   <hr class="section-divider mb-28" />
 
   <div class="mx-auto max-w-6xl px-6">
-    <!-- Editorial header: right-aligned for variety -->
-    <div class="ml-auto max-w-xl text-right">
-      <span class="font-mono text-xs uppercase tracking-[0.2em] text-accent-500">
-        Interface
-      </span>
-      <h2 class="mt-4 font-display text-3xl font-bold tracking-tight text-surface-50 sm:text-4xl lg:text-5xl">
-        See it in action
-      </h2>
-      <p class="mt-4 text-lg text-surface-400">
-        A clean, intuitive interface designed for the best viewing experience.
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+      <div class="max-w-xl">
+        <span class="font-mono text-xs uppercase tracking-[0.2em] text-accent-500">
+          Interface
+        </span>
+        <h2 class="mt-4 font-display text-3xl font-bold tracking-tight text-surface-50 sm:text-4xl lg:text-5xl">
+          Flip through the app
+        </h2>
+      </div>
+      <p class="max-w-sm text-base text-surface-400 sm:text-right">
+        Six screens, one player. Pick a channel or let it run.
       </p>
     </div>
 
-    <div class="mt-14">
-      <!-- Tab buttons with underline style -->
-      <div class="flex flex-wrap justify-center gap-1 rounded-lg border border-surface-700/60 bg-surface-900/50 p-1.5" role="tablist">
+    <div class="mt-12 grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)]" data-channel-switcher>
+      <!-- Channel list -->
+      <div
+        class="flex flex-col overflow-hidden rounded-xl border border-surface-800 bg-surface-900/40"
+        role="tablist"
+        aria-label="App screens"
+        aria-orientation="vertical"
+      >
+        <div class="flex items-center justify-between border-b border-surface-800 px-4 py-3 font-mono text-[11px] uppercase tracking-[0.15em] text-surface-500">
+          <span>Channels</span>
+          <span>{pad(channels.length)}</span>
+        </div>
         {
-          tabs.map((tab, i) => (
+          channels.map((channel, i) => (
             <button
+              type="button"
               role="tab"
+              id={`screen-tab-${channel.id}`}
               aria-selected={i === 0 ? 'true' : 'false'}
-              data-tab={tab.id}
-              class:list={[
-                'screenshot-tab rounded-md px-5 py-2 font-mono text-xs uppercase tracking-[0.1em] transition-all duration-200',
-                i === 0
-                  ? 'bg-accent-500/15 text-accent-400'
-                  : 'text-surface-500 hover:text-surface-300',
-              ]}
+              aria-controls={`screen-panel-${channel.id}`}
+              tabindex={i === 0 ? 0 : -1}
+              data-channel={channel.id}
+              class="channel-tab group relative grid grid-cols-[38px_minmax(0,1fr)] gap-3 border-t border-surface-800 px-4 py-3.5 text-left transition-colors duration-200 first-of-type:border-t-0 hover:bg-white/[0.025] focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent-400"
             >
-              {tab.label}
+              <span class="channel-number pt-0.5 font-mono text-xs tabular-nums text-surface-500 transition-colors duration-200">
+                {pad(i + 1)}
+              </span>
+              <span>
+                <span class="block font-display text-[15px] font-semibold tracking-tight text-surface-100">
+                  {channel.label}
+                </span>
+                <span class="mt-0.5 block text-[12.5px] leading-snug text-surface-500">
+                  {channel.description}
+                </span>
+              </span>
+              <span class="pointer-events-none absolute inset-x-0 -bottom-px h-0.5" aria-hidden="true">
+                <span class="channel-progress block h-full w-0 bg-accent-500" />
+              </span>
             </button>
           ))
         }
+        <div class="mt-auto border-t border-surface-800 px-4 py-3 font-mono text-[11px] text-surface-500">
+          <kbd class="rounded border border-surface-700 px-1.5 py-px text-surface-400">↑</kbd>
+          <kbd class="rounded border border-surface-700 px-1.5 py-px text-surface-400">↓</kbd>
+          <span class="ml-1.5">switch channel</span>
+        </div>
       </div>
 
-      <!-- Screenshots with window chrome -->
-      <div class="relative mt-8">
+      <!-- Screen -->
+      <div class="relative order-first aspect-[4/3] overflow-hidden rounded-xl border border-surface-700/60 bg-surface-900 shadow-2xl shadow-black/40 lg:order-none lg:aspect-auto lg:min-h-[460px]">
         {
-          tabs.map((tab, i) => (
+          channels.map((channel, i) => (
             <div
-              data-panel={tab.id}
+              role="tabpanel"
+              id={`screen-panel-${channel.id}`}
+              aria-labelledby={`screen-tab-${channel.id}`}
+              aria-hidden={i === 0 ? 'false' : 'true'}
+              data-channel-panel={channel.id}
               class:list={[
-                'screenshot-panel transition-opacity duration-300',
-                i !== 0 && 'hidden',
+                'channel-panel absolute inset-0 transition-opacity duration-300',
+                i !== 0 && 'pointer-events-none opacity-0',
               ]}
             >
-              <div class="relative mx-auto max-w-4xl">
-                <!-- Ambient glow -->
-                <div class="absolute -inset-6 rounded-2xl bg-accent-500/[0.03] blur-2xl" />
-
-                <!-- Window chrome -->
-                <div class="relative overflow-hidden rounded-xl border border-surface-700/60 bg-surface-900 shadow-2xl shadow-black/30">
-                  <div class="flex items-center gap-2 border-b border-surface-700/60 px-4 py-2.5">
-                    <div class="flex gap-1.5">
-                      <span class="h-2.5 w-2.5 rounded-full bg-red-500/70" />
-                      <span class="h-2.5 w-2.5 rounded-full bg-yellow-500/70" />
-                      <span class="h-2.5 w-2.5 rounded-full bg-green-500/70" />
-                    </div>
-                    <span class="ml-2 font-mono text-[11px] text-surface-500">{tab.label}</span>
-                  </div>
-                  <img
-                    src={tab.image}
-                    alt={tab.alt}
-                    width={tab.width}
-                    height={tab.height}
-                    class="h-auto w-full"
-                    loading="lazy"
-                    decoding="async"
-                  />
-                </div>
-              </div>
+              <img
+                src={channel.image}
+                alt={channel.alt}
+                width={channel.width}
+                height={channel.height}
+                class="h-full w-full object-cover object-left-top"
+                loading={i === 0 ? 'eager' : 'lazy'}
+                decoding="async"
+              />
             </div>
           ))
         }
+
+        <!-- On-screen display: shows the channel number for a moment after a switch -->
+        <div
+          class="channel-osd pointer-events-none absolute left-4 top-4 flex -translate-y-1 items-center gap-2.5 rounded-lg border border-white/10 bg-surface-950/75 px-3 py-2 font-mono text-xs text-surface-100 opacity-0 backdrop-blur transition-all duration-200"
+          aria-hidden="true"
+        >
+          <span class="font-medium text-accent-400" data-osd-number>CH 01</span>
+          <span data-osd-label>{channels[0].label}</span>
+        </div>
+
+        <!-- Caption -->
+        <div class="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-5 bg-gradient-to-t from-surface-950/90 via-surface-950/60 to-transparent px-5 pb-4 pt-14">
+          <div class="min-w-0">
+            <span class="block font-display text-[15px] font-semibold text-surface-50" data-caption-label>{channels[0].label}</span>
+            <span class="mt-0.5 hidden text-[13px] text-surface-300 sm:block" data-caption-description>{channels[0].description}</span>
+          </div>
+          <a
+            href={channels[0].link.href}
+            class="pointer-events-auto shrink-0 whitespace-nowrap font-mono text-[11px] uppercase tracking-[0.1em] text-accent-400 transition-colors hover:text-accent-300"
+            data-caption-link
+          >
+            {channels[0].link.label} →
+          </a>
+        </div>
       </div>
     </div>
   </div>
 </section>
 
-<script>
-  const tabs = document.querySelectorAll('.screenshot-tab');
-  const panels = document.querySelectorAll('.screenshot-panel');
+<script define:vars={{ channels: channels.map((c) => ({ id: c.id, label: c.label, description: c.description, link: c.link })) }}>
+  const root = document.querySelector('[data-channel-switcher]');
+  if (root) {
+    const tabs = Array.from(root.querySelectorAll('.channel-tab'));
+    const panels = Array.from(root.querySelectorAll('.channel-panel'));
+    const osd = root.querySelector('.channel-osd');
+    const osdNumber = root.querySelector('[data-osd-number]');
+    const osdLabel = root.querySelector('[data-osd-label]');
+    const captionLabel = root.querySelector('[data-caption-label]');
+    const captionDescription = root.querySelector('[data-caption-description]');
+    const captionLink = root.querySelector('[data-caption-link]');
 
-  tabs.forEach((tab) => {
-    tab.addEventListener('click', () => {
-      const target = (tab as HTMLElement).dataset.tab;
+    const DWELL_MS = 7000;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let current = 0;
+    let startedAt = 0;
+    let frame = 0;
+    let paused = false;
+    let osdTimer = 0;
 
-      // Reset all tabs
-      tabs.forEach((t) => {
-        t.classList.remove('bg-accent-500/15', 'text-accent-400');
-        t.classList.add('text-surface-500');
-        t.setAttribute('aria-selected', 'false');
+    const progressOf = (i) => tabs[i].querySelector('.channel-progress');
+
+    function show(index, { focus = false, announce = true } = {}) {
+      current = (index + tabs.length) % tabs.length;
+      tabs.forEach((tab, i) => {
+        const active = i === current;
+        tab.setAttribute('aria-selected', active ? 'true' : 'false');
+        tab.tabIndex = active ? 0 : -1;
+        progressOf(i).style.width = '0%';
       });
-
-      // Activate clicked tab
-      tab.classList.add('bg-accent-500/15', 'text-accent-400');
-      tab.classList.remove('text-surface-500');
-      tab.setAttribute('aria-selected', 'true');
-
-      // Show/hide panels
-      panels.forEach((panel) => {
-        if ((panel as HTMLElement).dataset.panel === target) {
-          panel.classList.remove('hidden');
-        } else {
-          panel.classList.add('hidden');
-        }
+      panels.forEach((panel, i) => {
+        const active = i === current;
+        panel.classList.toggle('opacity-0', !active);
+        panel.classList.toggle('pointer-events-none', !active);
+        panel.setAttribute('aria-hidden', active ? 'false' : 'true');
       });
+      const channel = channels[current];
+      captionLabel.textContent = channel.label;
+      captionDescription.textContent = channel.description;
+      captionLink.textContent = `${channel.link.label} →`;
+      captionLink.setAttribute('href', channel.link.href);
+      if (announce) {
+        osdNumber.textContent = `CH ${String(current + 1).padStart(2, '0')}`;
+        osdLabel.textContent = channel.label;
+        osd.classList.remove('opacity-0', '-translate-y-1');
+        window.clearTimeout(osdTimer);
+        osdTimer = window.setTimeout(() => osd.classList.add('opacity-0', '-translate-y-1'), 1400);
+      }
+      startedAt = performance.now();
+      if (focus) tabs[current].focus({ preventScroll: true });
+    }
+
+    function tick(now) {
+      if (!paused) {
+        const progress = (now - startedAt) / DWELL_MS;
+        if (progress >= 1) show(current + 1);
+        else progressOf(current).style.width = `${progress * 100}%`;
+      }
+      frame = window.requestAnimationFrame(tick);
+    }
+
+    function start() {
+      if (reduceMotion || frame) return;
+      startedAt = performance.now();
+      frame = window.requestAnimationFrame(tick);
+    }
+
+    function stop() {
+      if (!frame) return;
+      window.cancelAnimationFrame(frame);
+      frame = 0;
+      progressOf(current).style.width = '0%';
+    }
+
+    tabs.forEach((tab, i) => tab.addEventListener('click', () => show(i, { focus: true })));
+
+    root.addEventListener('keydown', (event) => {
+      if (!(event.target instanceof HTMLElement) || event.target.getAttribute('role') !== 'tab') return;
+      const keys = { ArrowDown: current + 1, ArrowUp: current - 1, Home: 0, End: tabs.length - 1 };
+      if (!(event.key in keys)) return;
+      event.preventDefault();
+      show(keys[event.key], { focus: true });
     });
-  });
+
+    // A visitor who is reading or operating the block keeps the current channel.
+    root.addEventListener('mouseenter', () => { paused = true; });
+    root.addEventListener('mouseleave', () => { paused = false; startedAt = performance.now(); });
+    root.addEventListener('focusin', () => { paused = true; });
+    root.addEventListener('focusout', (event) => {
+      if (root.contains(event.relatedTarget)) return;
+      paused = false;
+      startedAt = performance.now();
+    });
+
+    // Only run while the block is on screen.
+    const observer = new IntersectionObserver(
+      (entries) => entries.forEach((entry) => (entry.isIntersecting ? start() : stop())),
+      { threshold: 0.25 },
+    );
+    observer.observe(root);
+  }
 </script>
+
+<style>
+  .channel-tab[aria-selected='true'] {
+    @apply bg-surface-850;
+  }
+  .channel-tab[aria-selected='true'] .channel-number {
+    @apply text-accent-400;
+  }
+</style>

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -18,6 +18,11 @@
  * their panels, focus order equals reading order); on phones the list simply
  * hides the per-channel descriptions and the keyboard hint so the screen
  * stays close.
+ *
+ * Hover and focus only pause while they last, which is no use to a touch or
+ * screen-reader visitor, so the list footer carries a "Pause auto-advance"
+ * toggle that stays paused until pressed again (WCAG 2.2.2). It is removed
+ * under reduced motion, where there is nothing to pause.
  */
 const channels = [
   {
@@ -144,10 +149,27 @@ const pad = (n: number) => String(n).padStart(2, '0');
             </button>
           ))
         }
-        <div class="mt-auto hidden border-t border-surface-800 px-4 py-3 font-mono text-[11px] text-surface-500 lg:block">
-          <kbd class="rounded border border-surface-700 px-1.5 py-px text-surface-400">↑</kbd>
-          <kbd class="rounded border border-surface-700 px-1.5 py-px text-surface-400">↓</kbd>
-          <span class="ml-1.5">switch channel</span>
+        <div class="mt-auto flex items-center justify-between gap-3 border-t border-surface-800 px-4 py-2.5 font-mono text-[11px] text-surface-500">
+          <span class="hidden lg:inline">
+            <kbd class="rounded border border-surface-700 px-1.5 py-px text-surface-400">↑</kbd>
+            <kbd class="rounded border border-surface-700 px-1.5 py-px text-surface-400">↓</kbd>
+            <span class="ml-1.5">channel</span>
+          </span>
+          <button
+            type="button"
+            class="channel-autoplay ml-auto inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-surface-700 px-2.5 py-1 text-surface-300 transition-colors hover:border-surface-500 hover:text-surface-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent-400"
+            aria-pressed="false"
+            aria-label="Pause auto-advance"
+            data-autoplay-toggle
+          >
+            <svg class="h-3 w-3" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true" data-icon-pause>
+              <rect x="2" y="1.5" width="3" height="9" rx="0.5" /><rect x="7" y="1.5" width="3" height="9" rx="0.5" />
+            </svg>
+            <svg class="hidden h-3 w-3" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true" data-icon-play>
+              <path d="M2.5 1.5v9l7.5-4.5z" />
+            </svg>
+            <span data-autoplay-label>Pause</span>
+          </button>
         </div>
       </div>
 
@@ -226,10 +248,12 @@ const pad = (n: number) => String(n).padStart(2, '0');
     let startedAt = 0;
     let pausedAt = 0;
     let frame = 0;
-    // Hover and focus pause independently; autoplay resumes only when neither holds.
+    // Hover and focus pause while they last; the toggle pauses until the
+    // visitor resumes. Autoplay runs only when none of the three holds.
     let hovered = false;
     let focused = false;
-    const paused = () => hovered || focused;
+    let stopped = false;
+    const paused = () => hovered || focused || stopped;
     let osdTimer = 0;
 
     const progressOf = (i) => tabs[i].querySelector('.channel-progress');
@@ -329,6 +353,23 @@ const pad = (n: number) => String(n).padStart(2, '0');
     });
 
     // Only run while the block is on screen.
+    const toggle = root.querySelector('[data-autoplay-toggle]');
+    if (toggle) {
+      if (reduceMotion) {
+        // Nothing to pause: the loop never starts under reduced motion.
+        toggle.remove();
+      } else {
+        toggle.addEventListener('click', () => {
+          stopped = !stopped;
+          toggle.setAttribute('aria-pressed', String(stopped));
+          toggle.querySelector('[data-autoplay-label]').textContent = stopped ? 'Resume' : 'Pause';
+          toggle.setAttribute('aria-label', stopped ? 'Resume auto-advance' : 'Pause auto-advance');
+          toggle.querySelector('[data-icon-pause]').classList.toggle('hidden', stopped);
+          toggle.querySelector('[data-icon-play]').classList.toggle('hidden', !stopped);
+        });
+      }
+    }
+
     const observer = new IntersectionObserver(
       (entries) => entries.forEach((entry) => (entry.isIntersecting ? start() : stop())),
       { threshold: 0.25 },

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -134,7 +134,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
                 <span class="block font-display text-[15px] font-semibold tracking-tight text-surface-100">
                   {channel.label}
                 </span>
-                <span class="mt-0.5 hidden text-[12.5px] leading-snug text-surface-500 sm:block">
+                <span class="mt-0.5 hidden text-[12.5px] leading-snug text-surface-500 sm:block lg:hidden xl:block">
                   {channel.description}
                 </span>
               </span>
@@ -152,7 +152,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
       </div>
 
       <!-- Screen -->
-      <div class="relative aspect-[4/3] overflow-hidden rounded-xl border border-surface-700/60 bg-surface-900 shadow-2xl shadow-black/40 lg:aspect-auto lg:min-h-[460px]">
+      <div class="relative aspect-[4/3] overflow-hidden rounded-xl border border-surface-700/60 bg-surface-950 shadow-2xl shadow-black/40 lg:aspect-auto lg:min-h-[460px]">
         {
           channels.map((channel, i) => (
             <div
@@ -172,7 +172,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
                 alt={channel.alt}
                 width={channel.width}
                 height={channel.height}
-                class="h-full w-full object-cover object-left-top"
+                class="h-full w-full object-contain"
                 loading="lazy"
                 decoding="async"
               />

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -214,7 +214,10 @@ const pad = (n: number) => String(n).padStart(2, '0');
     let current = 0;
     let startedAt = 0;
     let frame = 0;
-    let paused = false;
+    // Hover and focus pause independently; autoplay resumes only when neither holds.
+    let hovered = false;
+    let focused = false;
+    const paused = () => hovered || focused;
     let osdTimer = 0;
 
     const progressOf = (i) => tabs[i].querySelector('.channel-progress');
@@ -250,7 +253,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
     }
 
     function tick(now) {
-      if (!paused) {
+      if (!paused()) {
         const progress = (now - startedAt) / DWELL_MS;
         if (progress >= 1) show(current + 1);
         else progressOf(current).style.width = `${progress * 100}%`;
@@ -282,13 +285,16 @@ const pad = (n: number) => String(n).padStart(2, '0');
     });
 
     // A visitor who is reading or operating the block keeps the current channel.
-    root.addEventListener('mouseenter', () => { paused = true; });
-    root.addEventListener('mouseleave', () => { paused = false; startedAt = performance.now(); });
-    root.addEventListener('focusin', () => { paused = true; });
+    const resumeIfIdle = () => {
+      if (!paused()) startedAt = performance.now();
+    };
+    root.addEventListener('mouseenter', () => { hovered = true; });
+    root.addEventListener('mouseleave', () => { hovered = false; resumeIfIdle(); });
+    root.addEventListener('focusin', () => { focused = true; });
     root.addEventListener('focusout', (event) => {
       if (root.contains(event.relatedTarget)) return;
-      paused = false;
-      startedAt = performance.now();
+      focused = false;
+      resumeIfIdle();
     });
 
     // Only run while the block is on screen.

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -110,16 +110,12 @@ const pad = (n: number) => String(n).padStart(2, '0');
 
     <div class="mt-12 grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)]" data-channel-switcher>
       <!-- Channel list -->
-      <div
-        class="flex flex-col overflow-hidden rounded-xl border border-surface-800 bg-surface-900/40"
-        role="tablist"
-        aria-label="App screens"
-        aria-orientation="vertical"
-      >
+      <div class="flex flex-col overflow-hidden rounded-xl border border-surface-800 bg-surface-900/40">
         <div class="flex items-center justify-between border-b border-surface-800 px-4 py-3 font-mono text-[11px] uppercase tracking-[0.15em] text-surface-500">
           <span>Channels</span>
           <span>{pad(channels.length)}</span>
         </div>
+        <div role="tablist" aria-label="App screens" aria-orientation="vertical" class="flex flex-col">
         {
           channels.map((channel, i) => (
             <button
@@ -149,6 +145,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
             </button>
           ))
         }
+        </div>
         <div class="mt-auto flex items-center justify-between gap-3 border-t border-surface-800 px-4 py-2.5 font-mono text-[11px] text-surface-500">
           <span class="hidden lg:inline">
             <kbd class="rounded border border-surface-700 px-1.5 py-px text-surface-400">↑</kbd>
@@ -244,16 +241,16 @@ const pad = (n: number) => String(n).padStart(2, '0');
 
     const DWELL_MS = 7000;
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    let current = 0;
-    let startedAt = 0;
-    let pausedAt = 0;
-    let frame = 0;
     // Hover and focus pause while they last; the toggle pauses until the
     // visitor resumes. Autoplay runs only when none of the three holds.
     let hovered = false;
     let focused = false;
     let stopped = false;
     const paused = () => hovered || focused || stopped;
+    let current = 0;
+    let startedAt = 0;
+    let pausedAt = 0;
+    let frame = 0;
     let osdTimer = 0;
 
     const progressOf = (i) => tabs[i].querySelector('.channel-progress');
@@ -274,7 +271,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
         progressOf(i).style.width = '0%';
       });
       loadFrame(current);
-      loadFrame(current + 1);
+      if (!reduceMotion && !stopped) loadFrame(current + 1);
       panels.forEach((panel, i) => {
         const active = i === current;
         panel.classList.toggle('opacity-0', !active);

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -363,6 +363,8 @@ const pad = (n: number) => String(n).padStart(2, '0');
           toggle.setAttribute('aria-label', stopped ? 'Resume auto-advance' : 'Pause auto-advance');
           toggle.querySelector('[data-icon-pause]').classList.toggle('hidden', stopped);
           toggle.querySelector('[data-icon-play]').classList.toggle('hidden', !stopped);
+          // A channel picked while paused skipped its successor; fetch it now that autoplay can reach it.
+          if (!stopped) loadFrame(current + 1);
         });
       }
     }

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -13,6 +13,11 @@
  * under it with opacity 0, so native lazy loading would fetch all six at
  * once. The script assigns `src` from `data-src` when a channel is shown and
  * preloads the one after it, so at most two frames are in flight.
+ *
+ * The list precedes the screen in the DOM at every breakpoint (tabs before
+ * their panels, focus order equals reading order); on phones the list simply
+ * hides the per-channel descriptions and the keyboard hint so the screen
+ * stays close.
  */
 const channels = [
   {
@@ -120,7 +125,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
               aria-controls={`screen-panel-${channel.id}`}
               tabindex={i === 0 ? 0 : -1}
               data-channel={channel.id}
-              class="channel-tab group relative grid grid-cols-[38px_minmax(0,1fr)] gap-3 border-t border-surface-800 px-4 py-3.5 text-left transition-colors duration-200 first-of-type:border-t-0 hover:bg-white/[0.025] focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent-400"
+              class="channel-tab group relative grid grid-cols-[38px_minmax(0,1fr)] gap-3 border-t border-surface-800 px-4 py-3 text-left sm:py-3.5 transition-colors duration-200 first-of-type:border-t-0 hover:bg-white/[0.025] focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-accent-400"
             >
               <span class="channel-number pt-0.5 font-mono text-xs tabular-nums text-surface-500 transition-colors duration-200">
                 {pad(i + 1)}
@@ -129,7 +134,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
                 <span class="block font-display text-[15px] font-semibold tracking-tight text-surface-100">
                   {channel.label}
                 </span>
-                <span class="mt-0.5 block text-[12.5px] leading-snug text-surface-500">
+                <span class="mt-0.5 hidden text-[12.5px] leading-snug text-surface-500 sm:block">
                   {channel.description}
                 </span>
               </span>
@@ -139,7 +144,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
             </button>
           ))
         }
-        <div class="mt-auto border-t border-surface-800 px-4 py-3 font-mono text-[11px] text-surface-500">
+        <div class="mt-auto hidden border-t border-surface-800 px-4 py-3 font-mono text-[11px] text-surface-500 lg:block">
           <kbd class="rounded border border-surface-700 px-1.5 py-px text-surface-400">↑</kbd>
           <kbd class="rounded border border-surface-700 px-1.5 py-px text-surface-400">↓</kbd>
           <span class="ml-1.5">switch channel</span>
@@ -147,7 +152,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
       </div>
 
       <!-- Screen -->
-      <div class="relative order-first aspect-[4/3] overflow-hidden rounded-xl border border-surface-700/60 bg-surface-900 shadow-2xl shadow-black/40 lg:order-none lg:aspect-auto lg:min-h-[460px]">
+      <div class="relative aspect-[4/3] overflow-hidden rounded-xl border border-surface-700/60 bg-surface-900 shadow-2xl shadow-black/40 lg:aspect-auto lg:min-h-[460px]">
         {
           channels.map((channel, i) => (
             <div
@@ -219,6 +224,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     let current = 0;
     let startedAt = 0;
+    let pausedAt = 0;
     let frame = 0;
     // Hover and focus pause independently; autoplay resumes only when neither holds.
     let hovered = false;
@@ -264,11 +270,20 @@ const pad = (n: number) => String(n).padStart(2, '0');
         osdTimer = window.setTimeout(() => osd.classList.add('opacity-0', '-translate-y-1'), 1400);
       }
       startedAt = performance.now();
+      pausedAt = 0;
       if (focus) tabs[current].focus({ preventScroll: true });
     }
 
+    // The dwell clock stops while paused: the time spent hovering or focused is
+    // added to the start mark on resume, so the bar continues from where it froze.
     function tick(now) {
-      if (!paused()) {
+      if (paused()) {
+        if (!pausedAt) pausedAt = now;
+      } else {
+        if (pausedAt) {
+          startedAt += now - pausedAt;
+          pausedAt = 0;
+        }
         const progress = (now - startedAt) / DWELL_MS;
         if (progress >= 1) show(current + 1);
         else progressOf(current).style.width = `${progress * 100}%`;
@@ -280,6 +295,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
       loadFrame(current + 1);
       if (reduceMotion || frame) return;
       startedAt = performance.now();
+      pausedAt = 0;
       frame = window.requestAnimationFrame(tick);
     }
 
@@ -301,16 +317,12 @@ const pad = (n: number) => String(n).padStart(2, '0');
     });
 
     // A visitor who is reading or operating the block keeps the current channel.
-    const resumeIfIdle = () => {
-      if (!paused()) startedAt = performance.now();
-    };
     root.addEventListener('mouseenter', () => { hovered = true; });
-    root.addEventListener('mouseleave', () => { hovered = false; resumeIfIdle(); });
+    root.addEventListener('mouseleave', () => { hovered = false; });
     root.addEventListener('focusin', () => { focused = true; });
     root.addEventListener('focusout', (event) => {
       if (root.contains(event.relatedTarget)) return;
       focused = false;
-      resumeIfIdle();
     });
 
     // Only run while the block is on screen.

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -157,7 +157,6 @@ const pad = (n: number) => String(n).padStart(2, '0');
           <button
             type="button"
             class="channel-autoplay ml-auto inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-surface-700 px-2.5 py-1 text-surface-300 transition-colors hover:border-surface-500 hover:text-surface-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent-400"
-            aria-pressed="false"
             aria-label="Pause auto-advance"
             data-autoplay-toggle
           >
@@ -186,7 +185,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
               aria-hidden={i === 0 ? 'false' : 'true'}
               data-channel-panel={channel.id}
               class:list={[
-                'channel-panel absolute inset-0 transition-opacity duration-300',
+                'channel-panel absolute inset-0 transition-opacity duration-300 motion-reduce:transition-none',
                 i !== 0 && 'pointer-events-none opacity-0',
               ]}
             >
@@ -206,7 +205,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
 
         <!-- On-screen display: shows the channel number for a moment after a switch -->
         <div
-          class="channel-osd pointer-events-none absolute left-4 top-4 flex -translate-y-1 items-center gap-2.5 rounded-lg border border-white/10 bg-surface-950/75 px-3 py-2 font-mono text-xs text-surface-100 opacity-0 backdrop-blur transition-all duration-200"
+          class="channel-osd pointer-events-none absolute left-4 top-4 flex -translate-y-1 items-center gap-2.5 rounded-lg border border-white/10 bg-surface-950/75 px-3 py-2 font-mono text-xs text-surface-100 opacity-0 backdrop-blur transition-all duration-200 motion-reduce:transition-none"
           aria-hidden="true"
         >
           <span class="font-medium text-accent-400" data-osd-number>CH 01</span>
@@ -377,7 +376,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
     };
     toggle?.addEventListener('click', () => {
       stopped = !stopped;
-      toggle.setAttribute('aria-pressed', String(stopped));
+      // An action button, not a toggle: the name says what pressing it does next.
       toggle.querySelector('[data-autoplay-label]').textContent = stopped ? 'Resume' : 'Pause';
       toggle.setAttribute('aria-label', stopped ? 'Resume auto-advance' : 'Pause auto-advance');
       toggle.querySelector('[data-icon-pause]').classList.toggle('hidden', stopped);

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -8,6 +8,11 @@
  * under the active row) until the visitor hovers, focuses or scrolls the block
  * out of view; `prefers-reduced-motion` turns autoplay off entirely. Arrow keys
  * move between channels like a remote.
+ *
+ * Only the first frame ships with a `src`; the inactive panels sit stacked
+ * under it with opacity 0, so native lazy loading would fetch all six at
+ * once. The script assigns `src` from `data-src` when a channel is shown and
+ * preloads the one after it, so at most two frames are in flight.
  */
 const channels = [
   {
@@ -157,7 +162,8 @@ const pad = (n: number) => String(n).padStart(2, '0');
               ]}
             >
               <img
-                src={channel.image}
+                src={i === 0 ? channel.image : undefined}
+                data-src={channel.image}
                 alt={channel.alt}
                 width={channel.width}
                 height={channel.height}
@@ -222,6 +228,13 @@ const pad = (n: number) => String(n).padStart(2, '0');
 
     const progressOf = (i) => tabs[i].querySelector('.channel-progress');
 
+    // Inactive frames carry their URL in data-src; give a frame its src the
+    // first time it is needed (the shown channel and the one after it).
+    function loadFrame(i) {
+      const img = panels[(i + panels.length) % panels.length].querySelector('img');
+      if (img && !img.getAttribute('src')) img.setAttribute('src', img.dataset.src ?? '');
+    }
+
     function show(index, { focus = false, announce = true } = {}) {
       current = (index + tabs.length) % tabs.length;
       tabs.forEach((tab, i) => {
@@ -230,6 +243,8 @@ const pad = (n: number) => String(n).padStart(2, '0');
         tab.tabIndex = active ? 0 : -1;
         progressOf(i).style.width = '0%';
       });
+      loadFrame(current);
+      loadFrame(current + 1);
       panels.forEach((panel, i) => {
         const active = i === current;
         panel.classList.toggle('opacity-0', !active);
@@ -262,6 +277,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
     }
 
     function start() {
+      loadFrame(current + 1);
       if (reduceMotion || frame) return;
       startedAt = performance.now();
       frame = window.requestAnimationFrame(tick);

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -295,8 +295,9 @@ const pad = (n: number) => String(n).padStart(2, '0');
     // the bar keeps its width, and the clock resumes from the same mark when
     // the block scrolls back in. Only a channel change resets the dwell.
     function start() {
-      loadFrame(current + 1);
       if (reduceMotion || frame) return;
+      loadFrame(current + 1); // autoplay is on, so the next frame will be needed
+
       if (!startedAt) startedAt = performance.now();
       frame = window.requestAnimationFrame(tick);
     }

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -295,8 +295,11 @@ const pad = (n: number) => String(n).padStart(2, '0');
         window.clearTimeout(osdTimer);
         osdTimer = window.setTimeout(() => osd.classList.add('opacity-0', '-translate-y-1'), 1400);
       }
+      // A fresh dwell for the new channel. When the loop is not running the
+      // channel starts out paused right now, so time spent paused before
+      // Resume is not counted against it.
       startedAt = performance.now();
-      pausedAt = 0;
+      pausedAt = frame ? 0 : startedAt;
       if (focus) tabs[current].focus({ preventScroll: true });
     }
 

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -162,7 +162,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
                 width={channel.width}
                 height={channel.height}
                 class="h-full w-full object-cover object-left-top"
-                loading={i === 0 ? 'eager' : 'lazy'}
+                loading="lazy"
                 decoding="async"
               />
             </div>

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -291,11 +291,13 @@ const pad = (n: number) => String(n).padStart(2, '0');
       frame = window.requestAnimationFrame(tick);
     }
 
+    // Leaving the viewport is a pause like any other: the frame loop stops,
+    // the bar keeps its width, and the clock resumes from the same mark when
+    // the block scrolls back in. Only a channel change resets the dwell.
     function start() {
       loadFrame(current + 1);
       if (reduceMotion || frame) return;
-      startedAt = performance.now();
-      pausedAt = 0;
+      if (!startedAt) startedAt = performance.now();
       frame = window.requestAnimationFrame(tick);
     }
 
@@ -303,7 +305,7 @@ const pad = (n: number) => String(n).padStart(2, '0');
       if (!frame) return;
       window.cancelAnimationFrame(frame);
       frame = 0;
-      progressOf(current).style.width = '0%';
+      if (!pausedAt) pausedAt = performance.now();
     }
 
     tabs.forEach((tab, i) => tab.addEventListener('click', () => show(i, { focus: true })));

--- a/apps/website/src/components/ScreenshotShowcase.astro
+++ b/apps/website/src/components/ScreenshotShowcase.astro
@@ -22,7 +22,9 @@
  * Hover and focus only pause while they last, which is no use to a touch or
  * screen-reader visitor, so the list footer carries a "Pause auto-advance"
  * toggle that stays paused until pressed again (WCAG 2.2.2). It is removed
- * under reduced motion, where there is nothing to pause.
+ * under reduced motion, where there is nothing to pause. The transient pauses
+ * watch the channel list and the screen only, so pressing Resume restarts
+ * autoplay at once even though the button keeps the pointer and the focus.
  */
 const channels = [
   {
@@ -171,7 +173,10 @@ const pad = (n: number) => String(n).padStart(2, '0');
       </div>
 
       <!-- Screen -->
-      <div class="relative aspect-[4/3] overflow-hidden rounded-xl border border-surface-700/60 bg-surface-950 shadow-2xl shadow-black/40 lg:aspect-auto lg:min-h-[460px]">
+      <div
+        class="relative aspect-[4/3] overflow-hidden rounded-xl border border-surface-700/60 bg-surface-950 shadow-2xl shadow-black/40 lg:aspect-auto lg:min-h-[460px]"
+        data-channel-screen
+      >
         {
           channels.map((channel, i) => (
             <div
@@ -340,14 +345,21 @@ const pad = (n: number) => String(n).padStart(2, '0');
       show(keys[event.key], { focus: true });
     });
 
-    // A visitor who is reading or operating the block keeps the current channel.
-    root.addEventListener('mouseenter', () => { hovered = true; });
-    root.addEventListener('mouseleave', () => { hovered = false; });
-    root.addEventListener('focusin', () => { focused = true; });
-    root.addEventListener('focusout', (event) => {
-      if (root.contains(event.relatedTarget)) return;
-      focused = false;
-    });
+    // A visitor who is reading the list or the screen keeps the current
+    // channel. The footer with the Pause/Resume control is deliberately not
+    // one of these regions: after pressing Resume the pointer and the focus
+    // are still on that button, and autoplay must visibly restart right away.
+    const regions = [root.querySelector('[role="tablist"]'), root.querySelector('[data-channel-screen]')].filter(Boolean);
+    const insideRegion = (node) => node instanceof Node && regions.some((region) => region.contains(node));
+    for (const region of regions) {
+      region.addEventListener('mouseenter', () => { hovered = true; });
+      region.addEventListener('mouseleave', () => { hovered = false; });
+      region.addEventListener('focusin', () => { focused = true; });
+      region.addEventListener('focusout', (event) => {
+        if (insideRegion(event.relatedTarget)) return;
+        focused = false;
+      });
+    }
 
     // Only run while the block is on screen.
     const toggle = root.querySelector('[data-autoplay-toggle]');

--- a/tools/testing/website-browser-support.mjs
+++ b/tools/testing/website-browser-support.mjs
@@ -1,0 +1,101 @@
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { extname, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Shared plumbing for the website tests that drive the built site in a real
+ * browser: a loopback static server for `dist/apps/website` mounted under the
+ * GitHub Pages base path, and a Chromium launcher.
+ *
+ * The server only ever hands out files below the build directory: the
+ * requested path is resolved against the root and anything that escapes it is
+ * answered with 404. Only local tests talk to it, but the guard keeps the
+ * helper honest and static analysis quiet.
+ *
+ * Chromium comes from the Playwright download when one exists, otherwise from
+ * the system Chrome/Chromium channel (GitHub's Ubuntu runners ship Google
+ * Chrome). In CI a missing browser is a failure, never a silent skip, so the
+ * interaction assertions cannot rot unnoticed; locally the caller may skip.
+ */
+
+export const distRoot = fileURLToPath(new URL('../../dist/apps/website/', import.meta.url));
+export const BASE_PATH = '/iptvnator';
+
+const MIME = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.webp': 'image/webp',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.xml': 'text/xml',
+};
+
+/** Maps a request URL to a file below `distRoot`, or `null` when it escapes the root. */
+export function resolveDistFile(url) {
+  let pathname;
+  try {
+    pathname = decodeURIComponent(new URL(url, 'http://localhost').pathname);
+  } catch {
+    return null;
+  }
+  if (pathname.startsWith(BASE_PATH)) {
+    pathname = pathname.slice(BASE_PATH.length) || '/';
+  }
+  const root = resolve(distRoot);
+  const candidate = resolve(root, `.${pathname}`);
+  if (candidate !== root && !candidate.startsWith(root + sep)) {
+    return null;
+  }
+  const file = existsSync(candidate) && statSync(candidate).isDirectory() ? resolve(candidate, 'index.html') : candidate;
+  return existsSync(file) ? file : null;
+}
+
+/** Serves the build on a random loopback port; resolves to `{ server, origin }`. */
+export function serveDist() {
+  const server = createServer((req, res) => {
+    const file = resolveDistFile(req.url ?? '/');
+    if (!file) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    res.setHeader('content-type', MIME[extname(file)] ?? 'application/octet-stream');
+    createReadStream(file).pipe(res);
+  });
+  return new Promise((done) =>
+    server.listen(0, '127.0.0.1', () => done({ server, origin: `http://127.0.0.1:${server.address().port}` })),
+  );
+}
+
+/**
+ * Launches Chromium, trying the Playwright download first and the system
+ * channels next. Returns `null` when none is available — except in CI, where
+ * that is thrown as an error so the browser half of a test cannot be skipped.
+ */
+export async function launchBrowser() {
+  let playwright;
+  try {
+    playwright = await import('@playwright/test');
+  } catch (error) {
+    return unavailable(`@playwright/test is not installed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const attempts = [];
+  for (const options of [{}, { channel: 'chrome' }, { channel: 'chromium' }]) {
+    try {
+      return await playwright.chromium.launch(options);
+    } catch (error) {
+      attempts.push(`${JSON.stringify(options)}: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`);
+    }
+  }
+  return unavailable(`no Chromium could be launched (${attempts.join('; ')})`);
+}
+
+function unavailable(reason) {
+  if (process.env.CI) {
+    throw new Error(`Website browser tests must run in CI, but ${reason}`);
+  }
+  return null;
+}

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -42,6 +42,10 @@ test('showcase markup: a vertical tablist with one selected channel and a panel 
   assert.match(html, /href="\/iptvnator\/features\/epg\/"/, 'captions link into the feature pages');
   const toggleTag = html.match(/<button[^>]*data-autoplay-toggle[^>]*>/)?.[0];
   assert.ok(toggleTag && /aria-pressed="false"/.test(toggleTag), 'a persistent pause control ships in the markup');
+  const tablist = html.match(/<div role="tablist"[\s\S]*?<\/div>/)?.[0];
+  assert.ok(tablist, 'tablist element');
+  assert.equal((tablist.match(/<button/g) ?? []).length, CHANNELS.length, 'the tablist holds exactly the tabs');
+  assert.doesNotMatch(tablist, /data-autoplay-toggle/, 'the pause control lives outside the tablist');
 
   const frames = panels.map((panel) => html.slice(html.indexOf(panel)).match(/<img[^>]*>/)[0]);
   assert.equal(frames.filter((img) => / src="/.test(img)).length, 1, 'only the first frame ships with a src');
@@ -183,6 +187,7 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     await calm.keyboard.press('Tab');
     await calm.locator('.channel-tab').nth(1).click();
     assert.equal(await selectedChannel(calm), 'live-tv', 'manual switching still works');
+    assert.deepEqual(await loaded(calm), [true, true, false, false, false, false], 'a manual switch loads only the chosen frame under reduced motion');
     await calm.close();
   } finally {
     await browser.close();

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -141,6 +141,7 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     assert.equal(await toggle.getAttribute('aria-pressed'), 'false');
     assert.deepEqual((await loaded(page)).slice(3, 5), [true, true], 'resuming preloads the successor');
     assert.equal(await page.evaluate(() => document.activeElement?.hasAttribute('data-autoplay-toggle')), true, 'the button keeps focus');
+    assert.ok((await progressWidth(page)) < 3, 'time spent paused is not counted against the picked channel');
     await page.waitForTimeout(500);
     assert.ok((await progressWidth(page)) > pausedOnMovies + 2, 'autoplay runs while the toggle is focused and hovered');
     await page.mouse.move(5, 5);

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -124,6 +124,19 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
       null,
       { timeout: 5000 },
     );
+
+    // Scrolling the block away pauses the dwell; scrolling back resumes it from the same mark.
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(400); // let the IntersectionObserver report the exit
+    const whileAway = await progressWidth(page);
+    await page.waitForTimeout(700);
+    const stillAway = await progressWidth(page);
+    assert.ok(Math.abs(stillAway - whileAway) < 0.5, `progress holds while offscreen (${whileAway} → ${stillAway})`);
+    await page.locator('#screenshots').scrollIntoViewIfNeeded();
+    await page.mouse.move(5, 5);
+    await page.waitForTimeout(400);
+    const afterReturn = await progressWidth(page);
+    assert.ok(afterReturn >= whileAway && afterReturn < whileAway + 15, `progress resumes after scrolling back (${whileAway} → ${afterReturn})`);
     assert.deepEqual(errors, []);
     await page.close();
 

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -147,6 +147,7 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     await calm.mouse.move(5, 5);
     await calm.waitForTimeout(1500);
     assert.equal(await progressWidth(calm), 0, 'no progress under prefers-reduced-motion');
+    assert.deepEqual(await loaded(calm), [true, false, false, false, false, false], 'no prefetch when autoplay is off');
     assert.equal(await selectedChannel(calm), 'dashboard');
     await calm.keyboard.press('Tab');
     await calm.locator('.channel-tab').nth(1).click();

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -1,10 +1,8 @@
 import { readFile } from 'node:fs/promises';
-import { createServer } from 'node:http';
-import { createReadStream, existsSync, statSync } from 'node:fs';
-import { extname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { BASE_PATH as BASE, distRoot, launchBrowser, serveDist } from './website-browser-support.mjs';
 
 /**
  * The home page "Flip through the app" channel switcher.
@@ -14,23 +12,11 @@ import assert from 'node:assert/strict';
  * interaction half serves the build over HTTP and drives it in Chromium:
  * autoplay advances, hover and focus pause independently, arrow keys move
  * the selection together with the panel, caption and on-screen badge, and
- * `prefers-reduced-motion` turns autoplay off. The browser half is skipped
- * when no Chromium is available, so the structural checks still run
- * everywhere.
+ * `prefers-reduced-motion` turns autoplay off. Without a Chromium the browser
+ * half is skipped locally and fails in CI (see website-browser-support.mjs).
  */
 
-const distRoot = fileURLToPath(new URL('../../dist/apps/website/', import.meta.url));
-const BASE = '/iptvnator';
 const CHANNELS = ['dashboard', 'live-tv', 'epg', 'movies', 'downloads', 'settings'];
-
-const MIME = {
-  '.html': 'text/html',
-  '.css': 'text/css',
-  '.js': 'text/javascript',
-  '.webp': 'image/webp',
-  '.png': 'image/png',
-  '.svg': 'image/svg+xml',
-};
 
 test('showcase markup: a vertical tablist with one selected channel and a panel each', async () => {
   const html = await readFile(join(distRoot, 'index.html'), 'utf8');
@@ -56,40 +42,6 @@ test('showcase markup: a vertical tablist with one selected channel and a panel 
   assert.match(html, /href="\/iptvnator\/features\/epg\/"/, 'captions link into the feature pages');
 });
 
-async function launchBrowser() {
-  let playwright;
-  try {
-    playwright = await import('@playwright/test');
-  } catch {
-    return null;
-  }
-  for (const options of [{}, { channel: 'chrome' }, { channel: 'chromium' }]) {
-    try {
-      return await playwright.chromium.launch(options);
-    } catch {
-      // try the next install
-    }
-  }
-  return null;
-}
-
-function serveDist() {
-  const server = createServer((req, res) => {
-    let pathname = decodeURIComponent(req.url.split('?')[0]);
-    if (pathname.startsWith(BASE)) pathname = pathname.slice(BASE.length) || '/';
-    let file = join(distRoot, pathname);
-    if (existsSync(file) && statSync(file).isDirectory()) file = join(file, 'index.html');
-    if (!existsSync(file)) {
-      res.statusCode = 404;
-      res.end('not found');
-      return;
-    }
-    res.setHeader('content-type', MIME[extname(file)] ?? 'application/octet-stream');
-    createReadStream(file).pipe(res);
-  });
-  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server)));
-}
-
 const selectedChannel = (page) => page.$eval('.channel-tab[aria-selected="true"]', (el) => el.dataset.channel);
 const progressWidth = (page) =>
   page.$eval('.channel-tab[aria-selected="true"] .channel-progress', (el) => parseFloat(el.style.width) || 0);
@@ -101,8 +53,7 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     t.skip('no Chromium available for the browser half');
     return;
   }
-  const server = await serveDist();
-  const origin = `http://127.0.0.1:${server.address().port}`;
+  const { server, origin } = await serveDist();
   try {
     const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
     const errors = [];

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -1,0 +1,183 @@
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * The home page "Flip through the app" channel switcher.
+ *
+ * The structural half reads the built HTML: a vertical tablist with one
+ * selected channel, roving tabindex, and a panel per channel. The
+ * interaction half serves the build over HTTP and drives it in Chromium:
+ * autoplay advances, hover and focus pause independently, arrow keys move
+ * the selection together with the panel, caption and on-screen badge, and
+ * `prefers-reduced-motion` turns autoplay off. The browser half is skipped
+ * when no Chromium is available, so the structural checks still run
+ * everywhere.
+ */
+
+const distRoot = fileURLToPath(new URL('../../dist/apps/website/', import.meta.url));
+const BASE = '/iptvnator';
+const CHANNELS = ['dashboard', 'live-tv', 'epg', 'movies', 'downloads', 'settings'];
+
+const MIME = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.webp': 'image/webp',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+};
+
+test('showcase markup: a vertical tablist with one selected channel and a panel each', async () => {
+  const html = await readFile(join(distRoot, 'index.html'), 'utf8');
+  assert.match(html, /<section id="screenshots"/);
+  assert.match(html, /role="tablist"[^>]*aria-orientation="vertical"/);
+
+  const tabs = [...html.matchAll(/<button[^>]*role="tab"[^>]*>/g)].map((m) => m[0]);
+  assert.equal(tabs.length, CHANNELS.length, 'one tab per channel');
+  for (const [i, tab] of tabs.entries()) {
+    assert.match(tab, new RegExp(`data-channel="${CHANNELS[i]}"`));
+    assert.match(tab, new RegExp(`aria-controls="screen-panel-${CHANNELS[i]}"`));
+    assert.match(tab, new RegExp(`aria-selected="${i === 0 ? 'true' : 'false'}"`));
+    assert.match(tab, new RegExp(`tabindex="${i === 0 ? '0' : '-1'}"`));
+  }
+
+  const panels = [...html.matchAll(/<div[^>]*role="tabpanel"[^>]*>/g)].map((m) => m[0]);
+  assert.equal(panels.length, CHANNELS.length, 'one panel per channel');
+  for (const [i, panel] of panels.entries()) {
+    assert.match(panel, new RegExp(`id="screen-panel-${CHANNELS[i]}"`));
+    assert.match(panel, new RegExp(`aria-labelledby="screen-tab-${CHANNELS[i]}"`));
+    assert.match(panel, new RegExp(`aria-hidden="${i === 0 ? 'false' : 'true'}"`));
+  }
+  assert.match(html, /href="\/iptvnator\/features\/epg\/"/, 'captions link into the feature pages');
+});
+
+async function launchBrowser() {
+  let playwright;
+  try {
+    playwright = await import('@playwright/test');
+  } catch {
+    return null;
+  }
+  for (const options of [{}, { channel: 'chrome' }, { channel: 'chromium' }]) {
+    try {
+      return await playwright.chromium.launch(options);
+    } catch {
+      // try the next install
+    }
+  }
+  return null;
+}
+
+function serveDist() {
+  const server = createServer((req, res) => {
+    let pathname = decodeURIComponent(req.url.split('?')[0]);
+    if (pathname.startsWith(BASE)) pathname = pathname.slice(BASE.length) || '/';
+    let file = join(distRoot, pathname);
+    if (existsSync(file) && statSync(file).isDirectory()) file = join(file, 'index.html');
+    if (!existsSync(file)) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    res.setHeader('content-type', MIME[extname(file)] ?? 'application/octet-stream');
+    createReadStream(file).pipe(res);
+  });
+  return new Promise((resolve) => server.listen(0, '127.0.0.1', () => resolve(server)));
+}
+
+const selectedChannel = (page) => page.$eval('.channel-tab[aria-selected="true"]', (el) => el.dataset.channel);
+const progressWidth = (page) =>
+  page.$eval('.channel-tab[aria-selected="true"] .channel-progress', (el) => parseFloat(el.style.width) || 0);
+const hiddenPanels = (page) => page.$$eval('.channel-panel', (els) => els.map((el) => el.getAttribute('aria-hidden')));
+
+test('showcase interaction: autoplay, pausing, keyboard and synchronized state', async (t) => {
+  const browser = await launchBrowser();
+  if (!browser) {
+    t.skip('no Chromium available for the browser half');
+    return;
+  }
+  const server = await serveDist();
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  try {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    const errors = [];
+    page.on('pageerror', (error) => errors.push(String(error)));
+    await page.goto(`${origin}${BASE}/`, { waitUntil: 'networkidle' });
+    await page.locator('#screenshots').scrollIntoViewIfNeeded();
+    // Park the pointer away from the block so hover cannot pause autoplay.
+    await page.mouse.move(5, 5);
+
+    await page.waitForFunction(
+      () => parseFloat(document.querySelector('.channel-tab[aria-selected="true"] .channel-progress').style.width) > 5,
+      null,
+      { timeout: 5000 },
+    );
+    assert.equal(await selectedChannel(page), 'dashboard', 'autoplay starts on the first channel');
+
+    // Hover pauses.
+    await page.locator('.channel-tab').nth(2).hover();
+    await page.waitForTimeout(150);
+    const pausedAt = await progressWidth(page);
+    await page.waitForTimeout(700);
+    assert.ok(Math.abs((await progressWidth(page)) - pausedAt) < 0.5, 'progress holds while hovered');
+
+    // Clicking selects immediately and focus keeps the pause after the pointer leaves.
+    await page.locator('.channel-tab').nth(2).click();
+    assert.equal(await selectedChannel(page), 'epg');
+    assert.equal(await page.evaluate(() => document.activeElement?.dataset.channel), 'epg', 'click moves focus to the tab');
+    await page.mouse.move(5, 5);
+    await page.waitForTimeout(900);
+    assert.equal(await progressWidth(page), 0, 'a focused tab keeps autoplay paused after mouseleave');
+    assert.equal(await selectedChannel(page), 'epg');
+
+    // Keyboard: ArrowDown / ArrowUp / End / Home move selection, focus, panel, caption and badge together.
+    await page.keyboard.press('ArrowDown');
+    assert.equal(await selectedChannel(page), 'movies');
+    assert.equal(await page.evaluate(() => document.activeElement?.dataset.channel), 'movies');
+    assert.deepEqual(await hiddenPanels(page), ['true', 'true', 'true', 'false', 'true', 'true']);
+    assert.equal(await page.$eval('[data-caption-label]', (el) => el.textContent.trim()), 'Movies & series');
+    assert.equal(await page.$eval('[data-osd-number]', (el) => el.textContent.trim()), 'CH 04');
+    assert.equal(await page.$eval('.channel-osd', (el) => el.classList.contains('opacity-0')), false, 'badge shows on switch');
+    await page.keyboard.press('ArrowUp');
+    assert.equal(await selectedChannel(page), 'epg');
+    await page.keyboard.press('End');
+    assert.equal(await selectedChannel(page), 'settings');
+    await page.keyboard.press('ArrowDown');
+    assert.equal(await selectedChannel(page), 'dashboard', 'ArrowDown wraps around');
+    await page.keyboard.press('Home');
+    assert.equal(await selectedChannel(page), 'dashboard');
+    const tabIndexes = await page.$$eval('.channel-tab', (els) => els.map((el) => el.tabIndex));
+    assert.deepEqual(tabIndexes, [0, -1, -1, -1, -1, -1], 'roving tabindex follows the selection');
+
+    // Blurring the list resumes autoplay.
+    await page.evaluate(() => document.activeElement?.blur());
+    await page.waitForFunction(
+      () => parseFloat(document.querySelector('.channel-tab[aria-selected="true"] .channel-progress').style.width) > 5,
+      null,
+      { timeout: 5000 },
+    );
+    assert.deepEqual(errors, []);
+    await page.close();
+
+    // Reduced motion: no autoplay at all.
+    const calm = await browser.newPage({ viewport: { width: 1440, height: 900 }, reducedMotion: 'reduce' });
+    await calm.goto(`${origin}${BASE}/`, { waitUntil: 'networkidle' });
+    await calm.locator('#screenshots').scrollIntoViewIfNeeded();
+    await calm.mouse.move(5, 5);
+    await calm.waitForTimeout(1500);
+    assert.equal(await progressWidth(calm), 0, 'no progress under prefers-reduced-motion');
+    assert.equal(await selectedChannel(calm), 'dashboard');
+    await calm.keyboard.press('Tab');
+    await calm.locator('.channel-tab').nth(1).click();
+    assert.equal(await selectedChannel(calm), 'live-tv', 'manual switching still works');
+    await calm.close();
+  } finally {
+    await browser.close();
+    server.close();
+  }
+});

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -208,6 +208,36 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     await page.waitForTimeout(400);
     const afterReturn = await progressWidth(page);
     assert.ok(afterReturn >= whileAway && afterReturn < whileAway + 15, `progress resumes after scrolling back (${whileAway} → ${afterReturn})`);
+    // A hidden document pauses the dwell: no frames, progress frozen, resumes on return.
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => true });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(150);
+    const hiddenAt = await progressWidth(page);
+    const framesWhileHidden = await rafCount(page);
+    await page.waitForTimeout(600);
+    assert.ok(Math.abs((await progressWidth(page)) - hiddenAt) < 0.5, 'progress holds while the document is hidden');
+    assert.equal(await rafCount(page), framesWhileHidden, 'no frames while the document is hidden');
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => false });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await page.waitForTimeout(400);
+    assert.ok((await progressWidth(page)) > hiddenAt, 'the dwell resumes when the document is visible again');
+
+    // Reduced motion switched on at runtime stops autoplay and hides the control; switching it off restores both.
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.waitForTimeout(150);
+    const reducedAt = await progressWidth(page);
+    await page.waitForTimeout(600);
+    assert.ok(Math.abs((await progressWidth(page)) - reducedAt) < 0.5, 'autoplay stops when reduced motion is enabled at runtime');
+    assert.equal(await page.locator('[data-autoplay-toggle]').isVisible(), false, 'the pause control hides under reduced motion');
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await page.waitForTimeout(400);
+    assert.ok((await progressWidth(page)) > reducedAt, 'autoplay resumes when the preference is cleared');
+    assert.equal(await page.locator('[data-autoplay-toggle]').isVisible(), true, 'the pause control returns');
+
     assert.deepEqual(errors, []);
     await page.close();
 
@@ -220,7 +250,7 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     assert.equal(await progressWidth(calm), 0, 'no progress under prefers-reduced-motion');
     assert.deepEqual(await loaded(calm), [true, false, false, false, false, false], 'no prefetch when autoplay is off');
     assert.equal(await selectedChannel(calm), 'dashboard');
-    assert.equal(await calm.locator('[data-autoplay-toggle]').count(), 0, 'no pause control when nothing advances');
+    assert.equal(await calm.locator('[data-autoplay-toggle]').isVisible(), false, 'no pause control when nothing advances');
     await calm.keyboard.press('Tab');
     await calm.locator('.channel-tab').nth(1).click();
     assert.equal(await selectedChannel(calm), 'live-tv', 'manual switching still works');

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -68,6 +68,16 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
     const errors = [];
     page.on('pageerror', (error) => errors.push(String(error)));
+    // Count scheduled animation frames so a paused switcher can be shown to schedule none.
+    await page.addInitScript(() => {
+      const raf = window.requestAnimationFrame.bind(window);
+      window.__rafCount = 0;
+      window.requestAnimationFrame = (cb) => {
+        window.__rafCount += 1;
+        return raf(cb);
+      };
+    });
+    const rafCount = (p) => p.evaluate(() => window.__rafCount);
     await page.goto(`${origin}${BASE}/`, { waitUntil: 'networkidle' });
     await page.locator('#screenshots').scrollIntoViewIfNeeded();
     // Park the pointer away from the block so hover cannot pause autoplay.
@@ -101,8 +111,11 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     await page.mouse.move(5, 5);
     await page.evaluate(() => document.activeElement?.blur());
     const stoppedAt = await progressWidth(page);
-    await page.waitForTimeout(800);
+    await page.waitForTimeout(200);
+    const framesAtPause = await rafCount(page);
+    await page.waitForTimeout(600);
     assert.ok(Math.abs((await progressWidth(page)) - stoppedAt) < 0.5, 'the toggle keeps autoplay paused after mouseleave and blur');
+    assert.equal(await rafCount(page), framesAtPause, 'a paused switcher schedules no animation frames');
 
     // A channel picked while paused does not preload its successor; resuming fetches it.
     await page.locator('.channel-tab').nth(3).click();
@@ -113,6 +126,15 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     await page.waitForTimeout(300);
     const pausedOnMovies = await progressWidth(page);
     assert.ok(pausedOnMovies < 0.5, 'still paused on the newly picked channel');
+
+    // Scrolling away and back while paused must not fetch the successor either.
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(400);
+    await page.locator('#screenshots').scrollIntoViewIfNeeded();
+    await page.mouse.move(5, 5);
+    await page.waitForTimeout(400);
+    assert.deepEqual((await loaded(page)).slice(3, 5), [true, false], 'returning to a paused switcher loads no successor');
+    assert.ok((await progressWidth(page)) < 0.5, 'still paused after returning');
 
     // Resume restarts autoplay at once, with the pointer and the focus still on the button.
     await toggle.click();

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -103,17 +103,26 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     const stoppedAt = await progressWidth(page);
     await page.waitForTimeout(800);
     assert.ok(Math.abs((await progressWidth(page)) - stoppedAt) < 0.5, 'the toggle keeps autoplay paused after mouseleave and blur');
+
     // A channel picked while paused does not preload its successor; resuming fetches it.
     await page.locator('.channel-tab').nth(3).click();
     assert.equal(await selectedChannel(page), 'movies');
     assert.deepEqual((await loaded(page)).slice(3, 5), [true, false], 'paused: the picked frame loads, its successor does not');
+    await page.mouse.move(5, 5);
+    await page.evaluate(() => document.activeElement?.blur());
+    await page.waitForTimeout(300);
+    const pausedOnMovies = await progressWidth(page);
+    assert.ok(pausedOnMovies < 0.5, 'still paused on the newly picked channel');
+
+    // Resume restarts autoplay at once, with the pointer and the focus still on the button.
     await toggle.click();
     assert.equal(await toggle.getAttribute('aria-pressed'), 'false');
     assert.deepEqual((await loaded(page)).slice(3, 5), [true, true], 'resuming preloads the successor');
+    assert.equal(await page.evaluate(() => document.activeElement?.hasAttribute('data-autoplay-toggle')), true, 'the button keeps focus');
+    await page.waitForTimeout(500);
+    assert.ok((await progressWidth(page)) > pausedOnMovies + 2, 'autoplay runs while the toggle is focused and hovered');
     await page.mouse.move(5, 5);
     await page.evaluate(() => document.activeElement?.blur());
-    await page.waitForTimeout(500);
-    assert.ok((await progressWidth(page)) > stoppedAt, 'resuming continues the dwell');
 
     // Hover pauses.
     await page.locator('.channel-tab').nth(2).hover();

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -103,8 +103,13 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     const stoppedAt = await progressWidth(page);
     await page.waitForTimeout(800);
     assert.ok(Math.abs((await progressWidth(page)) - stoppedAt) < 0.5, 'the toggle keeps autoplay paused after mouseleave and blur');
+    // A channel picked while paused does not preload its successor; resuming fetches it.
+    await page.locator('.channel-tab').nth(3).click();
+    assert.equal(await selectedChannel(page), 'movies');
+    assert.deepEqual((await loaded(page)).slice(3, 5), [true, false], 'paused: the picked frame loads, its successor does not');
     await toggle.click();
     assert.equal(await toggle.getAttribute('aria-pressed'), 'false');
+    assert.deepEqual((await loaded(page)).slice(3, 5), [true, true], 'resuming preloads the successor');
     await page.mouse.move(5, 5);
     await page.evaluate(() => document.activeElement?.blur());
     await page.waitForTimeout(500);

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -40,6 +40,10 @@ test('showcase markup: a vertical tablist with one selected channel and a panel 
     assert.match(panel, new RegExp(`aria-hidden="${i === 0 ? 'false' : 'true'}"`));
   }
   assert.match(html, /href="\/iptvnator\/features\/epg\/"/, 'captions link into the feature pages');
+
+  const frames = panels.map((panel) => html.slice(html.indexOf(panel)).match(/<img[^>]*>/)[0]);
+  assert.equal(frames.filter((img) => / src="/.test(img)).length, 1, 'only the first frame ships with a src');
+  assert.ok(frames.every((img) => /data-src="\/iptvnator\/screenshots\//.test(img)), 'every frame carries its data-src');
 });
 
 const selectedChannel = (page) => page.$eval('.channel-tab[aria-selected="true"]', (el) => el.dataset.channel);
@@ -69,6 +73,8 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
       { timeout: 5000 },
     );
     assert.equal(await selectedChannel(page), 'dashboard', 'autoplay starts on the first channel');
+    const loaded = (p) => p.$$eval('.channel-panel img', (els) => els.map((el) => Boolean(el.getAttribute('src'))));
+    assert.deepEqual(await loaded(page), [true, true, false, false, false, false], 'only the shown frame and the next one have a src');
 
     // Hover pauses.
     await page.locator('.channel-tab').nth(2).hover();
@@ -93,6 +99,7 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     assert.deepEqual(await hiddenPanels(page), ['true', 'true', 'true', 'false', 'true', 'true']);
     assert.equal(await page.$eval('[data-caption-label]', (el) => el.textContent.trim()), 'Movies & series');
     assert.equal(await page.$eval('[data-osd-number]', (el) => el.textContent.trim()), 'CH 04');
+    assert.deepEqual((await loaded(page)).slice(2, 5), [true, true, true], 'a shown frame and its successor get their src');
     assert.equal(await page.$eval('.channel-osd', (el) => el.classList.contains('opacity-0')), false, 'badge shows on switch');
     await page.keyboard.press('ArrowUp');
     assert.equal(await selectedChannel(page), 'epg');

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -40,6 +40,8 @@ test('showcase markup: a vertical tablist with one selected channel and a panel 
     assert.match(panel, new RegExp(`aria-hidden="${i === 0 ? 'false' : 'true'}"`));
   }
   assert.match(html, /href="\/iptvnator\/features\/epg\/"/, 'captions link into the feature pages');
+  const toggleTag = html.match(/<button[^>]*data-autoplay-toggle[^>]*>/)?.[0];
+  assert.ok(toggleTag && /aria-pressed="false"/.test(toggleTag), 'a persistent pause control ships in the markup');
 
   const frames = panels.map((panel) => html.slice(html.indexOf(panel)).match(/<img[^>]*>/)[0]);
   assert.equal(frames.filter((img) => / src="/.test(img)).length, 1, 'only the first frame ships with a src');
@@ -75,6 +77,34 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     assert.equal(await selectedChannel(page), 'dashboard', 'autoplay starts on the first channel');
     const loaded = (p) => p.$$eval('.channel-panel img', (els) => els.map((el) => Boolean(el.getAttribute('src'))));
     assert.deepEqual(await loaded(page), [true, true, false, false, false, false], 'only the shown frame and the next one have a src');
+
+    // The dwell really rolls over: tab, panel, caption and badge all move to channel 02.
+    await page.waitForFunction(
+      () => document.querySelector('.channel-tab[aria-selected="true"]')?.dataset.channel === 'live-tv',
+      null,
+      { timeout: 9000 },
+    );
+    assert.deepEqual(await hiddenPanels(page), ['true', 'false', 'true', 'true', 'true', 'true'], 'the panel follows autoplay');
+    assert.equal(await page.$eval('[data-caption-label]', (el) => el.textContent.trim()), 'Live TV');
+    assert.equal(await page.$eval('[data-osd-number]', (el) => el.textContent.trim()), 'CH 02');
+    assert.deepEqual((await loaded(page)).slice(0, 3), [true, true, true], 'autoplay preloads the frame after the new channel');
+
+    // The toggle pauses until pressed again, whatever the pointer and focus do.
+    const toggle = page.locator('[data-autoplay-toggle]');
+    await toggle.click();
+    assert.equal(await toggle.getAttribute('aria-pressed'), 'true');
+    assert.equal(await toggle.getAttribute('aria-label'), 'Resume auto-advance');
+    await page.mouse.move(5, 5);
+    await page.evaluate(() => document.activeElement?.blur());
+    const stoppedAt = await progressWidth(page);
+    await page.waitForTimeout(800);
+    assert.ok(Math.abs((await progressWidth(page)) - stoppedAt) < 0.5, 'the toggle keeps autoplay paused after mouseleave and blur');
+    await toggle.click();
+    assert.equal(await toggle.getAttribute('aria-pressed'), 'false');
+    await page.mouse.move(5, 5);
+    await page.evaluate(() => document.activeElement?.blur());
+    await page.waitForTimeout(500);
+    assert.ok((await progressWidth(page)) > stoppedAt, 'resuming continues the dwell');
 
     // Hover pauses.
     await page.locator('.channel-tab').nth(2).hover();
@@ -149,6 +179,7 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     assert.equal(await progressWidth(calm), 0, 'no progress under prefers-reduced-motion');
     assert.deepEqual(await loaded(calm), [true, false, false, false, false, false], 'no prefetch when autoplay is off');
     assert.equal(await selectedChannel(calm), 'dashboard');
+    assert.equal(await calm.locator('[data-autoplay-toggle]').count(), 0, 'no pause control when nothing advances');
     await calm.keyboard.press('Tab');
     await calm.locator('.channel-tab').nth(1).click();
     assert.equal(await selectedChannel(calm), 'live-tv', 'manual switching still works');

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -82,8 +82,13 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     const pausedAt = await progressWidth(page);
     await page.waitForTimeout(700);
     assert.ok(Math.abs((await progressWidth(page)) - pausedAt) < 0.5, 'progress holds while hovered');
+    await page.mouse.move(5, 5);
+    await page.waitForTimeout(400);
+    const resumed = await progressWidth(page);
+    assert.ok(resumed >= pausedAt && resumed < pausedAt + 15, `progress resumes from where it paused (${pausedAt} → ${resumed})`);
 
     // Clicking selects immediately and focus keeps the pause after the pointer leaves.
+    await page.locator('.channel-tab').nth(2).hover();
     await page.locator('.channel-tab').nth(2).click();
     assert.equal(await selectedChannel(page), 'epg');
     assert.equal(await page.evaluate(() => document.activeElement?.dataset.channel), 'epg', 'click moves focus to the tab');

--- a/tools/testing/website-screenshot-showcase.test.mjs
+++ b/tools/testing/website-screenshot-showcase.test.mjs
@@ -41,7 +41,10 @@ test('showcase markup: a vertical tablist with one selected channel and a panel 
   }
   assert.match(html, /href="\/iptvnator\/features\/epg\/"/, 'captions link into the feature pages');
   const toggleTag = html.match(/<button[^>]*data-autoplay-toggle[^>]*>/)?.[0];
-  assert.ok(toggleTag && /aria-pressed="false"/.test(toggleTag), 'a persistent pause control ships in the markup');
+  assert.ok(toggleTag && /aria-label="Pause auto-advance"/.test(toggleTag), 'a persistent pause control ships in the markup');
+  assert.doesNotMatch(toggleTag, /aria-pressed/, 'the control is an action button, not a toggle with a changing name');
+  assert.match(html, /channel-osd[^"]*motion-reduce:transition-none/, 'the OSD slide is off under reduced motion');
+  assert.match(html, /channel-panel[^"]*motion-reduce:transition-none/, 'the panel fade is off under reduced motion');
   const tablist = html.match(/<div role="tablist"[\s\S]*?<\/div>/)?.[0];
   assert.ok(tablist, 'tablist element');
   assert.equal((tablist.match(/<button/g) ?? []).length, CHANNELS.length, 'the tablist holds exactly the tabs');
@@ -106,7 +109,6 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
     // The toggle pauses until pressed again, whatever the pointer and focus do.
     const toggle = page.locator('[data-autoplay-toggle]');
     await toggle.click();
-    assert.equal(await toggle.getAttribute('aria-pressed'), 'true');
     assert.equal(await toggle.getAttribute('aria-label'), 'Resume auto-advance');
     await page.mouse.move(5, 5);
     await page.evaluate(() => document.activeElement?.blur());
@@ -138,7 +140,7 @@ test('showcase interaction: autoplay, pausing, keyboard and synchronized state',
 
     // Resume restarts autoplay at once, with the pointer and the focus still on the button.
     await toggle.click();
-    assert.equal(await toggle.getAttribute('aria-pressed'), 'false');
+    assert.equal(await toggle.getAttribute('aria-label'), 'Pause auto-advance');
     assert.deepEqual((await loaded(page)).slice(3, 5), [true, true], 'resuming preloads the successor');
     assert.equal(await page.evaluate(() => document.activeElement?.hasAttribute('data-autoplay-toggle')), true, 'the button keeps focus');
     assert.ok((await progressWidth(page)) < 3, 'time spent paused is not counted against the picked channel');


### PR DESCRIPTION
## Summary

Second landing redesign PR (after #1539). "See it in action" was a tab strip in a dashed frame showing one screenshot inside a drawn window chrome that duplicated the chrome already in the shot. It is now a **channel switcher**, in the language of the player itself:

- **Channel list on the left**: number, screen name and one line about what the screen is for. **One frame on the right**, with a caption that links to the matching feature page.
- **Runs on its own**: channels advance every 7 s with a progress hairline under the active row. Hovering, focusing or scrolling the block out of view pauses it; `prefers-reduced-motion` disables autoplay entirely. A brief on-screen `CH 03` badge confirms every switch.
- **Keyboard and a11y**: Arrow keys, Home and End move between channels; the list is a vertical `tablist` with roving `tabindex`, panels carry `aria-hidden`.
- **Six screens**: Dashboard, Live TV, Program guide, Movies & series, Downloads, Settings. Same files from `public/screenshots`; the add-playlist shot is replaced by the movie detail and the download manager.
- On phones the screen comes first and the list follows.

## Validation

- `pnpm nx build website` (with `WEBSITE_SKIP_RELEASE_FETCH=1`): 32 pages built.
- `pnpm nx test website`: 36/36 passing.
- Playwright pass over the built page at 1440px and 390px: autoplay progress advances, `ArrowDown`×2 selects channel 03 with the OSD and caption updated, panels toggle `aria-hidden`, click selects channel 05, no console errors.
- No `.changes` note: `apps/website/**` is exempt from the release-note gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
