### PR TITLE
test(xtream): split the live-stream layout spec under the max-lines cap

### DIFF
--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.browsing-navigation.spec.ts
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.browsing-navigation.spec.ts
@@ -1,0 +1,395 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import {
+    ActivatedRoute,
+    NavigationEnd,
+    Router,
+    convertToParamMap,
+} from '@angular/router';
+import { MockPipe } from 'ng-mocks';
+import { TranslatePipe } from '@ngx-translate/core';
+import { BehaviorSubject, Subject } from 'rxjs';
+import {
+    LIVE_EPG_PANEL_STATE_STORAGE_KEY,
+    liveSidebarStateStorageKey,
+    LiveLayoutSidebarStateService,
+    PORTAL_PLAYER,
+    ResizableDirective,
+} from '@iptvnator/portal/shared/util';
+import {
+    FavoritesService,
+    XtreamStore,
+    XtreamUrlService,
+} from '@iptvnator/portal/xtream/data-access';
+import { EpgListViewComponent, EpgTimelineComponent } from '@iptvnator/ui/epg';
+import { WebPlayerViewComponent } from '@iptvnator/ui/playback';
+import { GridListComponent } from '@iptvnator/portal/shared/ui';
+import { PortalChannelsListComponent } from '../portal-channels-list/portal-channels-list.component';
+import { LiveStreamLayoutComponent } from './live-stream-layout.component';
+import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
+import {
+    LIVE_CHANNEL_SORT_STORAGE_KEY,
+    StubEpgTimelineComponent,
+    StubGridListComponent,
+    StubPortalChannelsListComponent,
+    StubResizableDirective,
+    StubWebPlayerViewComponent,
+    categories,
+    categoryItemCounts,
+    currentEpgItem,
+    currentPlaylist,
+    epgItems,
+    favoritesService,
+    fixedNow,
+    hasMoreContent,
+    isLoadingEpg,
+    liveStreams,
+    paginatedContent,
+    playlist,
+    portalPlayer,
+    sampleChannel,
+    selectedCategoryId,
+    selectedContentType,
+    selectedItem,
+    selectedTypeContentLoading,
+    settingsStore,
+    xtreamStore,
+    xtreamUrlService,
+} from './live-stream-layout.spec-harness';
+
+// Split out of live-stream-layout.component.spec.ts, which sits at the
+// 1200-line test cap (max-lines). These cases cover channel navigation while
+// browsing: remote-control navigation that must preserve the browsing order
+// (#1554), and the Ctrl+F "auto-open" flow driven by router NavigationEnd.
+describe('LiveStreamLayoutComponent - browsing navigation', () => {
+    let fixture: ComponentFixture<LiveStreamLayoutComponent>;
+    let component: LiveStreamLayoutComponent;
+    let routeQueryParamMap: BehaviorSubject<
+        ReturnType<typeof convertToParamMap>
+    >;
+
+    let routerEvents: Subject<unknown>;
+    let router: { events: Subject<unknown>; navigate: jest.Mock };
+
+    const originalElectron = window.electron;
+
+    beforeEach(async () => {
+        currentPlaylist.set(playlist);
+        jest.useFakeTimers();
+        jest.setSystemTime(fixedNow);
+        settingsStore.resolvedEpgViewMode.set('timeline');
+        localStorage.removeItem(LIVE_CHANNEL_SORT_STORAGE_KEY);
+        localStorage.removeItem(LIVE_EPG_PANEL_STATE_STORAGE_KEY);
+        localStorage.removeItem(liveSidebarStateStorageKey('portal'));
+        settingsStore.openStreamOnDoubleClick.set(false);
+
+        window.electron = {
+            updateRemoteControlStatus: jest.fn(),
+            onChannelChange: jest.fn(() => jest.fn()),
+            onRemoteControlCommand: jest.fn(() => jest.fn()),
+        } as typeof window.electron;
+
+        routerEvents = new Subject();
+        router = { events: routerEvents, navigate: jest.fn() };
+        xtreamStore.constructStreamUrl.mockClear();
+        xtreamStore.openPlayer.mockClear();
+        xtreamStore.setSelectedItem.mockClear();
+        xtreamStore.setSelectedCategory.mockClear();
+        xtreamStore.loadMoreContent.mockClear();
+        xtreamStore.selectItemsFromSelectedCategory.mockReturnValue([
+            sampleChannel,
+        ]);
+        liveStreams.set([]);
+        paginatedContent.set([]);
+        hasMoreContent.set(false);
+        favoritesService.getFavorites.mockClear();
+        xtreamUrlService.resolveCatchupUrl.mockClear();
+        portalPlayer.isEmbeddedPlayer.mockReset();
+        portalPlayer.isEmbeddedPlayer.mockReturnValue(true);
+        portalPlayer.openExternalPlayback.mockClear();
+
+        epgItems.set([]);
+        currentEpgItem.set(null);
+        isLoadingEpg.set(false);
+        categories.set([{ category_id: 1, category_name: 'News' }]);
+        categoryItemCounts.set(new Map<number, number>([[1, 1]]));
+        selectedTypeContentLoading.set(false);
+        selectedCategoryId.set(1);
+        selectedContentType.set('live');
+        selectedItem.set(sampleChannel);
+        currentPlaylist.set(playlist);
+        routeQueryParamMap = new BehaviorSubject(convertToParamMap({}));
+
+        await TestBed.configureTestingModule({
+            imports: [LiveStreamLayoutComponent, NoopAnimationsModule],
+            providers: [
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        snapshot: {
+                            data: {},
+                            queryParamMap: convertToParamMap({}),
+                        },
+                        queryParamMap: routeQueryParamMap.asObservable(),
+                        pathFromRoot: [
+                            {
+                                snapshot: {
+                                    data: { layout: 'workspace' },
+                                },
+                            },
+                        ],
+                    },
+                },
+                {
+                    provide: Router,
+                    useValue: {
+                        events: router.events.asObservable(),
+                        navigate: router.navigate,
+                    },
+                },
+                { provide: XtreamStore, useValue: xtreamStore },
+                { provide: FavoritesService, useValue: favoritesService },
+                { provide: XtreamUrlService, useValue: xtreamUrlService },
+                {
+                    provide: RuntimeCapabilitiesService,
+                    useValue: {
+                        get supportsEpg() {
+                            return Boolean(window.electron);
+                        },
+                        get isElectron() {
+                            return Boolean(window.electron);
+                        },
+                        get supportsRemoteControl() {
+                            return Boolean(
+                                window.electron?.updateRemoteControlStatus &&
+                                window.electron.onChannelChange &&
+                                window.electron.onRemoteControlCommand
+                            );
+                        },
+                    },
+                },
+                { provide: SettingsStore, useValue: settingsStore },
+                { provide: PORTAL_PLAYER, useValue: portalPlayer },
+            ],
+        })
+            .overrideComponent(LiveStreamLayoutComponent, {
+                remove: {
+                    imports: [
+                        EpgListViewComponent,
+                        EpgTimelineComponent,
+                        GridListComponent,
+                        PortalChannelsListComponent,
+                        ResizableDirective,
+                        TranslatePipe,
+                        WebPlayerViewComponent,
+                    ],
+                },
+                add: {
+                    imports: [
+                        StubEpgTimelineComponent,
+                        StubGridListComponent,
+                        StubPortalChannelsListComponent,
+                        StubResizableDirective,
+                        MockPipe(
+                            TranslatePipe,
+                            (value: string | null | undefined) => value ?? ''
+                        ),
+                        StubWebPlayerViewComponent,
+                    ],
+                },
+            })
+            .compileComponents();
+
+        fixture = TestBed.createComponent(LiveStreamLayoutComponent);
+        component = fixture.componentInstance;
+
+        TestBed.inject(LiveLayoutSidebarStateService).setState(
+            'portal',
+            'expanded'
+        );
+    });
+
+    afterEach(() => {
+        TestBed.inject(LiveLayoutSidebarStateService).setState(
+            'portal',
+            'expanded'
+        );
+        fixture.destroy();
+        jest.useRealTimers();
+        localStorage.removeItem(LIVE_CHANNEL_SORT_STORAGE_KEY);
+        localStorage.removeItem(LIVE_EPG_PANEL_STATE_STORAGE_KEY);
+        localStorage.removeItem(liveSidebarStateStorageKey('portal'));
+        window.electron = originalElectron;
+    });
+
+    it('keeps remote order after browsing another category and changing sort', () => {
+        const first = { ...sampleChannel, category_id: '1', name: 'Zulu' };
+        const next = { ...first, xtream_id: 102, name: 'Alpha' };
+        liveStreams.set([first, next]);
+        xtreamStore.selectItemsFromSelectedCategory.mockReturnValue([
+            first,
+            next,
+        ]);
+        selectedItem.set(first);
+        component.playLive(first);
+        xtreamStore.setSelectedCategory.mockClear();
+        selectedCategoryId.set(2);
+        xtreamStore.selectItemsFromSelectedCategory.mockReturnValue([]);
+        component.setLiveChannelSortMode('name-desc');
+        component['handleRemoteChannelChange']('down');
+        expect(xtreamStore.constructStreamUrl).toHaveBeenLastCalledWith(next);
+        expect(xtreamStore.setSelectedCategory).not.toHaveBeenCalled();
+    });
+
+    it('starts external playback from remote channel navigation when double-click opening is enabled', () => {
+        const nextChannel = {
+            ...sampleChannel,
+            category_id: '1',
+            xtream_id: 102,
+            name: 'Channel 102',
+        };
+        settingsStore.openStreamOnDoubleClick.set(true);
+        portalPlayer.isEmbeddedPlayer.mockReturnValue(false);
+        selectedItem.set(sampleChannel);
+        xtreamStore.selectItemsFromSelectedCategory.mockReturnValue([
+            sampleChannel,
+            nextChannel,
+        ]);
+
+        liveStreams.set([{ ...sampleChannel, category_id: '1' }, nextChannel]);
+        component.playLive(sampleChannel);
+        xtreamStore.openPlayer.mockClear();
+        (
+            component as unknown as {
+                handleRemoteChannelChange(direction: 'up' | 'down'): void;
+            }
+        ).handleRemoteChannelChange('down');
+
+        expect(xtreamStore.openPlayer).toHaveBeenCalledWith(
+            'https://example.com/live.ts',
+            'Channel 102',
+            'channel-101.png'
+        );
+    });
+
+    describe('auto-open from Ctrl+F search navigation state', () => {
+        const searchChannel = {
+            xtream_id: 202,
+            name: 'Search Channel',
+            category_id: '7',
+            stream_icon: 'search-channel.png',
+            tv_archive: 0,
+            tv_archive_duration: 0,
+        };
+
+        function triggerNavigationEnd() {
+            routerEvents.next(
+                new NavigationEnd(
+                    1,
+                    '/workspace/xtreams/playlist-1/live',
+                    '/workspace/xtreams/playlist-1/live'
+                )
+            );
+        }
+
+        beforeEach(() => {
+            window.history.replaceState(
+                { openXtreamLiveItemId: searchChannel.xtream_id },
+                ''
+            );
+        });
+
+        afterEach(() => {
+            window.history.replaceState({}, '');
+        });
+
+        it('plays and selects a channel found in liveStreams on NavigationEnd', () => {
+            liveStreams.set([searchChannel]);
+            fixture.detectChanges();
+
+            triggerNavigationEnd();
+            fixture.detectChanges();
+
+            expect(xtreamStore.constructStreamUrl).toHaveBeenCalledWith(
+                searchChannel
+            );
+            expect(xtreamStore.setSelectedItem).toHaveBeenCalledWith(
+                searchChannel
+            );
+        });
+
+        it('sets the channel category so the sidebar highlights the correct entry', () => {
+            liveStreams.set([searchChannel]);
+            fixture.detectChanges();
+
+            triggerNavigationEnd();
+            fixture.detectChanges();
+
+            expect(xtreamStore.setSelectedCategory).toHaveBeenCalledWith(7);
+        });
+
+        it('does not auto-open while selectedContentType is not live', () => {
+            selectedContentType.set('vod');
+            liveStreams.set([searchChannel]);
+            fixture.detectChanges();
+
+            triggerNavigationEnd();
+            fixture.detectChanges();
+
+            expect(xtreamStore.constructStreamUrl).not.toHaveBeenCalledWith(
+                searchChannel
+            );
+        });
+
+        it('waits for liveStreams to populate before playing', () => {
+            liveStreams.set([]);
+            fixture.detectChanges();
+
+            triggerNavigationEnd();
+            fixture.detectChanges();
+
+            expect(xtreamStore.constructStreamUrl).not.toHaveBeenCalled();
+
+            liveStreams.set([searchChannel]);
+            fixture.detectChanges();
+
+            expect(xtreamStore.constructStreamUrl).toHaveBeenCalledWith(
+                searchChannel
+            );
+        });
+
+        it('clears the pending ID when the channel is not found in liveStreams', () => {
+            liveStreams.set([{ ...searchChannel, xtream_id: 999 }]);
+            fixture.detectChanges();
+
+            triggerNavigationEnd();
+            fixture.detectChanges();
+
+            expect(xtreamStore.constructStreamUrl).not.toHaveBeenCalledWith(
+                searchChannel
+            );
+        });
+
+        it('re-triggers auto-open on re-navigation when component is reused', () => {
+            liveStreams.set([searchChannel]);
+            fixture.detectChanges();
+
+            // First navigation — clears the pending state
+            triggerNavigationEnd();
+            fixture.detectChanges();
+            xtreamStore.constructStreamUrl.mockClear();
+
+            // Simulate navigating away and back with the same state
+            window.history.replaceState(
+                { openXtreamLiveItemId: searchChannel.xtream_id },
+                ''
+            );
+            triggerNavigationEnd();
+            fixture.detectChanges();
+
+            expect(xtreamStore.constructStreamUrl).toHaveBeenCalledWith(
+                searchChannel
+            );
+        });
+    });
+});

--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.spec.ts
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.component.spec.ts
@@ -1,16 +1,10 @@
-import { Directive, Component, input, output, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import {
-    ActivatedRoute,
-    NavigationEnd,
-    Router,
-    convertToParamMap,
-} from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { MockPipe } from 'ng-mocks';
 import { TranslatePipe } from '@ngx-translate/core';
-import { BehaviorSubject, Subject, of } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import {
     LIVE_EPG_PANEL_STATE_STORAGE_KEY,
     liveSidebarStateStorageKey,
@@ -23,21 +17,14 @@ import {
     XtreamStore,
     XtreamUrlService,
 } from '@iptvnator/portal/xtream/data-access';
-import {
-    EpgListViewComponent,
-    EpgProgramActivationEvent,
-    EpgTimelineComponent,
-    EpgTimelineSummary,
-} from '@iptvnator/ui/epg';
+import { EpgListViewComponent, EpgTimelineComponent } from '@iptvnator/ui/epg';
 import {
     type PlaybackFallbackRequest,
     WebPlayerViewComponent,
 } from '@iptvnator/ui/playback';
 import {
-    EpgItem,
     EpgProgram,
-    RecordingStartMetadata,
-    RecordingStoppedEvent,
+    EpgItem,
     ResolvedPortalPlayback,
 } from '@iptvnator/shared/interfaces';
 import { GridListComponent } from '@iptvnator/portal/shared/ui';
@@ -45,92 +32,35 @@ import { PortalChannelsListComponent } from '../portal-channels-list/portal-chan
 import { LiveStreamLayoutComponent } from './live-stream-layout.component';
 import { RuntimeCapabilitiesService, SettingsStore } from '@iptvnator/services';
 import { createPlaybackSessionKey } from '@iptvnator/playback/util';
-
-const LIVE_CHANNEL_SORT_STORAGE_KEY = 'xtream-live-channel-sort-mode';
-
-@Component({
-    selector: 'app-portal-channels-list',
-    standalone: true,
-    template: '<div data-test-id="portal-channels-list-stub"></div>',
-})
-class StubPortalChannelsListComponent {
-    readonly sortMode = input<'server' | 'name-asc' | 'name-desc'>('server');
-    readonly channelsOverride = input<unknown[] | null>(null);
-    readonly searchTermInput = input('');
-    readonly revealRequest = input<unknown>(null);
-    readonly filteredChannels = signal<unknown[]>([]);
-    readonly playClicked = output<unknown>();
-    readonly playbackRequested = output<unknown>();
-}
-
-@Component({
-    selector: 'app-grid-list',
-    standalone: true,
-    template: '<div data-test-id="grid-list-stub"></div>',
-})
-class StubGridListComponent {
-    readonly items = input<unknown[]>([]);
-    readonly isLoading = input(false);
-    readonly isAppending = input(false);
-    readonly appendError = input(false);
-    readonly searchTerm = input('');
-    readonly variant = input<'poster' | 'logo'>('poster');
-    readonly type = input<string>();
-    readonly itemClicked = output<unknown>();
-    readonly retryLoadMore = output<void>();
-}
-
-@Component({
-    selector: 'app-web-player-view',
-    standalone: true,
-    template: '',
-})
-class StubWebPlayerViewComponent {
-    readonly playbackSessionKey = input.required<string>();
-    readonly streamUrl = input('');
-    readonly title = input('');
-    readonly playback = input<unknown>(null);
-    readonly recordingMetadata = input<RecordingStartMetadata | null>(null);
-    readonly externalFallbackRequested = output<PlaybackFallbackRequest>();
-    readonly recordingStopped = output<RecordingStoppedEvent>();
-}
-
-// Matches both live-panel selectors so the host's timeline ↔ list swap can be
-// asserted by tag name; both branches share the identical contract.
-@Component({
-    selector: 'app-epg-timeline, app-epg-list-view',
-    standalone: true,
-    template: `
-        <div class="live-epg-panel-label">{{ summaryLabelKey() }}</div>
-        <div class="live-epg-panel-summary">{{ summary()?.title }}</div>
-    `,
-})
-class StubEpgTimelineComponent {
-    readonly programs = input<EpgProgram[]>([]);
-    readonly channelName = input('');
-    readonly channelLogo = input('');
-    readonly sourceLabel = input('');
-    readonly archivePlaybackAvailable = input(false);
-    readonly archiveDays = input(0);
-    readonly activeProgram = input<EpgProgram | null>(null);
-    readonly isLivePlayback = input(true);
-    readonly loading = input(false);
-    readonly selectedDate = input<string | null>(null);
-    readonly collapsed = input(false);
-    readonly summary = input<EpgTimelineSummary | null>(null);
-    readonly summaryLabelKey = input('');
-    readonly offsetMinutes = input(0);
-    readonly programActivated = output<EpgProgramActivationEvent>();
-    readonly returnToLive = output<void>();
-    readonly selectedDateChange = output<string>();
-    readonly collapsedChange = output<boolean>();
-}
-
-@Directive({
-    selector: '[appResizable]',
-    standalone: true,
-})
-class StubResizableDirective {}
+import {
+    LIVE_CHANNEL_SORT_STORAGE_KEY,
+    StubEpgTimelineComponent,
+    StubGridListComponent,
+    StubPortalChannelsListComponent,
+    StubResizableDirective,
+    StubWebPlayerViewComponent,
+    categories,
+    categoryItemCounts,
+    currentEpgItem,
+    currentPlaylist,
+    epgItems,
+    favoritesService,
+    fixedNow,
+    hasMoreContent,
+    isLoadingEpg,
+    liveStreams,
+    paginatedContent,
+    playlist,
+    portalPlayer,
+    sampleChannel,
+    selectedCategoryId,
+    selectedContentType,
+    selectedItem,
+    selectedTypeContentLoading,
+    settingsStore,
+    xtreamStore,
+    xtreamUrlService,
+} from './live-stream-layout.spec-harness';
 
 describe('LiveStreamLayoutComponent', () => {
     let fixture: ComponentFixture<LiveStreamLayoutComponent>;
@@ -138,80 +68,9 @@ describe('LiveStreamLayoutComponent', () => {
     let routeQueryParamMap: BehaviorSubject<
         ReturnType<typeof convertToParamMap>
     >;
-    const fixedNow = new Date('2026-04-05T12:00:00.000Z');
-
-    const sampleChannel = {
-        xtream_id: 101,
-        name: 'Channel 101',
-        stream_icon: 'channel-101.png',
-        tv_archive: 1,
-        tv_archive_duration: 3,
-    };
-    const playlist = {
-        id: 'playlist-1',
-        serverUrl: 'http://demo.example',
-        username: 'demo',
-        password: 'secret',
-    };
-
-    const categories = signal([{ category_id: 1, category_name: 'News' }]);
-    const categoryItemCounts = signal(new Map<number, number>([[1, 1]]));
-    const epgItems = signal<EpgItem[]>([]);
-    const currentEpgItem = signal<EpgItem | null>(null);
-    const isLoadingEpg = signal(false);
-    const selectedTypeContentLoading = signal(false);
-    const selectedCategoryId = signal<number | null>(1);
-    const selectedContentType = signal<'live' | 'vod' | 'series'>('live');
-    const selectedItem = signal<unknown>(sampleChannel);
-    const currentPlaylist = signal(playlist);
-    const liveStreams = signal<unknown[]>([]);
-    const paginatedContent = signal<unknown[]>([]);
-    const hasMoreContent = signal(false);
-
-    const xtreamStore = {
-        getCategoriesBySelectedType: categories,
-        getCategoryItemCounts: categoryItemCounts,
-        getPaginatedContent: paginatedContent,
-        hasMoreContent,
-        epgItems,
-        currentEpgItem,
-        isLoadingEpg,
-        selectedTypeContentLoading,
-        selectedCategoryId,
-        selectedContentType,
-        selectedItem,
-        currentPlaylist,
-        liveStreams,
-        selectItemsFromSelectedCategory: jest.fn(() => [sampleChannel]),
-        constructStreamUrl: jest.fn(() => 'https://example.com/live.ts'),
-        openPlayer: jest.fn(),
-        setSelectedItem: jest.fn(),
-        setSelectedCategory: jest.fn(),
-        loadMoreContent: jest.fn(),
-    };
 
     let routerEvents: Subject<unknown>;
     let router: { events: Subject<unknown>; navigate: jest.Mock };
-    const favoritesService = {
-        getFavorites: jest.fn().mockReturnValue(of([])),
-    };
-    const xtreamUrlService = {
-        constructAutoLiveTsUrl: jest.fn(() => undefined),
-        resolveCatchupUrl: jest
-            .fn()
-            .mockResolvedValue('https://example.com/timeshift.ts'),
-    };
-    const portalPlayer = {
-        isEmbeddedPlayer: jest.fn().mockReturnValue(true),
-        openExternalPlayback: jest.fn(),
-    };
-    const settingsStore = {
-        openStreamOnDoubleClick: signal(false),
-        // Reset in beforeEach: the store is module-scoped, so a test failure
-        // before an in-test restore must not leak 'list' into siblings.
-        resolvedEpgViewMode: signal<'timeline' | 'list'>('timeline'),
-        resolvedEpgOffsetMinutes: signal(0),
-    };
 
     const originalElectron = window.electron;
 
@@ -1038,56 +897,6 @@ describe('LiveStreamLayoutComponent', () => {
         expect(epgTimeline.componentInstance.activeProgram()).toBeNull();
     });
 
-    it('keeps remote order after browsing another category and changing sort', () => {
-        const first = { ...sampleChannel, category_id: '1', name: 'Zulu' };
-        const next = { ...first, xtream_id: 102, name: 'Alpha' };
-        liveStreams.set([first, next]);
-        xtreamStore.selectItemsFromSelectedCategory.mockReturnValue([
-            first,
-            next,
-        ]);
-        selectedItem.set(first);
-        component.playLive(first);
-        xtreamStore.setSelectedCategory.mockClear();
-        selectedCategoryId.set(2);
-        xtreamStore.selectItemsFromSelectedCategory.mockReturnValue([]);
-        component.setLiveChannelSortMode('name-desc');
-        component['handleRemoteChannelChange']('down');
-        expect(xtreamStore.constructStreamUrl).toHaveBeenLastCalledWith(next);
-        expect(xtreamStore.setSelectedCategory).not.toHaveBeenCalled();
-    });
-
-    it('starts external playback from remote channel navigation when double-click opening is enabled', () => {
-        const nextChannel = {
-            ...sampleChannel,
-            category_id: '1',
-            xtream_id: 102,
-            name: 'Channel 102',
-        };
-        settingsStore.openStreamOnDoubleClick.set(true);
-        portalPlayer.isEmbeddedPlayer.mockReturnValue(false);
-        selectedItem.set(sampleChannel);
-        xtreamStore.selectItemsFromSelectedCategory.mockReturnValue([
-            sampleChannel,
-            nextChannel,
-        ]);
-
-        liveStreams.set([{ ...sampleChannel, category_id: '1' }, nextChannel]);
-        component.playLive(sampleChannel);
-        xtreamStore.openPlayer.mockClear();
-        (
-            component as unknown as {
-                handleRemoteChannelChange(direction: 'up' | 'down'): void;
-            }
-        ).handleRemoteChannelChange('down');
-
-        expect(xtreamStore.openPlayer).toHaveBeenCalledWith(
-            'https://example.com/live.ts',
-            'Channel 102',
-            'channel-101.png'
-        );
-    });
-
     it('shows an archive-unavailable notice when past programs exist but archive playback is unavailable', () => {
         const nonArchiveChannel = {
             ...sampleChannel,
@@ -1153,127 +962,6 @@ describe('LiveStreamLayoutComponent', () => {
     // `app-channel-list-hidden-state` (its TranslatePipe needs a
     // TranslateService); this spec is at the max-lines budget, so that branch
     // is covered by video-player-sidebar.spec.ts and the Electron E2E instead.
-    describe('auto-open from Ctrl+F search navigation state', () => {
-        const searchChannel = {
-            xtream_id: 202,
-            name: 'Search Channel',
-            category_id: '7',
-            stream_icon: 'search-channel.png',
-            tv_archive: 0,
-            tv_archive_duration: 0,
-        };
-
-        function triggerNavigationEnd() {
-            routerEvents.next(
-                new NavigationEnd(
-                    1,
-                    '/workspace/xtreams/playlist-1/live',
-                    '/workspace/xtreams/playlist-1/live'
-                )
-            );
-        }
-
-        beforeEach(() => {
-            window.history.replaceState(
-                { openXtreamLiveItemId: searchChannel.xtream_id },
-                ''
-            );
-        });
-
-        afterEach(() => {
-            window.history.replaceState({}, '');
-        });
-
-        it('plays and selects a channel found in liveStreams on NavigationEnd', () => {
-            liveStreams.set([searchChannel]);
-            fixture.detectChanges();
-
-            triggerNavigationEnd();
-            fixture.detectChanges();
-
-            expect(xtreamStore.constructStreamUrl).toHaveBeenCalledWith(
-                searchChannel
-            );
-            expect(xtreamStore.setSelectedItem).toHaveBeenCalledWith(
-                searchChannel
-            );
-        });
-
-        it('sets the channel category so the sidebar highlights the correct entry', () => {
-            liveStreams.set([searchChannel]);
-            fixture.detectChanges();
-
-            triggerNavigationEnd();
-            fixture.detectChanges();
-
-            expect(xtreamStore.setSelectedCategory).toHaveBeenCalledWith(7);
-        });
-
-        it('does not auto-open while selectedContentType is not live', () => {
-            selectedContentType.set('vod');
-            liveStreams.set([searchChannel]);
-            fixture.detectChanges();
-
-            triggerNavigationEnd();
-            fixture.detectChanges();
-
-            expect(xtreamStore.constructStreamUrl).not.toHaveBeenCalledWith(
-                searchChannel
-            );
-        });
-
-        it('waits for liveStreams to populate before playing', () => {
-            liveStreams.set([]);
-            fixture.detectChanges();
-
-            triggerNavigationEnd();
-            fixture.detectChanges();
-
-            expect(xtreamStore.constructStreamUrl).not.toHaveBeenCalled();
-
-            liveStreams.set([searchChannel]);
-            fixture.detectChanges();
-
-            expect(xtreamStore.constructStreamUrl).toHaveBeenCalledWith(
-                searchChannel
-            );
-        });
-
-        it('clears the pending ID when the channel is not found in liveStreams', () => {
-            liveStreams.set([{ ...searchChannel, xtream_id: 999 }]);
-            fixture.detectChanges();
-
-            triggerNavigationEnd();
-            fixture.detectChanges();
-
-            expect(xtreamStore.constructStreamUrl).not.toHaveBeenCalledWith(
-                searchChannel
-            );
-        });
-
-        it('re-triggers auto-open on re-navigation when component is reused', () => {
-            liveStreams.set([searchChannel]);
-            fixture.detectChanges();
-
-            // First navigation — clears the pending state
-            triggerNavigationEnd();
-            fixture.detectChanges();
-            xtreamStore.constructStreamUrl.mockClear();
-
-            // Simulate navigating away and back with the same state
-            window.history.replaceState(
-                { openXtreamLiveItemId: searchChannel.xtream_id },
-                ''
-            );
-            triggerNavigationEnd();
-            fixture.detectChanges();
-
-            expect(xtreamStore.constructStreamUrl).toHaveBeenCalledWith(
-                searchChannel
-            );
-        });
-    });
-
     it('hides the archive-unavailable notice when there are no past programs yet', () => {
         const nonArchiveChannel = {
             ...sampleChannel,

--- a/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.spec-harness.ts
+++ b/libs/portal/xtream/feature/src/lib/live-stream-layout/live-stream-layout.spec-harness.ts
@@ -1,0 +1,182 @@
+import { Directive, Component, input, output, signal } from '@angular/core';
+import { of } from 'rxjs';
+import {
+    EpgProgramActivationEvent,
+    EpgTimelineSummary,
+} from '@iptvnator/ui/epg';
+import { type PlaybackFallbackRequest } from '@iptvnator/ui/playback';
+import {
+    EpgItem,
+    EpgProgram,
+    RecordingStartMetadata,
+    RecordingStoppedEvent,
+} from '@iptvnator/shared/interfaces';
+
+/**
+ * Shared stubs, mocks and fixture state for the `LiveStreamLayoutComponent`
+ * spec suite. They live beside the specs rather than inside a single file
+ * because the suite is at the 1200-line test cap; module-scoped signals are
+ * safe to export because Jest gives every spec file its own module registry.
+ */
+
+export const LIVE_CHANNEL_SORT_STORAGE_KEY = 'xtream-live-channel-sort-mode';
+
+@Component({
+    selector: 'app-portal-channels-list',
+    standalone: true,
+    template: '<div data-test-id="portal-channels-list-stub"></div>',
+})
+export class StubPortalChannelsListComponent {
+    readonly sortMode = input<'server' | 'name-asc' | 'name-desc'>('server');
+    readonly channelsOverride = input<unknown[] | null>(null);
+    readonly searchTermInput = input('');
+    readonly revealRequest = input<unknown>(null);
+    readonly filteredChannels = signal<unknown[]>([]);
+    readonly playClicked = output<unknown>();
+    readonly playbackRequested = output<unknown>();
+}
+
+@Component({
+    selector: 'app-grid-list',
+    standalone: true,
+    template: '<div data-test-id="grid-list-stub"></div>',
+})
+export class StubGridListComponent {
+    readonly items = input<unknown[]>([]);
+    readonly isLoading = input(false);
+    readonly isAppending = input(false);
+    readonly appendError = input(false);
+    readonly searchTerm = input('');
+    readonly variant = input<'poster' | 'logo'>('poster');
+    readonly type = input<string>();
+    readonly itemClicked = output<unknown>();
+    readonly retryLoadMore = output<void>();
+}
+
+@Component({
+    selector: 'app-web-player-view',
+    standalone: true,
+    template: '',
+})
+export class StubWebPlayerViewComponent {
+    readonly playbackSessionKey = input.required<string>();
+    readonly streamUrl = input('');
+    readonly title = input('');
+    readonly playback = input<unknown>(null);
+    readonly recordingMetadata = input<RecordingStartMetadata | null>(null);
+    readonly externalFallbackRequested = output<PlaybackFallbackRequest>();
+    readonly recordingStopped = output<RecordingStoppedEvent>();
+}
+
+// Matches both live-panel selectors so the host's timeline ↔ list swap can be
+// asserted by tag name; both branches share the identical contract.
+@Component({
+    selector: 'app-epg-timeline, app-epg-list-view',
+    standalone: true,
+    template: `
+        <div class="live-epg-panel-label">{{ summaryLabelKey() }}</div>
+        <div class="live-epg-panel-summary">{{ summary()?.title }}</div>
+    `,
+})
+export class StubEpgTimelineComponent {
+    readonly programs = input<EpgProgram[]>([]);
+    readonly channelName = input('');
+    readonly channelLogo = input('');
+    readonly sourceLabel = input('');
+    readonly archivePlaybackAvailable = input(false);
+    readonly archiveDays = input(0);
+    readonly activeProgram = input<EpgProgram | null>(null);
+    readonly isLivePlayback = input(true);
+    readonly loading = input(false);
+    readonly selectedDate = input<string | null>(null);
+    readonly collapsed = input(false);
+    readonly summary = input<EpgTimelineSummary | null>(null);
+    readonly summaryLabelKey = input('');
+    readonly offsetMinutes = input(0);
+    readonly programActivated = output<EpgProgramActivationEvent>();
+    readonly returnToLive = output<void>();
+    readonly selectedDateChange = output<string>();
+    readonly collapsedChange = output<boolean>();
+}
+
+@Directive({
+    selector: '[appResizable]',
+    standalone: true,
+})
+export class StubResizableDirective {}
+
+export const fixedNow = new Date('2026-04-05T12:00:00.000Z');
+
+export const sampleChannel = {
+    xtream_id: 101,
+    name: 'Channel 101',
+    stream_icon: 'channel-101.png',
+    tv_archive: 1,
+    tv_archive_duration: 3,
+};
+export const playlist = {
+    id: 'playlist-1',
+    serverUrl: 'http://demo.example',
+    username: 'demo',
+    password: 'secret',
+};
+
+export const categories = signal([{ category_id: 1, category_name: 'News' }]);
+export const categoryItemCounts = signal(new Map<number, number>([[1, 1]]));
+export const epgItems = signal<EpgItem[]>([]);
+export const currentEpgItem = signal<EpgItem | null>(null);
+export const isLoadingEpg = signal(false);
+export const selectedTypeContentLoading = signal(false);
+export const selectedCategoryId = signal<number | null>(1);
+export const selectedContentType = signal<'live' | 'vod' | 'series'>('live');
+export const selectedItem = signal<unknown>(sampleChannel);
+export const currentPlaylist = signal(playlist);
+export const liveStreams = signal<unknown[]>([]);
+export const paginatedContent = signal<unknown[]>([]);
+export const hasMoreContent = signal(false);
+
+export const xtreamStore = {
+    getCategoriesBySelectedType: categories,
+    getCategoryItemCounts: categoryItemCounts,
+    getPaginatedContent: paginatedContent,
+    hasMoreContent,
+    epgItems,
+    currentEpgItem,
+    isLoadingEpg,
+    selectedTypeContentLoading,
+    selectedCategoryId,
+    selectedContentType,
+    selectedItem,
+    currentPlaylist,
+    liveStreams,
+    selectItemsFromSelectedCategory: jest.fn(() => [sampleChannel]),
+    constructStreamUrl: jest.fn(() => 'https://example.com/live.ts'),
+    openPlayer: jest.fn(),
+    setSelectedItem: jest.fn(),
+    setSelectedCategory: jest.fn(),
+    loadMoreContent: jest.fn(),
+};
+
+export const favoritesService = {
+    getFavorites: jest.fn().mockReturnValue(of([])),
+};
+
+export const xtreamUrlService = {
+    constructAutoLiveTsUrl: jest.fn(() => undefined),
+    resolveCatchupUrl: jest
+        .fn()
+        .mockResolvedValue('https://example.com/timeshift.ts'),
+};
+
+export const portalPlayer = {
+    isEmbeddedPlayer: jest.fn().mockReturnValue(true),
+    openExternalPlayback: jest.fn(),
+};
+
+export const settingsStore = {
+    openStreamOnDoubleClick: signal(false),
+    // Reset in beforeEach: the store is module-scoped, so a test failure
+    // before an in-test restore must not leak 'list' into siblings.
+    resolvedEpgViewMode: signal<'timeline' | 'list'>('timeline'),
+    resolvedEpgOffsetMinutes: signal(0),
+};


### PR DESCRIPTION
## Summary

- `master`'s Lint job is red: `live-stream-layout.component.spec.ts` exceeds the ESLint `max-lines` test cap (1209 counted lines vs. the 1200 maximum introduced by #1554/#1558), so every PR currently inherits a failing Lint check.
- Per `CLAUDE.md`, the fix is to split the spec rather than add it to the baseline. This PR moves the channel-navigation-while-browsing test cases into a new sibling spec file and extracts the suite's shared stubs/mocks/fixtures into a small harness module, following the precedent pattern documented for oversized test suites.

## What moved where

- `live-stream-layout.component.browsing-navigation.spec.ts` (new): the two remote-control "keep browsing order" cases added by #1554 (`keeps remote order after browsing another category and changing sort`, `starts external playback from remote channel navigation when double-click opening is enabled`) plus the nested `auto-open from Ctrl+F search navigation state` describe block (6 cases) — all navigation-while-browsing behavior.
- `live-stream-layout.spec-harness.ts` (new, production-linted, <300 lines): the 5 stub Angular components, shared signals, and mock service objects both spec files need to build the same `TestBed` fixture. Module-scoped exports are safe here because Jest gives each spec file its own module registry.
- `live-stream-layout.component.spec.ts`: now imports the shared stubs/mocks from the harness instead of declaring them inline, and keeps the remaining ~28 test cases. No assertions were changed — this is a pure move.

## Line counts (ESLint `max-lines`, blank lines/comments excluded)

| File | Counted lines |
| --- | --- |
| `live-stream-layout.component.spec.ts` (before, on `master`) | 1209 |
| `live-stream-layout.component.spec.ts` (after) | 916 |
| `live-stream-layout.component.browsing-navigation.spec.ts` (new) | 349 |
| `live-stream-layout.spec-harness.ts` (new) | 157 |

Note: `master` gained another commit (#1556) while this branch was in progress that also trimmed/restructured this same spec file; this PR is rebased on top of current `master` and the numbers above reflect that.

## Test counts

- `it(...)` cases: 36 total on `master` → 28 in the main spec + 8 in the new browsing-navigation spec = 36 (unchanged).
- `pnpm nx test portal-xtream-feature`: 43 suites / 456 tests passed, both before and after (suite count +1 for the new file, total test count unchanged).

## Test plan

- [x] `npx eslint --rule 'max-lines: ["error", {"max": 1200, "skipBlankLines": true, "skipComments": true}]'` on both spec files — 0 errors
- [x] `pnpm nx lint portal-xtream-feature` — 0 errors (25 pre-existing, unrelated warnings)
- [x] `pnpm nx test portal-xtream-feature` — 43 suites / 456 tests passed
- [x] `pnpm run typecheck:ci` — clean

Test-only change; no `.changes/` note needed (`no-release-note` label applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)